### PR TITLE
fix(install): avoid unbound CADDY_MODE when skipping Caddy auto-apply

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -882,7 +882,7 @@ CADDY_DOCKER_CONFIG
         fi
     else
         log_info "Skipping auto-apply. Please manually add one of the configurations above to your Caddyfile."
-        if [[ "$CADDY_MODE" =~ ^[Dd]ocker$ ]]; then
+        if [[ "${CADDY_MODE:-}" =~ ^[Dd]ocker$ ]]; then
             log_info "Remember to connect Caddy to the frontend network:"
             echo "  ${YELLOW}docker network connect cliproxyapi_frontend <your-caddy-container-name>${NC}"
         fi


### PR DESCRIPTION
脚本在回答 `n` 跳过自动应用 Caddy 后，仍然执行了下面这段代码：

```bash
if [[ "$CADDY_MODE" =~ ^[Dd]ocker$ ]]; then
    log_info "Remember to connect Caddy to the frontend network:"
    echo "  ${YELLOW}docker network connect cliproxyapi_frontend <your-caddy-container-name>${NC}"
fi
```

但 `CADDY_MODE` 这个变量只在选择 y 之后才会被赋值（通过 `read -p "Is your Caddy running on the host system or in Docker?"`），选 `n` 跳过时它从未被定义。而脚本开头有 `set -euo pipefail`，其中 `-u` 选项会让引用未定义变量直接报错退出。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes install script crash caused by an unbound CADDY_MODE when skipping Caddy auto-apply. The check now uses ${CADDY_MODE:-} so the Docker network reminder runs only when CADDY_MODE is set.

<sup>Written for commit 50ce643b13a936d06db1491ef3bc031f70009465. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

