### PR TITLE
fix: save config via PUT config.yaml instead of non-existent PUT config JSON

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -14,6 +14,7 @@
         "clsx": "^2.1.1",
         "geist": "^1.7.0",
         "jose": "^6.1.3",
+        "js-yaml": "^4.1.1",
         "next": "16.1.6",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
@@ -27,6 +28,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/bcrypt": "^6.0.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2384,6 +2386,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3031,7 +3040,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -5858,7 +5866,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -16,6 +16,7 @@
     "clsx": "^2.1.1",
     "geist": "^1.7.0",
     "jose": "^6.1.3",
+    "js-yaml": "^4.1.1",
     "next": "16.1.6",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
@@ -29,6 +30,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/bcrypt": "^6.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/dashboard/src/app/api/management/[...path]/route.ts
+++ b/dashboard/src/app/api/management/[...path]/route.ts
@@ -36,6 +36,7 @@ const NON_ADMIN_OAUTH_PATHS = new Set<string>([
 
 const ALLOWED_MANAGEMENT_PATHS = new Set<string>([
   "config",
+  "config.yaml",
   "usage",
   "logs",
   "logging-to-file",
@@ -96,7 +97,7 @@ function normalizeAndValidateManagementPath(rawPath: string): string | null {
     return null;
   }
 
-  if (!/^[a-z0-9-]+(?:\/[a-z0-9-]+)*$/i.test(normalizedPath)) {
+  if (!/^[a-z0-9.-]+(?:\/[a-z0-9.-]+)*$/i.test(normalizedPath)) {
     return null;
   }
 

--- a/dashboard/src/app/dashboard/config/page.tsx
+++ b/dashboard/src/app/dashboard/config/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/toast";
+import yaml from "js-yaml";
 
 // Config shape (excluding fields managed elsewhere)
 interface StreamingConfig {
@@ -184,10 +185,10 @@ export default function ConfigPage() {
     setSaving(true);
 
     try {
-      const res = await fetch("/api/management/config", {
+      const res = await fetch("/api/management/config.yaml", {
         method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(config),
+        headers: { "Content-Type": "text/yaml" },
+        body: yaml.dump(config, { lineWidth: -1, noRefs: true }),
       });
 
       if (!res.ok) {


### PR DESCRIPTION
## Summary

- **Root cause**: CLIProxyAPIPlus only exposes `GET /v0/management/config` (JSON) and `PUT /v0/management/config.yaml` (YAML). There is no `PUT /config` JSON endpoint — it was never implemented. The dashboard was sending `PUT /api/management/config` with JSON, which the backend returned 404 for.
- **Fix**: Convert config JSON → YAML via `js-yaml` before saving, and send to `PUT /api/management/config.yaml` with `Content-Type: text/yaml`.

## Changes

| File | What changed |
|------|-------------|
| `dashboard/src/app/dashboard/config/page.tsx` | Import `js-yaml`, change `handleSave` to serialize config as YAML and PUT to `/api/management/config.yaml` |
| `dashboard/src/app/api/management/[...path]/route.ts` | Add `config.yaml` to `ALLOWED_MANAGEMENT_PATHS`, update path regex to allow dots |
| `dashboard/package.json` | Add `js-yaml` dependency |

## Verified

- `PUT /v0/management/config.yaml` tested directly on production server → `{"changed":["config"],"ok":true}` with HTTP 200
- `GET /v0/management/config` continues to work for loading config (unchanged)
- Build passes, LSP diagnostics clean