### PR TITLE
fix(ci): reliable Docker build trigger with output fallback and workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to build (e.g. dashboard-v0.1.4)"
+        required: true
 
 permissions:
   contents: write
@@ -12,22 +17,55 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
     outputs:
-      release_created: ${{ steps.release.outputs['dashboard--release_created'] }}
-      tag_name: ${{ steps.release.outputs['dashboard--tag_name'] }}
-      version: ${{ steps.release.outputs['dashboard--version'] }}
+      release_created: ${{ steps.resolve.outputs.release_created }}
+      tag_name: ${{ steps.resolve.outputs.tag_name }}
+      version: ${{ steps.resolve.outputs.version }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Release-Please outputs use component prefix (dashboard--) for multi-package repos.
+      # Support both prefixed and non-prefixed keys for robustness.
+      - name: Resolve release outputs
+        id: resolve
+        env:
+          RP_RELEASE_CREATED: ${{ steps.release.outputs['dashboard--release_created'] || steps.release.outputs.release_created }}
+          RP_TAG_NAME: ${{ steps.release.outputs['dashboard--tag_name'] || steps.release.outputs.tag_name }}
+          RP_VERSION: ${{ steps.release.outputs['dashboard--version'] || steps.release.outputs.version }}
+        run: |
+          echo "release_created=${RP_RELEASE_CREATED}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${RP_TAG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${RP_VERSION}" >> "$GITHUB_OUTPUT"
+
+          if [ "${RP_RELEASE_CREATED}" = "true" ]; then
+            echo "✅ Release-Please created release: ${RP_TAG_NAME} (${RP_VERSION})"
+          else
+            echo "ℹ️ No release created (PR opened or no releasable commits)"
+          fi
+
   build-and-push:
     runs-on: ubuntu-latest
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag_name }}"
+          else
+            TAG="${{ needs.release-please.outputs.tag_name }}"
+          fi
+          VERSION=$(echo "$TAG" | sed 's/^.*v//')
+          echo "tag_name=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "🐳 Building Docker image: tag=${TAG}, version=${VERSION}"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -42,7 +80,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}/dashboard
           tags: |
-            type=raw,value=${{ needs.release-please.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=latest
             type=sha,prefix=sha-
 
@@ -58,6 +96,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            DASHBOARD_VERSION=${{ needs.release-please.outputs.tag_name }}
+            DASHBOARD_VERSION=${{ steps.version.outputs.tag_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,117 +1,200 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-02-08 | **Commit:** 78fdf41 | **Branch:** main
-
-## OVERVIEW
-
 Self-hosted AI proxy management dashboard. Next.js 16 + React 19 + TypeScript strict + Tailwind v4 + Prisma 7 + PostgreSQL. Controls CLIProxyAPI service via Docker socket.
 
 ## STRUCTURE
 
 ```
 cliproxyapi_dashboard/
-├── dashboard/          # Main Next.js application (work here)
-├── infrastructure/     # Docker Compose, Caddy, systemd configs
-├── plugin/             # OpenCode sync plugin (separate npm package)
-├── scripts/            # Host-level backup/restore scripts
-└── install.sh          # Production deployment script
+├── dashboard/          # Main Next.js app (ALL dev work here)
+│   ├── src/app/        # App Router: pages + API routes
+│   ├── src/components/ # UI primitives (ui/) + feature components
+│   ├── src/lib/        # Business logic (auth, providers, config-sync, errors)
+│   └── prisma/         # Schema + migrations
+├── plugin/             # OpenCode sync plugin (TS, Bun)
+├── infrastructure/     # Docker Compose, Caddy, systemd
+├── scripts/            # Backup/restore scripts
+└── install.sh          # Production installer
 ```
-
-## WHERE TO LOOK
-
-| Task | Location | Notes |
-|------|----------|-------|
-| Add API endpoint | `dashboard/src/app/api/` | Use `route.ts` pattern |
-| Add UI page | `dashboard/src/app/dashboard/` | Server Component default |
-| Core business logic | `dashboard/src/lib/` | Auth, providers, config-sync |
-| Database changes | `dashboard/prisma/schema.prisma` | Run migrate + generate |
-| Docker/deployment | `infrastructure/` | Compose + Caddy configs |
-| Environment vars | `infrastructure/.env` | Never commit |
-
-## CONVENTIONS
-
-### TypeScript (Strict)
-- **NEVER** `any` → use `unknown` + type guards
-- Const types: `const X = {...} as const; type X = typeof X[keyof typeof X]`
-- Import types explicitly: `import type { User } from "@/lib/types"`
-
-### React 19
-- Named imports only: `import { useState } from "react"`
-- **NO** `useMemo`/`useCallback` → React Compiler handles it
-- **NO** `forwardRef` → ref is a regular prop
-- Server Components default, `"use client"` only when needed
-
-### Tailwind v4
-- **NEVER** `var()` in className
-- **NEVER** hex colors in className
-- `cn()` only for conditional classes
-
-### API Routes
-- Always try-catch with structured JSON: `{ error: "message" }`
-- Auth: `verifySession()` for users, `validateSyncTokenFromHeader()` for CLI
-- CSRF: `validateOrigin()` for state-changing requests
-- Admin: check `user.isAdmin` for privileged operations
-
-## ANTI-PATTERNS (FORBIDDEN)
-
-| Pattern | Why | Alternative |
-|---------|-----|-------------|
-| `any` type | Breaks type safety | `unknown` + type guard |
-| `@ts-ignore` / `as any` | Masks real issues | Fix the type |
-| Manual memoization | React 19 handles it | Remove `useMemo`/`useCallback` |
-| Edit `generated/prisma/*` | Gets overwritten | Modify `schema.prisma` |
-| Commit `.env` or secrets | Security risk | Use `infrastructure/.env` |
-| `position: absolute` for dropdowns | Z-index issues | Use `position: fixed` |
 
 ## COMMANDS
 
+All dashboard commands run from `dashboard/`:
+
 ```bash
-cd dashboard                    # Always work from here
-npm run dev                     # Dev server :3000
-npm run build                   # Production build
-npm run lint                    # ESLint (flat config)
-npx prisma migrate dev --name X # DB migration
-npx prisma generate             # Regenerate client
-./dev-local.sh                  # Local Docker dev environment
-./dev-local.sh --reset          # Reset dev database
+npm run dev                       # Dev server :3000 (Turbopack)
+npm run build                     # Production build (standalone)
+npm run lint                      # ESLint flat config
+./dev-local.sh                    # Start Postgres + CLIProxyAPI + dev server
+./dev-local.sh --reset            # Wipe dev DB, start fresh
+./dev-local.sh --down             # Stop dev containers
+npx prisma migrate dev --name X   # Create migration
+npx prisma generate               # Regenerate client
+npx prisma db push                # Push schema without migration
+npx prisma studio                 # DB GUI
 ```
 
-## ARCHITECTURE NOTES
+Production (from repo root): `sudo ./install.sh`, `./rebuild.sh [--no-cache]`.
+Plugin (from `plugin/`): `bun install && bun build src/index.ts --outdir dist --target node`.
 
-### Dual-Write Pattern
-Provider keys stored in BOTH:
-1. PostgreSQL (ownership tracking via Prisma)
-2. CLIProxyAPI config.yaml (via Management API)
+**No test framework.** Verify changes via `npm run build` + `npm run lint`.
 
-`lib/providers/dual-write.ts` uses AsyncMutex to prevent race conditions.
+## WHERE TO LOOK
 
-### Config Sync Flow
+| Task | Location |
+|------|----------|
+| New page | `src/app/dashboard/{name}/page.tsx` (Server Component default) |
+| New API endpoint | `src/app/api/{name}/route.ts` (export HTTP methods) |
+| UI primitives | `src/components/ui/` (Button, Modal, Toast, Input, Card, Loading) |
+| Feature component | `src/components/` (kebab-case.tsx) |
+| Business logic | `src/lib/` (auth, providers, config-sync, errors, logger) |
+| DB schema | `prisma/schema.prisma` (then: migrate + generate + update entrypoint.sh) |
+| Env vars | `src/lib/env.ts` (Zod-validated) |
+| CSS / theme | `src/app/globals.css` (glassmorphic utility classes) |
+
+## CODE STYLE
+
+### Imports
+
+Order: (1) external libs, (2) `@/` internal, (3) type imports. Path alias `@/*` = `src/*`.
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";    // External
+import { verifySession } from "@/lib/auth/session";          // Internal
+import type { User } from "@/generated/prisma/client";       // Type import
 ```
-User Preferences → lib/config-sync/generate-bundle.ts → JSON bundle
-                   ↓
-CLI Plugin fetches via /api/config-sync/bundle (Bearer token auth)
+
+Always use `@/` paths, never relative `../` across module boundaries.
+
+### TypeScript
+
+- **Strict mode** enabled (`tsconfig.json`). No exceptions.
+- **NEVER** `any` -- use `unknown` + type guards or proper generics.
+- **NEVER** `@ts-ignore`, `@ts-expect-error`, or `as any`.
+- Const enums: `const X = {...} as const; type X = typeof X[keyof typeof X]` (see `ERROR_CODE` in `lib/errors.ts`).
+- Interfaces over type aliases for object shapes. PascalCase names, no `I` prefix.
+- Flat interfaces -- no inline nested object types.
+- Environment variables: add to Zod schema in `src/lib/env.ts`, access via `env.VAR_NAME`.
+
+### React 19
+
+- Named imports: `import { useState } from "react"` (never default import).
+- **NO** `useMemo`, `useCallback` -- React Compiler handles memoization.
+- **NO** `forwardRef` -- `ref` is a regular prop.
+- Server Components by default. Add `"use client"` only when using hooks/browser APIs.
+- **NO** Server Actions -- this project uses API routes exclusively.
+
+### Naming
+
+- **Files**: Components `kebab-case.tsx`, utilities `kebab-case.ts` or `camelCase.ts`, routes `route.ts`
+- **Exports**: Components PascalCase (`export function ConfigSubscriber`), functions camelCase
+- **Constants**: `UPPER_SNAKE_CASE` (`PASSWORD_MAX_LENGTH`, `ERROR_CODE`)
+- **Types/Interfaces**: PascalCase, no `I` prefix (`interface ButtonProps`, `type ErrorCode`)
+- **DB**: Models PascalCase, tables snake_case via `@@map("table_name")`
+
+### Tailwind v4
+
+- **NEVER** `var()` or hex colors in className.
+- `cn()` (from `@/lib/utils`) only for conditional classes. Static = direct `className="..."`.
+- Dark glassmorphic theme via CSS classes: `glass-card`, `glass-input`, `glass-button-*`, `glass-nav-*` (in `globals.css`).
+- CSS vars (`:root`) for colors -- reference in CSS only, not Tailwind classes.
+
+### Error Handling
+
+**API Routes** -- use `Errors.*` factories from `@/lib/errors`. Always wrap in try-catch:
+
+```typescript
+// Route pattern (see full template in dashboard/src/app/api/AGENTS.md)
+const session = await verifySession();
+if (!session) return Errors.unauthorized();
+const originError = validateOrigin(request);       // CSRF -- required on POST/PATCH/DELETE
+if (originError) return originError;
+try {
+  // ... business logic
+  return NextResponse.json({ success: true }, { status: 201 });
+} catch (error) {
+  return Errors.internal("Context description", error);  // Logs via pino + returns 500
+}
 ```
 
-### Three Auth Layers
-1. **Session (JWT)**: Dashboard users via cookie
-2. **Sync Token**: CLI plugins via Bearer header
-3. **Admin**: `isAdmin` flag for privileged operations
+Available: `Errors.unauthorized()`, `.forbidden()`, `.notFound()`, `.validation()`, `.missingFields()`, `.zodValidation()`, `.conflict()`, `.rateLimited()`, `.internal()`, `.database()`.
 
-## COMPLEXITY HOTSPOTS
+**Client Components** -- `try/catch` + `showToast()`. Never expose raw errors.
 
-| File | Lines | Risk |
-|------|-------|------|
-| `components/oh-my-opencode-config-generator.tsx` | 1344 | God component, complex state |
-| `app/dashboard/providers/page.tsx` | 1305 | Multi-provider UI logic |
-| `lib/providers/dual-write.ts` | 778 | Critical sync logic with mutex |
-| `lib/config-sync/generate-bundle.ts` | 400 | Orchestrates all config data |
+**Logging** -- server-only Pino (`@/lib/logger`): `logger.error({ err, context }, "message")`.
 
-## TESTING
+### Auth (Three Layers)
 
-**Current State**: No automated tests. Manual verification only.
+1. **Session**: `verifySession()` -- most routes (JWT cookie)
+2. **Admin**: `session.user.isAdmin` check -- privileged ops
+3. **Sync Token**: `validateSyncTokenFromHeader(request)` -- CLI plugin routes
+
+### Database
+
+- Import `prisma` from `@/lib/db` only. Prisma 7 + `@prisma/adapter-pg`.
+- Schema change workflow: edit `schema.prisma` -> `npx prisma migrate dev` -> `npx prisma generate` -> update `entrypoint.sh` + `dev-local.sh` resolve list.
+
+## ANTI-PATTERNS (FORBIDDEN)
+
+- `any`, `@ts-ignore`, `as any` -- use `unknown` + type guard
+- `useMemo`/`useCallback`/`forwardRef` -- React 19 Compiler handles memoization; ref is a prop
+- Server Actions -- use API routes only (project convention)
+- Import from `src/generated/prisma` directly -- use `@/lib/db`
+- Edit `generated/prisma/*` -- modify `schema.prisma` instead
+- Commit `.env` or secrets -- use `infrastructure/.env` (chmod 600)
+- `position: absolute` for dropdowns -- use `position: fixed`
+- Prisma calls in route handlers -- abstract into `src/lib/` functions
+- Skip `validateOrigin()` on POST/PATCH/DELETE -- always call it
+- Expose internal errors to client -- log + return generic message
+
+## GIT & CI/CD WORKFLOW
+
+### Branching & PRs
+
+- **NEVER push directly to `main`**. All changes go through Pull Requests.
+- Create a feature branch, commit, push, open PR via `gh pr create`.
+- Use **Conventional Commits** -- Release-Please parses them for changelogs and version bumps.
+
+### Commit Message Format
+
+```
+<type>(<scope>): <description>
+
+feat(providers): add OpenRouter custom provider support
+fix(auth): handle expired JWT gracefully
+chore(deps): bump prisma to 7.1.0
+refactor(config-sync): simplify bundle generation
+docs(readme): update installation steps
+```
+
+Types: `feat` (minor bump), `fix` (patch bump), `chore`, `refactor`, `docs`, `ci`, `style`, `perf`, `test`.
+
+### Release-Please (Automated Releases)
+
+This project uses [Release-Please](https://github.com/googleapis/release-please) for automated versioning and releases.
+
+- **Config**: `release-please-config.json` (root path `.`, component `dashboard`)
+- **Manifest**: `.release-please-manifest.json` (current version)
+- **Workflow**: `.github/workflows/release.yml` (release-please + Docker build)
+- **Flow**: Conventional commits on `main` → Release-Please opens a release PR → merge PR → GitHub Release created → Docker image built and pushed to GHCR (`ghcr.io/itsmylife44/cliproxyapi_dashboard`)
+- **Tags**: Format `dashboard-vX.Y.Z` (component prefix)
+- **GHCR image**: Built automatically on release, tagged with version
+
+### Docker & Deployment
+
+- **Docker Socket Proxy**: Dashboard uses `tcp://docker-proxy:2375` (tecnativa/docker-socket-proxy). No direct socket mount.
+- **Self-Update**: Dashboard checks for updates via GitHub Releases API (`/api/update/dashboard/check`), pulls from GHCR, tags as local compose image name, recreates container.
+- **Proxy Update**: CLIProxyAPI updates via Docker Hub digest comparison (`/api/update/check`).
+
+## ARCHITECTURE
+
+- **Dual-Write**: Provider keys in BOTH PostgreSQL + CLIProxyAPI config.yaml. `lib/providers/dual-write.ts` uses AsyncMutex. Never bypass.
+- **Config Sync**: User prefs -> `generate-bundle.ts` -> JSON -> CLI plugin fetches via `/api/config-sync/bundle`.
+- **Hotspots**: `oh-my-opencode-config-generator.tsx` (1344 lines), `providers/page.tsx` (1305), `dual-write.ts` (778), `generate-bundle.ts` (400).
 
 ## CHILD AGENTS.md
 
-- `dashboard/AGENTS.md` - Next.js app specifics
-- `dashboard/src/lib/AGENTS.md` - Core library modules
-- `dashboard/src/app/api/AGENTS.md` - API endpoint patterns
+Subdirectory-specific conventions (don't repeat what's here):
+- `dashboard/AGENTS.md` -- App Router structure, file naming, page patterns
+- `dashboard/src/lib/AGENTS.md` -- Module map, dependency flow, auth/CSRF patterns
+- `dashboard/src/app/api/AGENTS.md` -- Route template, auth layers, response format


### PR DESCRIPTION
## Summary

- Fix Docker build skipping when release-please creates a release but doesn't propagate `release_created` output (race condition with 0 post-release commits)
- Add `workflow_dispatch` trigger for manual Docker builds as fallback
- Update AGENTS.md with CI/CD workflow conventions (conventional commits, Release-Please, branching)

## Problem

When merging a release-please PR, the release gets created but the same workflow run finds 0 new commits and skips setting `release_created=true` → Docker build job is skipped → no GHCR image for the release.

## Fix

1. **Resolve step**: Checks both `dashboard--release_created` (component-prefixed) and `release_created` (non-prefixed) outputs
2. **workflow_dispatch**: Manual trigger with `tag_name` input — use from GitHub Actions UI when automated build fails
3. **Version resolution**: Extracts semver from tag regardless of source (release-please or manual dispatch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures Docker images build reliably on releases by handling missing Release-Please outputs and adds a manual fallback trigger. Also documents CI/CD conventions for releases and Docker builds.

- **Bug Fixes**
  - Prevents skipped Docker builds by resolving both component-prefixed and non-prefixed Release-Please outputs.
  - Skips Release-Please job on manual runs and allows the build job to run on workflow_dispatch.

- **New Features**
  - Adds workflow_dispatch with tag_name input to manually build/push images.
  - Adds version resolution to extract semver from tag for image tags and build args.
  - Updates AGENTS.md with branching rules, Conventional Commits, Release-Please flow, and GHCR tagging.

<sup>Written for commit e10b9c5d8f276effd7ef806ae0a15881331fe8fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

