### PR TITLE
fix(health): use proxy root endpoint instead of /v0/management for healthcheck

### DIFF
--- a/dashboard/src/app/api/health/route.ts
+++ b/dashboard/src/app/api/health/route.ts
@@ -29,7 +29,10 @@ async function checkProxy(): Promise<boolean> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT_MS);
 
-    const response = await fetch(env.CLIPROXYAPI_MANAGEMENT_URL, {
+    // Use the root endpoint (/) instead of /v0/management which has no route handler
+    // and produces 404 warn spam in cliproxyapi logs every healthcheck interval
+    const proxyRoot = env.CLIPROXYAPI_MANAGEMENT_URL.replace(/\/v0\/management\/?$/, "/");
+    const response = await fetch(proxyRoot, {
       method: "HEAD",
       signal: controller.signal,
     });


### PR DESCRIPTION
## Summary

- **Problem**: Docker healthcheck calls `HEAD /v0/management` every 15s, but cliproxyapi has no route handler for the bare `/v0/management` path → produces ~5,760 `404` warnings/day in logs
- **Root cause**: `checkProxy()` in `/api/health/route.ts` fetches `env.CLIPROXYAPI_MANAGEMENT_URL` (`http://cliproxyapi:8317/v0/management`) directly. Sub-routes like `/v0/management/config` work fine, but the parent path has no handler.
- **Fix**: Strip `/v0/management` suffix and hit the root endpoint (`/`) instead, which returns `200 OK`

## Details

The healthcheck was functionally fine (404 < 500 → proxy reported as "connected"), but the warn-level log spam was noisy. This is a one-line URL derivation change — no behavior change, same `HEAD` method, same timeout, same status evaluation logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update healthcheck to hit the cliproxyapi root endpoint (/) instead of /v0/management. This stops ~5,760 daily 404 warnings in logs without changing healthcheck behavior.

- **Bug Fixes**
  - Strip /v0/management from CLIPROXYAPI_MANAGEMENT_URL and send HEAD to root (/).
  - No behavior change: same method, timeout, and status check logic.

<sup>Written for commit 58f640b25c2fa20b941965f74a351696ef6dbc1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

