### PR TITLE
fix(health): use GET instead of HEAD for proxy healthcheck

### DIFF
--- a/dashboard/src/app/api/health/route.ts
+++ b/dashboard/src/app/api/health/route.ts
@@ -33,7 +33,7 @@ async function checkProxy(): Promise<boolean> {
     // and produces 404 warn spam in cliproxyapi logs every healthcheck interval
     const proxyRoot = env.CLIPROXYAPI_MANAGEMENT_URL.replace(/\/v0\/management\/?$/, "/");
     const response = await fetch(proxyRoot, {
-      method: "HEAD",
+      method: "GET",
       signal: controller.signal,
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #61. cliproxyapi's Gin router only registers `GET` handlers — `HEAD` is not implicitly handled. The previous fix switched the URL from `/v0/management` to `/` but kept `HEAD`, which still produces 404 warnings.

Switch from `HEAD` to `GET`. The root endpoint response is 116 bytes — negligible overhead for a 15s healthcheck.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the proxy healthcheck from HEAD to GET so cliproxyapi returns 200 on / and stops 404 warning spam.
The GET response is only 116 bytes, so the 15s check adds negligible overhead.

<sup>Written for commit 144c794c820a514c2e2f40897d4237e4ad84ed3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

