### PR TITLE
fix: remove incompatible thinking/reasoning options from generated config

### DIFF
--- a/dashboard/src/lib/config-sync/generate-bundle.ts
+++ b/dashboard/src/lib/config-sync/generate-bundle.ts
@@ -319,9 +319,6 @@ export async function generateConfigBundle(userId: string, syncApiKey?: string |
      if (def.reasoning) {
        entry.reasoning = true;
      }
-     if (def.options) {
-       entry.options = def.options;
-     }
      modelEntries[id] = entry;
    }
 


### PR DESCRIPTION
## Summary

Fixes #89 — JSON payload error when using thinking models (e.g. `claude-opus-4-6-thinking` via Antigravity).

## Root Cause

All models are served through CLIProxyAPI, which opencode consumes as `@ai-sdk/openai-compatible`. This SDK only supports `{ reasoningEffort: "low"|"medium"|"high" }` — **not** Anthropic-native `{ thinking: { type: "enabled", budgetTokens: N } }` or OpenAI `{ reasoning: { effort: "medium" } }`.

The dashboard was injecting these provider-specific options into the generated `opencode.json` config, causing the AI SDK to send malformed JSON payloads to CLIProxyAPI, which then rejected them.

## Changes

- **Removed `options` field** from `ModelDefinition` interface and all serialization paths (`opencode.ts`, `generate-bundle.ts`)
- **Removed thinking/reasoning options** from `inferModelDefinition()` and `extractOAuthModelAliases()`
- **Tightened `isReasoning` heuristic** via new `supportsReasoning()` helper:
  - Old: matched `"thinking"`, `"opus"`, `"codex"`, `"pro"`, `o1/o3/o4` → false positives on `gemini-3-pro`, `claude-opus-4-6` (non-thinking)
  - New: only matches `"thinking"`, `"reasoning"`, `o1/o3/o4` → exact match for reasoning models

## How it works now

```json
// Before (broken) — caused JSON payload error
"claude-opus-4-6-thinking": {
  "reasoning": true,
  "options": { "thinking": { "type": "enabled", "budgetTokens": 10000 } }
}

// After (fixed) — opencode auto-generates correct reasoningEffort variants
"claude-opus-4-6-thinking": {
  "reasoning": true
}
```

The `reasoning: true` flag is preserved so opencode's built-in variant system generates correct `reasoningEffort` variants for `@ai-sdk/openai-compatible` providers. CLIProxyAPI handles thinking budget/support internally per model.

## Affected models

All thinking/reasoning models served through CLIProxyAPI, including:
- `claude-opus-4-6-thinking`, `claude-sonnet-4-6-thinking` (Antigravity)
- `claude-opus-4-5-thinking`, `claude-sonnet-4-5-thinking` (Antigravity)
- OAuth model aliases with "thinking" in the name
- Previously incorrectly flagged: `gemini-3-pro`, `claude-opus-4-6` (non-thinking) — no longer marked as reasoning

## Verification

- ✅ `npm run build` — clean
- ✅ `npm run lint` — clean
- ✅ LSP diagnostics — no errors