### PR TITLE
fix: correct model-to-provider heuristics and add missing provider mappings

### DIFF
--- a/dashboard/src/lib/providers/model-grouping.ts
+++ b/dashboard/src/lib/providers/model-grouping.ts
@@ -10,7 +10,7 @@ const OWNED_BY_DISPLAY: Record<string, string> = {
   openai: "OpenAI/Codex",
   moonshot: "Kimi",
   "perplexity-pro": "Perplexity",
-  zai: "ZAI",
+  aws: "Kiro",
   kiro: "Kiro",
   iflow: "iFlow",
   qwen: "Qwen",
@@ -25,7 +25,6 @@ export const MODEL_PROVIDER_ORDER = [
   "OpenAI/Codex",
   "Kimi",
   "Perplexity",
-  "ZAI",
   "Kiro",
   "iFlow",
   "Qwen",
@@ -72,11 +71,13 @@ export function detectModelProvider(
   const lower = modelId.toLowerCase();
 
   if (lower.startsWith("claude-")) return "Claude";
-  if (lower.startsWith("gemini-")) return "Gemini";
+  if (lower.startsWith("gemini-") || lower.startsWith("imagen-")) return "Gemini";
   if (lower.startsWith("antigravity-")) return "Antigravity";
   if (lower.startsWith("kimi-")) return "Kimi";
   if (lower.startsWith("perplexity-")) return "Perplexity";
-  if (lower.startsWith("glm-")) return "ZAI";
+  if (lower.startsWith("kiro-") || lower.startsWith("amazonq-")) return "Kiro";
+  if (lower.startsWith("glm-") || lower.startsWith("iflow-") || lower.startsWith("minimax-") || lower.startsWith("tstars")) return "iFlow";
+  if (lower.startsWith("qwen")) return "Qwen";
   if (
     lower.startsWith("gpt-") ||
     lower.startsWith("o1") ||


### PR DESCRIPTION
## Summary

Fixes #86 — iFlow models (GLM-5 etc.) were incorrectly categorized under non-existent "ZAI" provider in the dashboard UI.

## Changes

**`dashboard/src/lib/providers/model-grouping.ts`**

### `OWNED_BY_DISPLAY` (owned_by → display name mapping)
- **Added** `aws: "Kiro"` — Kiro/AmazonQ models use `owned_by: "aws"` in CLIProxyAPIPlus
- **Removed** `zai: "ZAI"` — no provider in CLIProxyAPIPlus uses `owned_by: "zai"`

### `MODEL_PROVIDER_ORDER` (UI sort order)
- **Removed** `"ZAI"` — dead entry, never matched

### `detectModelProvider()` (fallback name-prefix heuristics)
- **Fixed** `glm-*` → `"iFlow"` (was incorrectly `"ZAI"`)
- **Added** `imagen-*` → `"Gemini"` (Google Imagen models)
- **Added** `kiro-*`, `amazonq-*` → `"Kiro"`
- **Added** `iflow-*`, `minimax-*`, `tstars*` → `"iFlow"`
- **Added** `qwen*` → `"Qwen"`

## Verification

Cross-referenced all model IDs and `OwnedBy` values from CLIProxyAPIPlus `internal/registry/model_definitions_static_data.go` and `model_definitions.go` against the dashboard heuristics. All providers now correctly covered:

| `owned_by` | Display | Heuristic prefixes |
|---|---|---|
| `anthropic` | Claude | `claude-` |
| `github-copilot` | Copilot | *(sourceMap only — IDs overlap with other providers)* |
| `google` | Gemini | `gemini-`, `imagen-` |
| `antigravity` | Antigravity | `antigravity-` |
| `openai` | OpenAI/Codex | `gpt-`, `o1`, `o3`, `o4`, `*codex*` |
| `moonshot` | Kimi | `kimi-` |
| `perplexity-pro` | Perplexity | `perplexity-` |
| `aws` | Kiro | `kiro-`, `amazonq-` |
| `iflow` | iFlow | `glm-`, `iflow-`, `minimax-`, `tstars` |
| `qwen` | Qwen | `qwen*` |

**Note:** The heuristic is a fallback only — the primary path uses `modelSourceMap` built from CLIProxyAPIPlus `/v1/models` `owned_by` field, which always takes precedence.