### PR TITLE
fix: use webhook for dashboard self-update instead of docker compose

### DIFF
--- a/dashboard/src/app/api/update/dashboard/route.ts
+++ b/dashboard/src/app/api/update/dashboard/route.ts
@@ -2,44 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { verifySession } from "@/lib/auth/session";
 import { validateOrigin } from "@/lib/auth/origin";
 import { prisma } from "@/lib/db";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { logger } from "@/lib/logger";
 
-const execFileAsync = promisify(execFile);
-
-const COMPOSE_DIR = process.env.COMPOSE_DIR || "/opt/cliproxyapi/infrastructure";
-
-function getCommandErrorText(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return String(error);
-}
-
-async function runCompose(args: string[]) {
-  return execFileAsync("docker", ["compose", ...args], { cwd: COMPOSE_DIR });
-}
-
-async function isComposeAvailable(): Promise<boolean> {
-  try {
-    await execFileAsync("docker", ["compose", "version"]);
-    return true;
-  } catch (error) {
-    const errorText = getCommandErrorText(error);
-    const composeMissing =
-      errorText.includes("unknown command: docker compose") ||
-      errorText.includes("unknown shorthand flag: 'f' in -f");
-
-    if (composeMissing) {
-      logger.info("Docker compose not available in runtime");
-    } else {
-      logger.warn({ err: error }, "Compose availability check failed");
-    }
-
-    return false;
-  }
-}
+const WEBHOOK_HOST = process.env.WEBHOOK_HOST || "http://localhost:9000";
+const DEPLOY_SECRET = process.env.DEPLOY_SECRET || "";
 
 export async function POST(request: NextRequest) {
   const session = await verifySession();
@@ -68,8 +34,6 @@ export async function POST(request: NextRequest) {
     return originError;
   }
 
-  let composeAvailable = false;
-
   try {
     const body = await request.json();
     const { confirm } = body;
@@ -81,44 +45,39 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    composeAvailable = await isComposeAvailable();
-
-    if (!composeAvailable) {
+    if (!DEPLOY_SECRET) {
       return NextResponse.json(
-        { error: "Docker Compose not available in runtime" },
+        { error: "DEPLOY_SECRET not configured. Set up the webhook deploy service first." },
         { status: 500 }
       );
     }
 
-    const pullResult = await runCompose(["pull", "dashboard"]);
-    logger.info({ stdout: pullResult.stdout }, "Pull result");
+    const response = await fetch(`${WEBHOOK_HOST}/hooks/deploy-dashboard`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Deploy-Token": DEPLOY_SECRET,
+      },
+      body: JSON.stringify({}),
+    });
 
-    await runCompose([
-      "up",
-      "-d",
-      "--no-deps",
-      "--force-recreate",
-      "dashboard",
-    ]);
+    if (!response.ok) {
+      const text = await response.text();
+      logger.error({ status: response.status, body: text }, "Webhook trigger failed");
+      return NextResponse.json(
+        { error: "Failed to trigger update. Check webhook service." },
+        { status: 502 }
+      );
+    }
 
     return NextResponse.json({
       success: true,
-      message: "Dashboard updated to latest. Container is restarting.",
+      message: "Dashboard update triggered. The container will restart shortly.",
     });
   } catch (error) {
-    logger.error({ err: error }, "Update error");
-
-    try {
-      if (composeAvailable) {
-        await runCompose(["up", "-d", "--no-deps", "dashboard"]);
-        logger.info("Recovery: compose ensured dashboard service is up");
-      }
-    } catch (restartError) {
-      logger.error({ err: restartError }, "Recovery failed");
-    }
-
+    logger.error({ err: error }, "Dashboard update error");
     return NextResponse.json(
-      { error: "Update failed. Container may need manual restart." },
+      { error: "Failed to reach webhook service. Is it running?" },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary

- Dashboard self-update now triggers the host webhook service instead of running `docker compose` from inside the container
- Fixes "manually restart the container" error when clicking "Update to Latest"

## Root Cause

The dashboard container has `docker-cli` (Alpine package) but **not** the Docker Compose plugin. `docker compose` is a separate CLI plugin that wasn't installed. So `isComposeAvailable()` returned `false` → fallback "manual restart" message.

## Fix

Instead of trying to run `docker compose pull` + `docker compose up` from inside the container, the update endpoint now triggers the existing webhook deploy service (`deploy.sh`) running on the host, which has full Docker + Compose access.

Flow: Dashboard UI → `/api/update/dashboard` → webhook on host:9000 → `deploy.sh` → `docker compose pull` + `docker compose up -d`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches dashboard self-update to call a host webhook instead of running docker compose inside the container. Fixes the “Update to Latest” flow by triggering pull + restart on the host.

- **Bug Fixes**
  - Update endpoint posts to WEBHOOK_HOST/hooks/deploy-dashboard with X-Deploy-Token.
  - Host webhook runs deploy.sh (compose pull/up) with full Docker access; no compose plugin needed in the container.
  - Clear errors: 500 when DEPLOY_SECRET missing; 502 if webhook call fails; improved logging.

- **Migration**
  - Configure DEPLOY_SECRET (required) and WEBHOOK_HOST for the dashboard.
  - Ensure the host webhook service is running (default http://localhost:9000) and hooks deploy.sh to update the dashboard.

<sup>Written for commit 0d87236412ca83e5b5f0788acc884b24500ee9e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

