### PR TITLE
feat: expose all CLIProxyAPIPlus config fields in dashboard

### DIFF
--- a/dashboard/src/app/dashboard/config/page.tsx
+++ b/dashboard/src/app/dashboard/config/page.tsx
@@ -1042,9 +1042,11 @@ export default function ConfigPage() {
             >
               <textarea
                 value={
-                  config.payload?.[key] != null
-                    ? JSON.stringify(config.payload[key], null, 2)
-                    : ""
+                  config.payload?.[key] == null
+                    ? ""
+                    : typeof config.payload[key] === "string"
+                      ? (config.payload[key] as string)
+                      : JSON.stringify(config.payload[key], null, 2)
                 }
                 onChange={(e) => {
                   const raw = e.target.value.trim();


### PR DESCRIPTION
## Summary

Adds all 11 missing CLIProxyAPIPlus backend configuration fields to the dashboard config page, achieving full feature parity with the proxy's config API.

## New fields added

### Simple toggles/inputs (added to existing sections)
- **General**: `disable-cooling`, `request-log`, `passthrough-headers`, `incognito-browser`
- **Retry & Resilience**: `max-retry-credentials`

### New sections (7)
| Section | Fields |
|---------|--------|
| TLS / HTTPS | `tls.enable`, `tls.cert`, `tls.key` |
| Kiro | `kiro-preferred-endpoint` |
| Claude Header Defaults | `user-agent`, `package-version`, `runtime-version`, `timeout` |
| Amp Code | `upstream-url`, `upstream-api-key`, `restrict-management-to-localhost`, `force-model-mappings` |
| Profiling (pprof) | `enable`, `addr` |
| OAuth Model Aliases | Per-provider collapsible editors with name/alias/fork per entry, add/remove rows |
| Payload Manipulation | JSON textarea editors for `default`, `default-raw`, `override`, `override-raw`, `filter` |

## Technical details
- All new TypeScript interfaces added (`TlsConfig`, `PprofConfig`, `ClaudeHeaderDefaults`, `AmpcodeConfig`, `PayloadConfig`, `OAuthModelAliasEntry`)
- Nested updater functions for each config group
- Nullable fields handled with `??` defaults throughout
- No new dependencies — reuses existing `Toggle`, `ConfigField`, `SectionHeader`, `Input` components
- Matching dark theme styling (slate borders, emerald toggles, etc.)