### PR TITLE
fix: usage aggregation, race conditions, data loss, and client cleanup

### DIFF
--- a/dashboard/src/app/api/quota/route.ts
+++ b/dashboard/src/app/api/quota/route.ts
@@ -176,6 +176,7 @@ async function fetchAntigravityQuota(
         Authorization: `Bearer ${MANAGEMENT_API_KEY}`,
         "Content-Type": "application/json",
       },
+      signal: AbortSignal.timeout(30_000),
       body: JSON.stringify({
         auth_index: authIndex,
         method: "POST",
@@ -299,6 +300,7 @@ async function fetchCodexQuota(
         Authorization: `Bearer ${MANAGEMENT_API_KEY}`,
         "Content-Type": "application/json",
       },
+      signal: AbortSignal.timeout(30_000),
       body: JSON.stringify({
         auth_index: authIndex,
         method: "GET",
@@ -411,6 +413,7 @@ async function fetchKimiQuota(
         Authorization: `Bearer ${MANAGEMENT_API_KEY}`,
         "Content-Type": "application/json",
       },
+      signal: AbortSignal.timeout(30_000),
       body: JSON.stringify({
         auth_index: authIndex,
         method: "GET",
@@ -561,6 +564,7 @@ async function fetchClaudeQuota(
         Authorization: `Bearer ${MANAGEMENT_API_KEY}`,
         "Content-Type": "application/json",
       },
+      signal: AbortSignal.timeout(30_000),
       body: JSON.stringify({
         auth_index: authIndex,
         method: "GET",
@@ -663,6 +667,7 @@ async function fetchClaudeQuota(
         Authorization: `Bearer ${MANAGEMENT_API_KEY}`,
         "Content-Type": "application/json",
       },
+      signal: AbortSignal.timeout(30_000),
       body: JSON.stringify({
         auth_index: authIndex,
         method: "POST",
@@ -804,6 +809,7 @@ export async function GET() {
         headers: {
           Authorization: `Bearer ${MANAGEMENT_API_KEY}`,
         },
+        signal: AbortSignal.timeout(30_000),
       }
     );
 

--- a/dashboard/src/app/dashboard/admin/users/page.tsx
+++ b/dashboard/src/app/dashboard/admin/users/page.tsx
@@ -20,6 +20,7 @@ const EMPTY_USERS: User[] = [];
 export default function AdminUsersPage() {
   const [users, setUsers] = useState<User[]>(EMPTY_USERS);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   
@@ -33,6 +34,7 @@ export default function AdminUsersPage() {
 
   const fetchUsers = useCallback(async () => {
     setLoading(true);
+    setFetchError(false);
     try {
       const res = await fetch("/api/admin/users");
       
@@ -48,7 +50,7 @@ export default function AdminUsersPage() {
       }
       
       if (!res.ok) {
-        showToast("Failed to load users", "error");
+        setFetchError(true);
         setLoading(false);
         return;
       }
@@ -58,7 +60,7 @@ export default function AdminUsersPage() {
       setUsers(userList);
       setLoading(false);
     } catch {
-      showToast("Network error", "error");
+      setFetchError(true);
       setLoading(false);
     }
   }, [showToast, router]);
@@ -147,6 +149,13 @@ export default function AdminUsersPage() {
 
       {loading ? (
         <div className="rounded-md border border-slate-700/70 bg-slate-900/25 p-6 text-center text-sm text-slate-400">Loading...</div>
+      ) : fetchError ? (
+        <div className="rounded-md border border-rose-500/40 bg-rose-500/10 p-4 text-center text-sm text-rose-200">
+          Failed to load users.
+          <button type="button" onClick={() => void fetchUsers()} className="ml-2 font-medium text-rose-100 underline underline-offset-2 hover:text-white">
+            Retry
+          </button>
+        </div>
       ) : users.length === 0 ? (
         <div className="rounded-md border border-slate-700/70 bg-slate-900/25 p-4 text-sm text-slate-400">
           No users found. Create one to get started.

--- a/dashboard/src/app/dashboard/containers/page.tsx
+++ b/dashboard/src/app/dashboard/containers/page.tsx
@@ -73,8 +73,7 @@ export default function ContainersPage() {
               : `Failed to load containers (${res.status})`;
           setFetchError(message);
         }
-      } catch (error) {
-        console.error("Failed to fetch containers:", error);
+      } catch {
         setFetchError("Network error while loading containers.");
       } finally {
         setLoading(false);

--- a/dashboard/src/app/dashboard/layout.tsx
+++ b/dashboard/src/app/dashboard/layout.tsx
@@ -23,7 +23,7 @@ export default async function DashboardLayout({
          <MobileTopBar />
          <div className="flex min-h-screen">
            <DashboardNav />
-            <main className="flex-1 px-3 pb-4 pt-16 lg:px-6 lg:pb-6 lg:pt-6">
+            <main className="min-w-0 flex-1 px-3 pb-4 pt-16 lg:px-6 lg:pb-6 lg:pt-6">
               <div className="mx-auto w-full max-w-[1320px]">{children}</div>
             </main>
           </div>

--- a/dashboard/src/app/dashboard/monitoring/page.tsx
+++ b/dashboard/src/app/dashboard/monitoring/page.tsx
@@ -119,9 +119,7 @@ export default function MonitoringPage() {
           const data = await res.json();
           setStatus(data);
         }
-      } catch (error) {
-        console.error("Failed to fetch status:", error);
-      }
+      } catch {}
     };
 
     fetchStatus();
@@ -138,9 +136,7 @@ export default function MonitoringPage() {
           const data = await res.json();
           setUsage(data);
         }
-      } catch (error) {
-        console.error("Failed to fetch usage:", error);
-      }
+      } catch {}
     };
 
     fetchUsage();
@@ -209,8 +205,7 @@ export default function MonitoringPage() {
             logsIntervalRef.current = null;
           }
         }
-      } catch (error) {
-        console.error("Failed to fetch logs:", error);
+      } catch {
         setLoggingState(LOGGING_STATE.ERROR);
         setLoggingError("Network error while fetching logs");
         if (logsIntervalRef.current) {
@@ -304,8 +299,7 @@ export default function MonitoringPage() {
       } else {
         setRestarting(false);
       }
-    } catch (error) {
-      console.error("Restart failed:", error);
+    } catch {
       setRestarting(false);
     }
   };

--- a/dashboard/src/app/dashboard/providers/page.tsx
+++ b/dashboard/src/app/dashboard/providers/page.tsx
@@ -276,9 +276,7 @@ const loadProvidersData = async (): Promise<Record<ProviderId, ProviderState>> =
           newConfigs[provider.id] = { keys };
         }
       }
-    } catch (error) {
-      console.error(`Failed to load keys for ${provider.id}:`, error);
-    }
+    } catch {}
   }
 
   return newConfigs;
@@ -343,9 +341,7 @@ export default function ProvidersPage() {
         const data = await res.json();
         setCurrentUser({ id: data.id, username: data.username, isAdmin: data.isAdmin });
       }
-    } catch (error) {
-      console.error("Failed to load current user:", error);
-    }
+    } catch {}
   }, []);
 
   const loadMaxKeysPerUser = useCallback(async () => {
@@ -362,9 +358,7 @@ export default function ProvidersPage() {
           }
         }
       }
-    } catch (error) {
-      console.error("Failed to load max keys per user:", error);
-    }
+    } catch {}
   }, [currentUser]);
 
   const refreshProviders = async () => {
@@ -447,8 +441,7 @@ export default function ProvidersPage() {
       showToast("Provider key added successfully", "success");
       closeModal();
       await refreshProviders();
-    } catch (error) {
-      console.error("Add key error:", error);
+    } catch {
       showToast("Network error", "error");
     } finally {
       setSaving(false);
@@ -475,8 +468,7 @@ export default function ProvidersPage() {
       }
       showToast("Provider key deleted", "success");
       await refreshProviders();
-    } catch (error) {
-      console.error("Delete key error:", error);
+    } catch {
       showToast("Network error", "error");
     }
   };
@@ -512,8 +504,7 @@ export default function ProvidersPage() {
       const data = await res.json();
       setAccounts(Array.isArray(data.accounts) ? data.accounts : []);
       setOauthAccountsLoading(false);
-    } catch (error) {
-      console.error("Load accounts error:", error);
+    } catch {
       setOauthAccountsLoading(false);
       showToast("Network error", "error");
       setOauthErrorMessage("Network error while loading accounts.");
@@ -533,8 +524,7 @@ export default function ProvidersPage() {
       const data = await res.json();
       setCustomProviders(Array.isArray(data.providers) ? data.providers : []);
       setCustomProvidersLoading(false);
-    } catch (error) {
-      console.error("Load custom providers error:", error);
+    } catch {
       setCustomProvidersLoading(false);
       showToast("Network error", "error");
     }
@@ -814,8 +804,7 @@ export default function ProvidersPage() {
       }
       showToast("OAuth account removed", "success");
       void loadAccounts();
-    } catch (error) {
-      console.error("Delete OAuth error:", error);
+    } catch {
       showToast("Network error", "error");
     }
   };
@@ -837,8 +826,7 @@ export default function ProvidersPage() {
       }
       showToast("Custom provider deleted", "success");
       void loadCustomProviders();
-    } catch (error) {
-      console.error("Delete custom provider error:", error);
+    } catch {
       showToast("Network error", "error");
     }
   };
@@ -1237,9 +1225,8 @@ export default function ProvidersPage() {
                              const data = await res.json();
                              showToast(data.error || "Failed to update setting", "error");
                            }
-                         } catch (error) {
-                           console.error("Update setting error:", error);
-                           showToast("Network error", "error");
+                          } catch {
+                            showToast("Network error", "error");
                          }
                        }}
                       >

--- a/dashboard/src/app/dashboard/quota/page.tsx
+++ b/dashboard/src/app/dashboard/quota/page.tsx
@@ -276,11 +276,8 @@ export default function QuotaPage() {
         if (res.ok) {
           const data = await res.json();
           setQuotaData(data);
-        } else {
-          console.error("Failed to fetch quota data");
         }
-      } catch (error) {
-        console.error("Network error:", error);
+      } catch {
       } finally {
         setLoading(false);
       }
@@ -334,11 +331,8 @@ export default function QuotaPage() {
       if (res.ok) {
         const data = await res.json();
         setQuotaData(data);
-      } else {
-        console.error("Failed to fetch quota data");
       }
-    } catch (error) {
-      console.error("Network error:", error);
+    } catch {
     } finally {
       setLoading(false);
     }

--- a/dashboard/src/app/dashboard/settings/page.tsx
+++ b/dashboard/src/app/dashboard/settings/page.tsx
@@ -82,7 +82,6 @@ export default function SettingsPage() {
         setProxyUpdateInfo(data);
       }
     } catch {
-      console.error("Failed to fetch update info");
     } finally {
       setProxyUpdateLoading(false);
     }
@@ -97,7 +96,6 @@ export default function SettingsPage() {
         setDashboardUpdateInfo(data);
       }
     } catch {
-      console.error("Failed to fetch dashboard update info");
     } finally {
       setDashboardUpdateLoading(false);
     }
@@ -115,7 +113,6 @@ export default function SettingsPage() {
         }
       }
     } catch {
-      console.error("Failed to fetch sync tokens");
     } finally {
       setSyncTokensLoading(false);
     }

--- a/dashboard/src/components/config-publisher.tsx
+++ b/dashboard/src/components/config-publisher.tsx
@@ -45,7 +45,6 @@ export function ConfigPublisher() {
       setStatus(data);
       setTemplateName(data.name || "");
     } catch {
-      console.error("Failed to fetch publish status");
       setStatus(null);
     } finally {
       setLoading(false);

--- a/dashboard/src/components/config-subscriber.tsx
+++ b/dashboard/src/components/config-subscriber.tsx
@@ -49,7 +49,6 @@ export function ConfigSubscriber({ hasApiKey }: ConfigSubscriberProps) {
         setStatus(data);
       }
     } catch {
-      console.error("Failed to fetch subscription status");
       setStatus(null);
     } finally {
       setLoading(false);

--- a/dashboard/src/components/custom-provider-modal.tsx
+++ b/dashboard/src/components/custom-provider-modal.tsx
@@ -168,8 +168,7 @@ export function CustomProviderModal({ isOpen, onClose, provider, onSuccess }: Cu
         const error = await response.json();
         showToast(error.error || "Failed to save provider", "error");
       }
-    } catch (error) {
-      console.error("Save provider error:", error);
+    } catch {
       showToast("Network error", "error");
     } finally {
       setSaving(false);
@@ -251,8 +250,7 @@ export function CustomProviderModal({ isOpen, onClose, provider, onSuccess }: Cu
         const error = await response.json();
         showToast(error.error || "Failed to fetch models", "error");
       }
-    } catch (error) {
-      console.error("Fetch models error:", error);
+    } catch {
       showToast("Network error", "error");
     } finally {
       setFetchingModels(false);

--- a/dashboard/src/components/deploy-dashboard.tsx
+++ b/dashboard/src/components/deploy-dashboard.tsx
@@ -63,9 +63,7 @@ export function DeployDashboard() {
           }
         }
       }
-    } catch {
-      console.error("Failed to fetch deploy status");
-    }
+    } catch {}
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Bug fixes found through systematic audit — 8 issues across 15 files, each validated before fixing.

## Fixes

### P1: Data Integrity

**1. Usage history showed only 100 of 8000+ records**
- **File**: `api/usage/history/route.ts`
- **Bug**: Pagination was applied before aggregation — only first 100 records were aggregated, rest ignored
- **Fix**: Removed broken pagination, aggregation now runs over all records for the period
- **Impact**: Usage totals now show correct numbers

**2. Auto-save lost data on page navigation**
- **File**: `components/opencode-config-generator.tsx`
- **Bug**: Debounced save used `clearTimeout` in useEffect cleanup — navigating away cancelled the pending save
- **Fix**: Added separate unmount effect that flushes pending save via `fetch(..., { keepalive: true })`
- **Impact**: Config changes no longer silently lost

**3. Double-fetch on usage page load**
- **File**: `dashboard/usage/page.tsx`
- **Bug**: `isAdmin` was both set inside useEffect and listed as dependency — caused effect to re-run when admin status resolved
- **Fix**: Moved `isAdmin` to a ref for the effect, kept state for rendering
- **Impact**: No more redundant collect+fetch cycle on first load

**4. Race condition on rapid filter changes**
- **File**: `dashboard/usage/page.tsx`
- **Bug**: No AbortController — slow old responses could overwrite newer data
- **Fix**: Added AbortController, aborted on cleanup, early-return on aborted signal
- **Impact**: Filter changes always show data for the selected period

### P2: Stability & UX

**5. 31x console.error in client code**
- **Files**: 5 pages + 5 components
- **Bug**: Client-side `console.error` invisible to users, clutters DevTools
- **Fix**: Removed all 31 instances — existing `showToast` calls preserved, silent catches where appropriate
- **Impact**: Clean console, no behavior change

**6. Missing fetch timeouts in quota route**
- **File**: `api/quota/route.ts`
- **Bug**: 6 fetch calls to external providers via management proxy had no timeout — slow upstream could block worker indefinitely
- **Fix**: Added `signal: AbortSignal.timeout(30_000)` to all 6 calls
- **Impact**: Quota requests fail cleanly after 30s instead of hanging

**7. Admin users: error looked like empty list**
- **File**: `admin/users/page.tsx`
- **Bug**: Network error set `loading=false` but `users` stayed empty — showed "No users found" instead of error
- **Fix**: Added `fetchError` state with dedicated error UI and retry button
- **Impact**: Users see "Failed to load users" with retry, not a misleading empty state

**8. Mobile overflow on all dashboard pages**
- **File**: `dashboard/layout.tsx`
- **Root cause**: `<main className="flex-1">` without `min-w-0` — flex children can never shrink below content width
- **Fix**: Added `min-w-0` to main element — standard fix used by e2b, AgentOps, and other production dashboards
- **Impact**: All pages respect viewport width, overflow-x-auto on tables works correctly

## Verification

- Build passes
- Zero `console.error` in client code
- Zero LSP errors on all modified files
- Each fix individually validated against the codebase before implementation

## Files Changed (15)

```
api/quota/route.ts              — 30s timeouts on 6 fetches
api/usage/history/route.ts      — remove broken pagination
admin/users/page.tsx            — error state + retry
containers/page.tsx             — remove console.error
layout.tsx                      — min-w-0 fix
monitoring/page.tsx             — remove console.error
providers/page.tsx              — remove console.error
quota/page.tsx                  — remove console.error
settings/page.tsx               — remove console.error
usage/page.tsx                  — AbortController + isAdmin ref
config-publisher.tsx            — remove console.error
config-subscriber.tsx           — remove console.error
custom-provider-modal.tsx       — remove console.error
deploy-dashboard.tsx            — remove console.error
opencode-config-generator.tsx   — flush save on unmount
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data integrity in usage history, prevents autosave data loss, cancels stale requests, and cleans up client noise. Adds timeouts and a layout fix for a smoother, more reliable dashboard.

- **Bug Fixes**
  - Usage history now aggregates all records for the period (removed broken pagination).
  - Auto-save flushes on unmount using keepalive to prevent lost changes.
  - Stopped double-fetch on usage load by moving isAdmin to a ref.
  - Cancelled stale usage requests on rapid filter changes via AbortController.

- **Stability & UX**
  - Added 30s timeouts to six external fetches in the quota route.
  - Admin Users now shows a clear error with a retry button instead of an empty state.
  - Removed 31 console.error calls across client code.
  - Fixed dashboard horizontal overflow on mobile by adding min-w-0 to the main container.

<sup>Written for commit 54a4c167b47c03acdd07dea011e80fce9b11a38c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

