### PR TITLE
fix: unify model grouping logic across model selector and config generators

### DIFF
--- a/dashboard/src/app/dashboard/page.tsx
+++ b/dashboard/src/app/dashboard/page.tsx
@@ -83,10 +83,16 @@ function extractOAuthAccounts(data: unknown): OAuthAccountEntry[] {
 function buildSourceMap(proxyModels: { id: string; owned_by: string }[]): Map<string, string> {
   const sourceMap = new Map<string, string>();
   for (const m of proxyModels) {
-    const source = m.owned_by === "anthropic" ? "Claude"
-      : m.owned_by === "google" || m.owned_by === "antigravity" ? "Gemini"
-      : m.owned_by === "openai" ? "OpenAI/Codex"
-      : m.owned_by;
+    const source =
+      m.owned_by === "anthropic"
+        ? "Claude"
+        : m.owned_by === "antigravity"
+          ? "Antigravity"
+          : m.owned_by === "google"
+            ? "Gemini"
+            : m.owned_by === "openai"
+              ? "OpenAI/Codex"
+              : m.owned_by;
     sourceMap.set(m.id, source);
   }
   return sourceMap;

--- a/dashboard/src/components/quick-start-config-section.tsx
+++ b/dashboard/src/components/quick-start-config-section.tsx
@@ -144,6 +144,7 @@ export function QuickStartConfigSection({
               proxyModelIds={availableModels}
               excludedModels={excludedModels}
               agentOverrides={agentOverrides}
+              modelSourceMap={modelSourceMap}
             />
           </div>
         </details>

--- a/dashboard/src/lib/providers/model-grouping.ts
+++ b/dashboard/src/lib/providers/model-grouping.ts
@@ -1,0 +1,79 @@
+export const MODEL_PROVIDER_ORDER = [
+  "Claude",
+  "Gemini",
+  "Antigravity",
+  "OpenAI/Codex",
+  "OpenAI-Compatible",
+  "Other",
+] as const;
+
+export type ModelProviderName = (typeof MODEL_PROVIDER_ORDER)[number];
+
+export interface ModelGroup {
+  provider: ModelProviderName;
+  models: string[];
+}
+
+function isModelProviderName(value: string): value is ModelProviderName {
+  return (MODEL_PROVIDER_ORDER as readonly string[]).includes(value);
+}
+
+export function detectModelProvider(
+  modelId: string,
+  modelSourceMap?: Map<string, string>
+): ModelProviderName {
+  const source = modelSourceMap?.get(modelId);
+  if (source && isModelProviderName(source)) {
+    return source;
+  }
+
+  const lower = modelId.toLowerCase();
+
+  if (lower.startsWith("claude-")) return "Claude";
+  if (lower.startsWith("gemini-")) return "Gemini";
+  if (lower.startsWith("antigravity-")) return "Antigravity";
+  if (
+    lower.startsWith("gpt-") ||
+    lower.startsWith("o1") ||
+    lower.startsWith("o3") ||
+    lower.startsWith("o4") ||
+    lower.includes("codex")
+  ) {
+    return "OpenAI/Codex";
+  }
+  if (
+    lower.startsWith("openrouter/") ||
+    lower.startsWith("groq/") ||
+    lower.startsWith("xai/") ||
+    lower.startsWith("deepseek/") ||
+    lower.startsWith("anthropic/") ||
+    lower.startsWith("google/")
+  ) {
+    return "OpenAI-Compatible";
+  }
+
+  return "Other";
+}
+
+export function groupModelsByProvider(
+  models: string[],
+  modelSourceMap?: Map<string, string>
+): ModelGroup[] {
+  const grouped = new Map<ModelProviderName, string[]>();
+
+  for (const model of models) {
+    const provider = detectModelProvider(model, modelSourceMap);
+    const existing = grouped.get(provider) ?? [];
+    existing.push(model);
+    grouped.set(provider, existing);
+  }
+
+  for (const providerModels of grouped.values()) {
+    providerModels.sort((a, b) => a.localeCompare(b));
+  }
+
+  return MODEL_PROVIDER_ORDER.map((provider) => ({
+    provider,
+    models: grouped.get(provider) ?? [],
+  })).filter((group) => group.models.length > 0);
+}


### PR DESCRIPTION
## Summary

- Extract shared model grouping logic into `lib/providers/model-grouping.ts` to eliminate code duplication
- Pass `modelSourceMap` to assignment dropdowns in config generators for consistent provider grouping
- Implement antigravity model name mapping for accurate config generation
- Reduce coupling by centralizing grouping, metadata, and mapping logic

## Changes

### Files Modified
- `dashboard/src/lib/providers/model-grouping.ts` (NEW) - Centralized grouping logic
- `dashboard/src/components/model-selector.tsx` - Refactored to use shared logic
- `dashboard/src/components/oh-my-opencode-config-generator.tsx` - Refactored to use shared logic
- `dashboard/src/components/quick-start-config-section.tsx` - Refactored to use shared logic
- `dashboard/src/app/dashboard/page.tsx` - Updated to pass modelSourceMap

### Key Improvements
1. **Unified Model Grouping**: Both model selection UI and assignment dropdowns now use identical grouping logic
2. **Antigravity Mapping**: Config generation properly maps antigravity models with correct names
3. **Reduced Duplication**: 38 lines of net deletion while improving functionality

## Verification

✅ `npm --prefix dashboard run build` succeeded
⚠️ `npm --prefix dashboard run lint` has pre-existing issues in unrelated files (not modified by this PR)

Lint failures are unrelated to the model grouping changes and exist in the following unrelated files:
- Pre-existing linting issues in dashboard configuration and type definitions


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unified model grouping and provider detection across the model selector and config generators. This makes provider groups consistent and fixes Antigravity name mapping while reducing duplicate code.

- **Refactors**
  - Centralized provider detection and grouping in lib/providers/model-grouping.ts.
  - Model selector and OhMyOpenCode config generator now use the shared logic.
  - Build and pass modelSourceMap to dropdowns for consistent provider labels (including Antigravity).
  - Preserved a stable provider order across UIs.

- **Bug Fixes**
  - Correct Antigravity model name mapping in config generation.

<sup>Written for commit 82ad3b19e8b9f2b60fb3973285ecc34b269e5101. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

