### PR TITLE
docs: update AGENTS.md with accurate metrics and patterns

### DIFF
--- a/dashboard/src/lib/AGENTS.md
+++ b/dashboard/src/lib/AGENTS.md
@@ -4,44 +4,57 @@
 
 ## OVERVIEW
 
-Server-side utilities: authentication, config generation, provider sync, API key management. Foundation layer for all API routes.
+Server-side utilities: authentication, config generation, provider sync, API key management, error handling, caching, logging. Foundation layer for all API routes.
 
 ## STRUCTURE
 
 ```
 lib/
-├── auth/              # Identity & sessions
-├── config-generators/ # JSON/YAML output builders
-├── config-sync/       # Bundle orchestration
-├── providers/         # AI provider dual-write
+├── auth/              # Identity & sessions (session, sync-token, origin, rate-limit, password)
+├── config-generators/ # JSON/YAML output builders (opencode, oh-my-opencode, shared)
+├── config-sync/       # Bundle orchestration (generate-bundle)
+├── providers/         # AI provider dual-write (dual-write, constants)
 ├── api-keys/          # Dashboard API keys
+├── validation/        # Zod schemas for request validation
+├── cache.ts           # LRU cache with TTL (proxy models, usage)
 ├── db.ts              # Prisma singleton
+├── env.ts             # Zod-validated environment variables
+├── errors.ts          # Errors.* response factories (401 lines)
+├── fetch-utils.ts     # fetchWithRetry with backoff
+├── log-storage.ts     # In-memory log ring buffer (10s cache)
+├── logger.ts          # Pino logger (server-only)
 └── utils.ts           # cn() helper
 ```
 
 ## MODULE MAP
 
-| Directory | Purpose | Key Export |
-|-----------|---------|------------|
-| `auth/` | JWT sessions, password hashing, CSRF | `verifySession()`, `validateOrigin()` |
+| Module | Purpose | Key Export |
+|--------|---------|------------|
+| `auth/` | JWT sessions, password hashing, CSRF, rate limiting | `verifySession()`, `validateOrigin()`, `checkRateLimitWithPreset()` |
 | `config-generators/` | Build opencode.json configs | `buildAvailableModelsFromProxy()`, `fetchProxyModels()` |
 | `config-sync/` | Merge all user data into bundle | `generateConfigBundle()` — models from proxy only, no upstream credentials |
 | `providers/` | Sync keys to DB + CLIProxyAPI | `contributeKey()`, `removeKey()` |
 | `api-keys/` | Dashboard access tokens | `generateApiKey()`, `syncKeysToCliProxyApi()` |
+| `validation/` | Request validation | Zod schemas for providers, config, settings |
+| `errors.ts` | Error response factories | `Errors.unauthorized()`, `.internal()`, etc. |
+| `cache.ts` | LRU with TTL + pattern invalidation | `proxyModelsCache`, `usageCache`, `CACHE_TTL` |
+| `fetch-utils.ts` | Resilient HTTP | `fetchWithRetry()` with exponential backoff |
 
 ## DEPENDENCY FLOW
 
 ```
 auth/ ←── (foundation, no deps)
    ↑
-api-keys/ ←── depends on auth
+api-keys/ ←── depends on auth, db
    ↑
-providers/ ←── depends on db, uses AsyncMutex
+providers/ ←── depends on db, cache, uses AsyncMutex
    ↑
 config-generators/ ←── pure functions, types only
    ↑
-config-sync/ ←── ORCHESTRATOR, depends on ALL above
+config-sync/ ←── ORCHESTRATOR, depends on ALL above + cache
 ```
+
+Shared by all: `db.ts`, `env.ts`, `errors.ts`, `logger.ts`, `cache.ts`.
 
 ## KEY FILES
 
@@ -49,21 +62,20 @@ config-sync/ ←── ORCHESTRATOR, depends on ALL above
 |------|-------|-------------|---------|
 | `auth/session.ts` | ~80 | HIGH | Cookie session management |
 | `auth/sync-token.ts` | ~110 | HIGH | CLI token validation |
-| `providers/dual-write.ts` | 778 | CRITICAL | DB + API sync with mutex |
-| `config-sync/generate-bundle.ts` | ~400 | CRITICAL | Main config orchestrator |
+| `providers/dual-write.ts` | 961 | CRITICAL | DB + API sync with mutex |
+| `config-sync/generate-bundle.ts` | 394 | CRITICAL | Main config orchestrator |
+| `errors.ts` | 401 | HIGH | All error response factories |
+| `cache.ts` | 107 | MEDIUM | LRU cache with TTL + invalidation |
 
 ## PATTERNS
 
 ### Auth Check (API Routes)
 ```typescript
+import { Errors } from "@/lib/errors";
 const session = await verifySession();
-if (!session) {
-  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-}
+if (!session) return Errors.unauthorized();
 // For admin:
-if (!session.user.isAdmin) {
-  return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-}
+if (!session.user.isAdmin) return Errors.forbidden();
 ```
 
 ### Sync Token Check (CLI Routes)
@@ -81,23 +93,37 @@ const originError = validateOrigin(request);
 if (originError) return originError;
 ```
 
+### Error Handling
+```typescript
+import { Errors } from "@/lib/errors";
+try {
+  // ... business logic
+} catch (error) {
+  return Errors.internal("context description", error);  // Logs via Pino + 500
+}
+```
+
 ### Dual-Write Pattern
 ```typescript
 // providers/dual-write.ts uses mutex to prevent races
 await contributeKey(userId, provider, apiKey, keyName);
 // Writes to: 1) Prisma DB  2) CLIProxyAPI Management API
+// Then invalidates proxy models cache
 ```
 
 ## KEY ARCHITECTURE DECISIONS
 
 - **Config bundle never contains upstream credentials**: Custom provider models come from CLIProxyAPI's `/v1/models` via `buildAvailableModelsFromProxy()`. The `generate-bundle.ts` must NOT embed `base-url` or `api-key-entries` from custom providers into the opencode config output.
-- **Proxy models cache**: `fetchProxyModelsCached()` in `config-sync/generate-bundle.ts` caches `/v1/models` responses for 60s. Invalidated via `invalidateProxyModelsCache()` after provider sync.
+- **Proxy models cache**: `fetchProxyModelsCached()` in `config-sync/generate-bundle.ts` caches `/v1/models` responses for **5 minutes** (300s). Invalidated via `invalidateProxyModelsCache()` after provider sync.
+- **Usage cache**: `usageCache` with 30s TTL for usage aggregation queries.
 - **Custom provider excluded-models**: Still extracted from management API config to feed into the model filter — this is the only remaining use of `extractCustomProviders()` in generate-bundle.
+- **Error factories**: All API error responses go through `Errors.*` which handles logging + consistent JSON shape. Never use raw `console.error` + `NextResponse.json`.
 
 ## ANTI-PATTERNS
 
 - **NEVER** call Prisma directly in routes → use lib functions
+- **NEVER** use `console.error` in routes → use `Errors.internal()` or `logger.error()`
 - **NEVER** skip `validateOrigin()` on POST/PATCH/DELETE
-- **NEVER** modify `config-sync/` without testing bundle output
+- **NEVER** modify `config-sync/` without testing bundle output (`npm run build`)
 - **NEVER** bypass the mutex in `dual-write.ts`
 - **NEVER** add upstream provider URLs or API keys to generated config bundles


### PR DESCRIPTION
## Summary

- Fix stale hotspot line counts (e.g. `oh-my-opencode-config-generator.tsx` 1438L, `providers/page.tsx` 1453L)
- Correct proxy models cache TTL documentation from 60s to 5min (actual `CACHE_TTL.PROXY_MODELS = 300_000`)
- Add `console.error` ban rule for API routes — must use `Errors.*` or `logger.error()`
- Rewrite API route template to use `Errors.internal()` instead of `console.error`
- Add missing lib modules (`dual-write.ts`, `generate-bundle.ts`) to module map
- Mark `/api/usage` as DEPRECATED (replaced by `/api/usage/history`)
- Update component count from 13 → 15

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes AGENTS.md across the repo to match current architecture and patterns. Updates caching (5-minute proxy models TTL), standardizes API error handling with Errors.*, adds missing lib modules and deployment/auth notes, and deprecates /api/usage in favor of /api/usage/history.

- **Migration**
  - Switch any callers from /api/usage to /api/usage/history.
  - In API routes, replace console.error with Errors.internal() or logger.error() and follow the new route template.

<sup>Written for commit ac4348c48a25fd8cb46f8190234defa3d855a7db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

