### PR TITLE
feat: add real Kimi quota tracking via /v1/usages endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Built with **Next.js 16**, **React 19**, **Tailwind CSS v4**, **Prisma**, and **
 | Claude | OAuth Usage API | Rate limits (requests/tokens) with reset times |
 | Codex | Wham Usage API | Daily request/token limits |
 | Antigravity | Model Availability API | Available models and status |
-| Kimi | Verification only | Kimi (Moonshot AI) has no OAuth quota API. Accounts are verified as active but no usage/balance data is available. The `api.kimi.com/coding` endpoint returns neither rate-limit headers nor a balance endpoint for OAuth tokens. |
+| Kimi | Coding Usage API | Weekly quota and 5-hour rate limit via `api.kimi.com/coding/v1/usages` |
 | iFlow | — | Not yet implemented |
 | Qwen | — | Not yet implemented |
 - **Config Sync**: Auto-sync OpenCode configs via sync tokens and the `opencode-cliproxyapi-sync` plugin


### PR DESCRIPTION
## Summary

- Replace the dummy chat completion call (`POST /v1/chat/completions` with fake message) with the actual **Kimi Coding Usage API** (`GET api.kimi.com/coding/v1/usages`)
- Shows real **weekly quota** (used/limit with reset time) and **5-hour rate limit window** instead of hardcoded "Account Active" status
- No new tokens or auth changes needed — works with the existing CLI OAuth token (`scope: kimi-code`)

## What changed

**`dashboard/src/app/api/quota/route.ts`**:
- Rewrote `fetchKimiQuota()` to call `GET /v1/usages` instead of sending a dummy chat completion
- Added typed interfaces for the Kimi usage response (`KimiUsagesResponse`, `KimiUsageDetail`)
- Added helper functions `parseKimiUsageDetail()` and `formatKimiWindowLabel()` for parsing the response
- Quota groups now show actual remaining fraction and reset times

**`README.md`**:
- Updated Kimi quota provider description from "Verification only" to "Coding Usage API"

## Discovery

Found this undocumented endpoint by examining the [kimi-cli source code](https://github.com/MoonshotAI/kimi-cli/blob/main/src/kimi_cli/ui/shell/usage.py) — their `/usage` command hits `{base_url}/usages` with the standard CLI bearer token. Verified it works through the CLIProxyAPI management api-call proxy on the live server.

## Testing

Verified on live server:
```
GET https://api.kimi.com/coding/v1/usages → 200
{
  "usage": { "limit": "100", "used": "43", "remaining": "57", "resetTime": "2026-02-19T..." },
  "limits": [{ "window": { "duration": 300, "timeUnit": "TIME_UNIT_MINUTE" }, "detail": { "limit": "100", "used": "27", "remaining": "73" } }]
}
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Kimi quota to the real Usage API so the dashboard shows weekly quota and 5‑hour rate limits with reset times. Removes the dummy chat completion check and works with the existing CLI OAuth token.

- **New Features**
  - Fetch real usage via GET api.kimi.com/coding/v1/usages.
  - Show weekly quota (used/limit) with reset time.
  - Show rate limit windows (e.g., 5h) with remaining fraction.

- **Refactors**
  - Rewrote fetchKimiQuota to use the usages endpoint.
  - Added typed response interfaces and small helpers for parsing/labels.
  - Updated README: Kimi provider is now “Coding Usage API”.

<sup>Written for commit 7ca9aaf19695c7a3df78bb31c2aeecf3305d877a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

