### PR TITLE
fix: block SSRF redirect bypass in fetch-models endpoint

### DIFF
--- a/dashboard/src/app/api/custom-providers/fetch-models/route.ts
+++ b/dashboard/src/app/api/custom-providers/fetch-models/route.ts
@@ -126,7 +126,8 @@ export async function POST(request: NextRequest) {
           "Authorization": `Bearer ${validated.apiKey}`,
           "Content-Type": "application/json"
         },
-        signal: controller.signal
+        signal: controller.signal,
+        redirect: "error"
       });
 
       clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary

- Adds `redirect: "error"` to the `fetch()` call in `/api/custom-providers/fetch-models` to prevent SSRF bypass via HTTP redirects

## Problem

The `isPrivateHost()` check validates the **initial** URL hostname, but `fetch()` follows redirects by default. An authenticated user could provide a public URL that redirects to an internal service (e.g. `http://cliproxyapi:8317/v0/management/config`), bypassing the SSRF protection entirely and reading sensitive proxy configuration including upstream API keys.

## Fix

Setting `redirect: "error"` causes the fetch to throw on any redirect response (3xx), blocking the bypass vector. This is the correct behavior since legitimate `/models` endpoints return 200 directly — they don't redirect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block SSRF redirect bypass in /api/custom-providers/fetch-models by setting fetch redirect: "error". This rejects 3xx responses so a public URL cannot redirect to internal hosts and expose sensitive data.

<sup>Written for commit 20bc17823e79205437657e1e4bf35248ffefff6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

