### PR TITLE
refactor: code quality overhaul — file splitting, API standardization, security fixes

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -25,7 +25,8 @@
     "react-dom": "19.2.3",
     "recharts": "^3.7.0",
     "server-only": "^0.0.1",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/dashboard/src/app/api/admin/deploy/route.ts
+++ b/dashboard/src/app/api/admin/deploy/route.ts
@@ -3,6 +3,8 @@ import { verifySession } from "@/lib/auth/session";
 import { validateOrigin } from "@/lib/auth/origin";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
+import { DeploySchema } from "@/lib/validation/schemas";
 
 const WEBHOOK_HOST = process.env.WEBHOOK_HOST || "http://localhost:9000";
 const DEPLOY_SECRET = process.env.DEPLOY_SECRET || "";
@@ -19,25 +21,23 @@ export async function POST(request: NextRequest) {
   try {
     const session = await verifySession();
     if (!session?.userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return apiError("Unauthorized", 401);
     }
 
     const originError = validateOrigin(request);
     if (originError) return originError;
 
     if (!(await isAdmin(session.userId))) {
-      return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+      return apiError("Admin access required", 403);
     }
 
     if (!DEPLOY_SECRET) {
-      return NextResponse.json(
-        { error: "DEPLOY_SECRET not configured on server" },
-        { status: 500 }
-      );
+      return apiError("DEPLOY_SECRET not configured on server", 500);
     }
 
     const body = await request.json().catch(() => ({}));
-    const noCache = body.noCache === true;
+    const parsed = DeploySchema.safeParse(body);
+    const noCache = parsed.success ? parsed.data.noCache === true : false;
     
     const endpoint = noCache ? "deploy-dashboard-nocache" : "deploy-dashboard";
     
@@ -53,43 +53,36 @@ export async function POST(request: NextRequest) {
     if (!response.ok) {
       const text = await response.text();
       logger.error({ status: response.status, response: text }, "Webhook error");
-      return NextResponse.json(
-        { error: "Failed to trigger deployment" },
-        { status: response.status }
-      );
+      return apiError("Failed to trigger deployment", response.status);
     }
 
     await response.body?.cancel();
 
-    return NextResponse.json({
-      success: true,
+    return apiSuccess({
       message: noCache ? "Full rebuild started" : "Quick update started",
     });
   } catch (error) {
     logger.error({ err: error }, "Deploy error");
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Deploy failed" },
-      { status: 500 }
-    );
+    return apiError("Deploy failed", 500);
   }
 }
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   try {
     const session = await verifySession();
     if (!session?.userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return apiError("Unauthorized", 401);
     }
 
+    const originError = validateOrigin(request);
+    if (originError) return originError;
+
     if (!(await isAdmin(session.userId))) {
-      return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+      return apiError("Admin access required", 403);
     }
 
     if (!DEPLOY_SECRET) {
-      return NextResponse.json(
-        { error: "DEPLOY_SECRET not configured" },
-        { status: 500 }
-      );
+      return apiError("DEPLOY_SECRET not configured", 500);
     }
 
     const url = new URL(request.url);
@@ -108,36 +101,30 @@ export async function GET(request: Request) {
     if (!response.ok) {
       if (response.status === 404) {
         await response.body?.cancel();
-        return NextResponse.json({
+        return apiSuccess({
           status: { status: "idle", message: "No deployment in progress" },
         });
       }
       await response.body?.cancel();
-      return NextResponse.json(
-        { error: "Failed to get deploy status" },
-        { status: response.status }
-      );
+      return apiError("Failed to get deploy status", response.status);
     }
 
     const text = await response.text();
     
     if (type === "log") {
-      return NextResponse.json({ log: text });
+      return apiSuccess({ log: text });
     }
-    
+
     try {
       const status = JSON.parse(text);
-      return NextResponse.json({ status });
+      return apiSuccess({ status });
     } catch {
-      return NextResponse.json({
+      return apiSuccess({
         status: { status: "idle", message: "No deployment in progress" },
       });
     }
   } catch (error) {
     logger.error({ err: error }, "Deploy status error");
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Failed to get status" },
-      { status: 500 }
-    );
+    return apiError("Failed to get deploy status", 500);
   }
 }

--- a/dashboard/src/app/api/admin/logs/route.ts
+++ b/dashboard/src/app/api/admin/logs/route.ts
@@ -4,11 +4,12 @@ import { validateOrigin } from "@/lib/auth/origin";
 import { prisma } from "@/lib/db";
 import { getLogs, clearLogs, getLogStats, type LogEntry } from "@/lib/log-storage";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 async function requireAdmin(): Promise<{ userId: string } | NextResponse> {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const user = await prisma.user.findUnique({
@@ -17,10 +18,7 @@ async function requireAdmin(): Promise<{ userId: string } | NextResponse> {
   });
 
   if (!user?.isAdmin) {
-    return NextResponse.json(
-      { error: "Forbidden - Admin access required" },
-      { status: 403 }
-    );
+    return apiError("Forbidden - Admin access required", 403);
   }
 
   return { userId: session.userId };
@@ -44,7 +42,7 @@ export async function GET(request: NextRequest) {
   const stats = getLogStats();
   const total = Math.max(stats.memoryCount, stats.fileCount);
 
-  return NextResponse.json({
+  return apiSuccess({
     logs,
     total,
     stats: {
@@ -71,5 +69,5 @@ export async function DELETE(request: NextRequest) {
   clearLogs();
   logger.info({ adminId: authResult.userId }, "Logs cleared by admin");
 
-  return NextResponse.json({ success: true });
+  return apiSuccess({ cleared: true });
 }

--- a/dashboard/src/app/api/admin/migrate-api-keys/route.ts
+++ b/dashboard/src/app/api/admin/migrate-api-keys/route.ts
@@ -4,6 +4,7 @@ import { validateOrigin } from "@/lib/auth/origin";
 import { prisma } from "@/lib/db";
 import { syncKeysToCliProxyApi } from "@/lib/api-keys/sync";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 /**
  * POST /api/admin/migrate-api-keys
@@ -32,7 +33,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // 1. Verify authentication
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   // 2. Verify admin status
@@ -42,10 +43,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   });
 
   if (!user?.isAdmin) {
-    return NextResponse.json(
-      { error: "Forbidden - Admin access required" },
-      { status: 403 }
-    );
+    return apiError("Forbidden - Admin access required", 403);
   }
 
   // 3. Validate origin
@@ -58,13 +56,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // 4. Check idempotency: if any UserApiKey exists, migration is already done
     const existingKeyCount = await prisma.userApiKey.count();
     if (existingKeyCount > 0) {
-      return NextResponse.json(
-        {
-          error: "Migration already completed",
-          details: `Found ${existingKeyCount} existing UserApiKey records`,
-        },
-        { status: 409 }
-      );
+      return apiError("Migration already completed", 409, `Found ${existingKeyCount} existing UserApiKey records`);
     }
 
     // 5. Fetch existing API keys from CLIProxyAPI
@@ -75,10 +67,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     if (!managementApiKey) {
       logger.error("MANAGEMENT_API_KEY not set");
-      return NextResponse.json(
-        { error: "Management API not configured" },
-        { status: 500 }
-      );
+      return apiError("Management API not configured", 500);
     }
 
     const response = await fetch(`${managementUrl}/api-keys`, {
@@ -92,10 +81,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         { status: response.status },
         "Failed to fetch existing API keys"
       );
-      return NextResponse.json(
-        { error: "Failed to fetch existing API keys from CLIProxyAPI" },
-        { status: 500 }
-      );
+      return apiError("Failed to fetch existing API keys from CLIProxyAPI", 500);
     }
 
     const data = (await response.json()) as unknown;
@@ -113,16 +99,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     });
 
     if (!firstAdmin) {
-      return NextResponse.json(
-        { error: "No admin user found in database" },
-        { status: 400 }
-      );
+      return apiError("No admin user found in database", 400);
     }
 
     // 7. If no keys to migrate, return success
     if (apiKeysArray.length === 0) {
-      return NextResponse.json({
-        success: true,
+      return apiSuccess({
         keysAssigned: 0,
         userId: firstAdmin.id,
       });
@@ -159,8 +141,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       // Don't fail the migration response - keys are in DB (source of truth)
     }
 
-    return NextResponse.json({
-      success: true,
+    return apiSuccess({
       keysAssigned: apiKeysArray.length,
       userId: firstAdmin.id,
     });
@@ -168,9 +149,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const message =
       error instanceof Error ? error.message : "Unknown error during migration";
     logger.error({ err: error, message }, "Migration error");
-    return NextResponse.json(
-      { error: "Internal server error during migration" },
-      { status: 500 }
-    );
+    return apiError("Internal server error during migration", 500);
   }
 }

--- a/dashboard/src/app/api/admin/revoke-sessions/route.ts
+++ b/dashboard/src/app/api/admin/revoke-sessions/route.ts
@@ -5,11 +5,12 @@ import { signToken } from "@/lib/auth/jwt";
 import { prisma } from "@/lib/db";
 import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 export async function POST(request: NextRequest) {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const user = await prisma.user.findUnique({
@@ -18,7 +19,7 @@ export async function POST(request: NextRequest) {
   });
 
   if (!user?.isAdmin) {
-    return NextResponse.json({ error: "Forbidden - Admin access required" }, { status: 403 });
+    return apiError("Forbidden - Admin access required", 403);
   }
 
   const originError = validateOrigin(request);
@@ -86,13 +87,12 @@ export async function POST(request: NextRequest) {
       ipAddress: extractIpAddress(request),
     });
 
-    return NextResponse.json({
-      success: true,
+    return apiSuccess({
       revokedUsers: result.revokedUsers,
       message: `Revoked sessions for ${result.revokedUsers} user(s).`,
     });
   } catch (error) {
     logger.error({ err: error, userId: user.id }, "Failed to revoke all sessions");
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    return apiError("Internal server error", 500);
   }
 }

--- a/dashboard/src/app/api/admin/settings/route.ts
+++ b/dashboard/src/app/api/admin/settings/route.ts
@@ -4,11 +4,13 @@ import { validateOrigin } from "@/lib/auth/origin";
 import { prisma } from "@/lib/db";
 import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
+import { UpdateSystemSettingSchema } from "@/lib/validation/schemas";
 
 async function requireAdmin(): Promise<{ userId: string; username: string } | NextResponse> {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const user = await prisma.user.findUnique({
@@ -17,10 +19,7 @@ async function requireAdmin(): Promise<{ userId: string; username: string } | Ne
   });
 
   if (!user?.isAdmin) {
-    return NextResponse.json(
-      { error: "Forbidden - Admin access required" },
-      { status: 403 }
-    );
+    return apiError("Forbidden - Admin access required", 403);
   }
 
   return { userId: session.userId, username: session.username };
@@ -41,13 +40,10 @@ export async function GET() {
       value: setting.value,
     }));
 
-    return NextResponse.json({ settings: settingsResponse });
+    return apiSuccess({ settings: settingsResponse });
   } catch (error) {
     logger.error({ err: error }, "Failed to fetch system settings");
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return apiError("Internal server error", 500);
   }
 }
 
@@ -64,35 +60,13 @@ export async function PUT(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { key, value } = body;
+    const parsed = UpdateSystemSettingSchema.safeParse(body);
 
-    if (!key || !value) {
-      return NextResponse.json(
-        { error: "Key and value are required" },
-        { status: 400 }
-      );
+    if (!parsed.success) {
+      return apiError("Validation failed", 400, parsed.error.issues);
     }
 
-    if (typeof key !== "string" || typeof value !== "string") {
-      return NextResponse.json(
-        { error: "Key and value must be strings" },
-        { status: 400 }
-      );
-    }
-
-    if (key.length === 0 || key.length > 255) {
-      return NextResponse.json(
-        { error: "Key must be between 1 and 255 characters" },
-        { status: 400 }
-      );
-    }
-
-    if (value.length === 0 || value.length > 1000) {
-      return NextResponse.json(
-        { error: "Value must be between 1 and 1000 characters" },
-        { status: 400 }
-      );
-    }
+    const { key, value } = parsed.data;
 
     const setting = await prisma.systemSetting.upsert({
       where: { key },
@@ -108,22 +82,15 @@ export async function PUT(request: NextRequest) {
       ipAddress: extractIpAddress(request),
     });
 
-    return NextResponse.json(
-      {
-        success: true,
-        setting: {
-          id: setting.id,
-          key: setting.key,
-          value: setting.value,
-        },
+    return apiSuccess({
+      setting: {
+        id: setting.id,
+        key: setting.key,
+        value: setting.value,
       },
-      { status: 200 }
-    );
+    });
   } catch (error) {
     logger.error({ err: error }, "Failed to update system setting");
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return apiError("Internal server error", 500);
   }
 }

--- a/dashboard/src/app/api/admin/telegram/route.ts
+++ b/dashboard/src/app/api/admin/telegram/route.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/db";
 import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
 import { Errors } from "@/lib/errors";
 import { logger } from "@/lib/logger";
+import { apiSuccess } from "@/lib/api-response";
 import {
   sendTelegramMessage,
   validateBotToken,
@@ -85,7 +86,7 @@ export async function GET() {
     const checkIntervalRaw = parseInt(settingMap.get(SETTING_KEYS.CHECK_INTERVAL) ?? "", 10);
     const cooldownRaw = parseInt(settingMap.get(SETTING_KEYS.COOLDOWN) ?? "", 10);
 
-    return NextResponse.json({
+    return apiSuccess({
       botToken: rawToken ? maskToken(rawToken) : "",
       chatId,
       threshold: Number.isNaN(threshold) ? 20 : threshold,
@@ -254,7 +255,7 @@ export async function PUT(request: NextRequest) {
       "Telegram settings updated"
     );
 
-    return NextResponse.json({ success: true });
+    return apiSuccess({ success: true });
   } catch (error) {
     return Errors.internal("update telegram settings", error);
   }
@@ -306,7 +307,7 @@ export async function POST(request: NextRequest) {
       "Telegram test message sent successfully"
     );
 
-    return NextResponse.json({ success: true });
+    return apiSuccess({ success: true });
   } catch (error) {
     return Errors.internal("send telegram test message", error);
   }

--- a/dashboard/src/app/api/admin/users/route.ts
+++ b/dashboard/src/app/api/admin/users/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/auth/validation";
 import { prisma } from "@/lib/db";
 import { Errors } from "@/lib/errors";
+import { apiSuccess } from "@/lib/api-response";
 import { cascadeDeleteUserProviders } from "@/lib/providers/cascade";
 import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
 import { logger } from "@/lib/logger";
@@ -73,7 +74,7 @@ export async function GET(request: NextRequest) {
       apiKeyCount: user._count.apiKeys,
     }));
 
-    return NextResponse.json({
+    return apiSuccess({
       data: usersResponse,
       pagination: {
         page,
@@ -165,7 +166,7 @@ export async function POST(request: NextRequest) {
       ipAddress: extractIpAddress(request),
     });
 
-    return NextResponse.json(
+    return apiSuccess(
       {
         success: true,
         user: {
@@ -175,7 +176,8 @@ export async function POST(request: NextRequest) {
           createdAt: user.createdAt.toISOString(),
         },
       },
-      { status: 201 }
+      undefined,
+      201
     );
   } catch (error) {
     return Errors.internal("User creation error", error);
@@ -240,7 +242,7 @@ export async function DELETE(request: NextRequest) {
       "Admin deleted user"
     );
 
-    return NextResponse.json({
+    return apiSuccess({
       success: true,
       username: targetUser.username,
       cascade: {

--- a/dashboard/src/app/api/agent-config/route.ts
+++ b/dashboard/src/app/api/agent-config/route.ts
@@ -15,6 +15,7 @@ import { validateFullConfig } from "@/lib/config-generators/oh-my-opencode-types
 import { z } from "zod";
 import { AgentConfigSchema, formatZodError } from "@/lib/validation/schemas";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 async function fetchManagementJson(path: string) {
   try {
@@ -82,7 +83,7 @@ export async function GET() {
   try {
     const session = await verifySession();
     if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return apiError("Unauthorized", 401);
     }
 
     const [agentOverride, managementConfig, authFilesData, modelPreference] =
@@ -114,14 +115,14 @@ export async function GET() {
     const defaults = computeDefaults(availableModels);
     const overrides = agentOverride?.overrides ? validateFullConfig(agentOverride.overrides) : {} as OhMyOpenCodeFullConfig;
 
-    return NextResponse.json({
+    return apiSuccess({
       overrides,
       availableModels,
       defaults,
     });
   } catch (error) {
     logger.error({ err: error }, "Get agent config error");
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    return apiError("Internal server error", 500);
   }
 }
 
@@ -129,7 +130,7 @@ export async function PUT(request: NextRequest) {
   try {
     const session = await verifySession();
     if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return apiError("Unauthorized", 401);
     }
 
     const originError = validateOrigin(request);
@@ -153,15 +154,14 @@ export async function PUT(request: NextRequest) {
       },
     });
 
-    return NextResponse.json({
-      success: true,
+    return apiSuccess({
       overrides: agentOverride.overrides,
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json(formatZodError(error), { status: 400 });
+      return apiError("Validation failed", 400, formatZodError(error));
     }
     logger.error({ err: error }, "Update agent config error");
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    return apiError("Internal server error", 500);
   }
 }

--- a/dashboard/src/app/api/auth/change-password/route.ts
+++ b/dashboard/src/app/api/auth/change-password/route.ts
@@ -7,6 +7,8 @@ import { prisma } from "@/lib/db";
 import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from "@/lib/auth/validation";
 import { checkRateLimitWithPreset } from "@/lib/auth/rate-limit";
 import { ERROR_CODE, Errors, apiError } from "@/lib/errors";
+import { apiSuccess } from "@/lib/api-response";
+import { ChangePasswordSchema } from "@/lib/validation/schemas";
 
 export async function POST(request: NextRequest) {
   try {
@@ -27,15 +29,13 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { currentPassword, newPassword } = body;
+    const parsed = ChangePasswordSchema.safeParse(body);
 
-    if (!currentPassword || !newPassword) {
-      return Errors.missingFields(["currentPassword", "newPassword"]);
+    if (!parsed.success) {
+      return Errors.zodValidation(parsed.error.issues);
     }
 
-    if (typeof currentPassword !== "string" || typeof newPassword !== "string") {
-      return Errors.validation("Invalid input types");
-    }
+    const { currentPassword, newPassword } = parsed.data;
 
     if (
       newPassword.length < PASSWORD_MIN_LENGTH ||
@@ -76,7 +76,7 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    return NextResponse.json({ data: { success: true } });
+    return apiSuccess({ passwordChanged: true });
   } catch (error) {
     return Errors.internal("Change password error", error);
   }

--- a/dashboard/src/app/api/auth/login/route.ts
+++ b/dashboard/src/app/api/auth/login/route.ts
@@ -14,6 +14,8 @@ import {
 import { ERROR_CODE, Errors, apiErrorWithHeaders } from "@/lib/errors";
 import { AUDIT_ACTION, logAuditAsync } from "@/lib/audit";
 import { logger } from "@/lib/logger";
+import { apiSuccess } from "@/lib/api-response";
+import { LoginSchema } from "@/lib/validation/schemas";
 
 const LOGIN_ATTEMPTS_LIMIT = 10;
 const LOGIN_WINDOW_MS = 15 * 60 * 1000;
@@ -41,15 +43,13 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { username, password } = body;
+    const parsed = LoginSchema.safeParse(body);
 
-    if (!username || !password) {
-      return Errors.missingFields(["username", "password"]);
+    if (!parsed.success) {
+      return Errors.zodValidation(parsed.error.issues);
     }
 
-    if (typeof username !== "string" || typeof password !== "string") {
-      return Errors.validation("Invalid input types");
-    }
+    const { username, password } = parsed.data;
 
     if (
       username.length < USERNAME_MIN_LENGTH ||
@@ -98,8 +98,7 @@ export async function POST(request: NextRequest) {
       ipAddress: ipAddress,
     });
 
-    return NextResponse.json({
-      success: true,
+    return apiSuccess({
       user: {
         id: user.id,
         username: user.username,

--- a/dashboard/src/app/api/auth/logout/route.ts
+++ b/dashboard/src/app/api/auth/logout/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { deleteSession, verifySession } from "@/lib/auth/session";
 import { validateOrigin } from "@/lib/auth/origin";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 export async function POST(request: NextRequest) {
   const originError = validateOrigin(request);
@@ -21,12 +22,9 @@ export async function POST(request: NextRequest) {
       logger.info({ userId: session.userId, username: session.username, ip }, "User logged out");
     }
 
-    return NextResponse.json({ success: true });
+    return apiSuccess({ loggedOut: true });
   } catch (error) {
     logger.error({ err: error }, "Logout error");
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return apiError("Internal server error", 500);
   }
 }

--- a/dashboard/src/app/api/auth/me/route.ts
+++ b/dashboard/src/app/api/auth/me/route.ts
@@ -2,13 +2,14 @@ import { NextResponse } from "next/server";
 import { verifySession } from "@/lib/auth/session";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 export async function GET() {
   try {
     const session = await verifySession();
     
     if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return apiError("Unauthorized", 401);
     }
 
     const user = await prisma.user.findUnique({
@@ -22,10 +23,10 @@ export async function GET() {
     });
 
     if (!user) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
+      return apiError("User not found", 404);
     }
 
-    return NextResponse.json({
+    return apiSuccess({
       id: user.id,
       username: user.username,
       isAdmin: user.isAdmin,
@@ -33,9 +34,6 @@ export async function GET() {
     });
   } catch (error) {
     logger.error({ err: error }, "Failed to fetch current user");
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return apiError("Internal server error", 500);
   }
 }

--- a/dashboard/src/app/api/config-sharing/publish/route.ts
+++ b/dashboard/src/app/api/config-sharing/publish/route.ts
@@ -5,6 +5,7 @@ import { checkRateLimitWithPreset } from "@/lib/auth/rate-limit";
 import { generateShareCode } from "@/lib/share-code";
 import { Errors } from "@/lib/errors";
 import { prisma } from "@/lib/db";
+import { apiSuccess } from "@/lib/api-response";
 
 interface PublishResponse {
   id: string;
@@ -78,7 +79,7 @@ export async function GET() {
       updatedAt: template.updatedAt.toISOString(),
     };
 
-    return NextResponse.json(response);
+    return apiSuccess(response);
   } catch (error) {
     return Errors.internal("Failed to fetch config template", error);
   }
@@ -141,7 +142,7 @@ export async function POST(request: NextRequest) {
       updatedAt: template.updatedAt.toISOString(),
     };
 
-    return NextResponse.json(response, { status: 201 });
+    return apiSuccess(response, undefined, 201);
   } catch (error) {
     return Errors.internal("Failed to create config template", error);
   }
@@ -203,7 +204,7 @@ export async function PATCH(request: NextRequest) {
       updatedAt: template.updatedAt.toISOString(),
     };
 
-    return NextResponse.json(response);
+    return apiSuccess(response);
   } catch (error) {
     return Errors.internal("Failed to update config template", error);
   }
@@ -233,7 +234,7 @@ export async function DELETE(request: NextRequest) {
       where: { userId: session.userId },
     });
 
-    return NextResponse.json({ success: true });
+    return apiSuccess({ success: true });
   } catch (error) {
     return Errors.internal("Failed to delete config template", error);
   }

--- a/dashboard/src/app/api/config-sharing/subscribe/route.ts
+++ b/dashboard/src/app/api/config-sharing/subscribe/route.ts
@@ -5,6 +5,7 @@ import { checkRateLimitWithPreset } from "@/lib/auth/rate-limit";
 import { normalizeShareCode } from "@/lib/share-code";
 import { Errors } from "@/lib/errors";
 import { prisma } from "@/lib/db";
+import { apiSuccess } from "@/lib/api-response";
 
 interface SubscriptionResponse {
   templateName: string;
@@ -67,7 +68,7 @@ export async function GET() {
     });
 
     if (!subscription) {
-      return NextResponse.json(null);
+      return apiSuccess(null);
     }
 
     const response: SubscriptionResponse = {
@@ -79,7 +80,7 @@ export async function GET() {
       lastSyncedAt: subscription.lastSyncedAt?.toISOString() || null,
     };
 
-    return NextResponse.json(response);
+    return apiSuccess(response);
   } catch (error) {
     return Errors.internal("Failed to fetch subscription", error);
   }
@@ -200,7 +201,7 @@ export async function POST(request: NextRequest) {
       lastSyncedAt: subscription.lastSyncedAt?.toISOString() || null,
     };
 
-    return NextResponse.json(response, { status: 201 });
+    return apiSuccess(response, undefined, 201);
   } catch (error) {
     return Errors.internal("Failed to create subscription", error);
   }
@@ -260,7 +261,7 @@ export async function PATCH(request: NextRequest) {
       lastSyncedAt: subscription.lastSyncedAt?.toISOString() || null,
     };
 
-    return NextResponse.json(response);
+    return apiSuccess(response);
   } catch (error) {
     return Errors.internal("Failed to update subscription", error);
   }
@@ -290,7 +291,7 @@ export async function DELETE(request: NextRequest) {
       where: { userId: session.userId },
     });
 
-    return NextResponse.json({ success: true });
+    return apiSuccess({ success: true });
   } catch (error) {
     return Errors.internal("Failed to delete subscription", error);
   }

--- a/dashboard/src/app/api/config-sync/bundle/route.ts
+++ b/dashboard/src/app/api/config-sync/bundle/route.ts
@@ -3,13 +3,14 @@ import { validateSyncTokenFromHeader } from "@/lib/auth/sync-token";
 import { generateConfigBundle } from "@/lib/config-sync/generate-bundle";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 export async function GET(request: NextRequest) {
   const authResult = await validateSyncTokenFromHeader(request);
 
   if (!authResult.ok) {
     const errorMessage = authResult.reason === "expired" ? "Sync token expired" : "Unauthorized";
-    return NextResponse.json({ error: errorMessage }, { status: 401 });
+    return apiError(errorMessage, 401);
   }
 
   try {
@@ -23,7 +24,7 @@ export async function GET(request: NextRequest) {
       data: { lastSyncedAt: new Date() },
     });
 
-    return NextResponse.json({
+    return apiSuccess({
       version: bundle.version,
       opencode: bundle.opencode,
       ohMyOpencode: bundle.ohMyOpencode,
@@ -32,9 +33,6 @@ export async function GET(request: NextRequest) {
     logger.error({ err: error }, "Config sync bundle error");
     const isSyncTokenError =
       error instanceof Error && error.message.includes("sync token");
-    return NextResponse.json(
-      { error: isSyncTokenError ? error.message : "Internal server error" },
-      { status: isSyncTokenError ? 400 : 500 }
-    );
+    return apiError(isSyncTokenError ? error.message : "Internal server error", isSyncTokenError ? 400 : 500);
   }
 }

--- a/dashboard/src/app/api/config-sync/tokens/[id]/route.ts
+++ b/dashboard/src/app/api/config-sync/tokens/[id]/route.ts
@@ -3,6 +3,7 @@ import { verifySession } from "@/lib/auth/session";
 import { validateOrigin } from "@/lib/auth/origin";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 export async function PATCH(
   request: NextRequest,
@@ -10,7 +11,7 @@ export async function PATCH(
 ) {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const originError = validateOrigin(request);
@@ -30,11 +31,11 @@ export async function PATCH(
     });
 
     if (!existingToken) {
-      return NextResponse.json({ error: "Token not found" }, { status: 404 });
+      return apiError("Token not found", 404);
     }
 
     if (existingToken.userId !== session.userId) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      return apiError("Forbidden", 403);
     }
 
     if (syncApiKeyId) {
@@ -44,7 +45,7 @@ export async function PATCH(
       });
 
       if (!ownedKey) {
-        return NextResponse.json({ error: "API key not found or not owned by you" }, { status: 403 });
+        return apiError("API key not found or not owned by you", 403);
       }
     }
 
@@ -53,13 +54,10 @@ export async function PATCH(
       data: { syncApiKey: syncApiKeyId },
     });
 
-    return NextResponse.json({ success: true });
+    return apiSuccess({ success: true });
   } catch (error) {
     logger.error({ err: error }, "Failed to update sync token");
-    return NextResponse.json(
-      { error: "Failed to update token" },
-      { status: 500 }
-    );
+    return apiError("Failed to update token", 500);
   }
 }
 
@@ -69,7 +67,7 @@ export async function DELETE(
 ) {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const originError = validateOrigin(request);
@@ -86,11 +84,11 @@ export async function DELETE(
     });
 
     if (!existingToken) {
-      return NextResponse.json({ error: "Token not found" }, { status: 404 });
+      return apiError("Token not found", 404);
     }
 
     if (existingToken.userId !== session.userId) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      return apiError("Forbidden", 403);
     }
 
     await prisma.syncToken.update({
@@ -98,12 +96,9 @@ export async function DELETE(
       data: { revokedAt: new Date() },
     });
 
-    return NextResponse.json({ success: true });
+    return apiSuccess({ success: true });
   } catch (error) {
     logger.error({ err: error }, "Failed to revoke sync token");
-    return NextResponse.json(
-      { error: "Failed to revoke token" },
-      { status: 500 }
-    );
+    return apiError("Failed to revoke token", 500);
   }
 }

--- a/dashboard/src/app/api/config-sync/tokens/route.ts
+++ b/dashboard/src/app/api/config-sync/tokens/route.ts
@@ -5,22 +5,17 @@ import { generateSyncToken } from "@/lib/auth/sync-token";
 import { prisma } from "@/lib/db";
 import { checkRateLimitWithPreset } from "@/lib/auth/rate-limit";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 export async function POST(request: NextRequest) {
   const rateLimit = checkRateLimitWithPreset(request, "config-sync-tokens", "CONFIG_SYNC_TOKENS");
   if (!rateLimit.allowed) {
-    return NextResponse.json(
-      { error: "Too many token creation requests. Try again later." },
-      {
-        status: 429,
-        headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
-      }
-    );
+    return apiError("Too many token creation requests. Try again later.", 429);
   }
 
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const originError = validateOrigin(request);
@@ -39,10 +34,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (!userApiKey) {
-      return NextResponse.json(
-        { error: "User API key not found. Please create an API key first." },
-        { status: 400 }
-      );
+      return apiError("User API key not found. Please create an API key first.", 400);
     }
 
     const syncToken = await prisma.syncToken.create({
@@ -54,7 +46,7 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    return NextResponse.json({
+    return apiSuccess({
       id: syncToken.id,
       token,
       name: syncToken.name,
@@ -63,17 +55,14 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     logger.error({ err: error }, "Failed to create sync token");
-    return NextResponse.json(
-      { error: "Failed to create token" },
-      { status: 500 }
-    );
+    return apiError("Failed to create token", 500);
   }
 }
 
 export async function GET() {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   try {
@@ -119,12 +108,9 @@ export async function GET() {
       orderBy: { createdAt: "asc" },
     });
 
-    return NextResponse.json({ tokens, apiKeys: allUserKeys });
+    return apiSuccess({ tokens, apiKeys: allUserKeys });
   } catch (error) {
     logger.error({ err: error }, "Failed to fetch sync tokens");
-    return NextResponse.json(
-      { error: "Failed to fetch tokens" },
-      { status: 500 }
-    );
+    return apiError("Failed to fetch tokens", 500);
   }
 }

--- a/dashboard/src/app/api/config-sync/version/route.ts
+++ b/dashboard/src/app/api/config-sync/version/route.ts
@@ -2,24 +2,22 @@ import { NextRequest, NextResponse } from "next/server";
 import { validateSyncTokenFromHeader } from "@/lib/auth/sync-token";
 import { generateConfigBundle } from "@/lib/config-sync/generate-bundle";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 export async function GET(request: NextRequest) {
   const authResult = await validateSyncTokenFromHeader(request);
 
   if (!authResult.ok) {
     const errorMessage = authResult.reason === "expired" ? "Sync token expired" : "Unauthorized";
-    return NextResponse.json({ error: errorMessage }, { status: 401 });
+    return apiError(errorMessage, 401);
   }
 
   try {
     const bundle = await generateConfigBundle(authResult.userId);
 
-    return NextResponse.json({ version: bundle.version });
+    return apiSuccess({ version: bundle.version });
   } catch (error) {
     logger.error({ err: error }, "Config sync version error");
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return apiError("Internal server error", 500);
   }
 }

--- a/dashboard/src/app/api/containers/[name]/action/route.ts
+++ b/dashboard/src/app/api/containers/[name]/action/route.ts
@@ -8,6 +8,7 @@ import { promisify } from "util";
 import { z } from "zod";
 import { ContainerActionSchema, formatZodError } from "@/lib/validation/schemas";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const execFileAsync = promisify(execFile);
 
@@ -20,10 +21,7 @@ export async function POST(
   const session = await verifySession();
 
   if (!session) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 }
-    );
+    return apiError("Unauthorized", 401);
   }
 
   const user = await prisma.user.findUnique({
@@ -32,10 +30,7 @@ export async function POST(
   });
 
   if (!user?.isAdmin) {
-    return NextResponse.json(
-      { error: "Forbidden: Admin access required" },
-      { status: 403 }
-    );
+    return apiError("Forbidden: Admin access required", 403);
   }
 
   const originError = validateOrigin(request);
@@ -46,10 +41,7 @@ export async function POST(
   const { name } = await params;
 
   if (!isValidContainerName(name)) {
-    return NextResponse.json(
-      { error: "Invalid or unrecognized container name" },
-      { status: 400 }
-    );
+    return apiError("Invalid or unrecognized container name", 400);
   }
 
   try {
@@ -65,27 +57,20 @@ export async function POST(
       | "allowRestart";
 
     if (!config[permissionKey]) {
-      return NextResponse.json(
-        { error: `Action '${typedAction}' is not allowed on container '${config.displayName}'` },
-        { status: 403 }
-      );
+      return apiError(`Action '${typedAction}' is not allowed on container '${config.displayName}'`, 403);
     }
 
     await execFileAsync("docker", [typedAction, name]);
 
-    return NextResponse.json({
-      success: true,
+    return apiSuccess({
       message: `Container '${config.displayName}' ${typedAction} completed`,
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json(formatZodError(error), { status: 400 });
+      return apiError("Validation failed", 400, formatZodError(error));
     }
     logger.error({ err: error, containerName: name }, "Container action error");
     const message = error instanceof Error ? error.message : "Unknown error";
-    return NextResponse.json(
-      { error: `Failed to perform action: ${message}` },
-      { status: 500 }
-    );
+    return apiError(`Failed to perform action: ${message}`, 500);
   }
 }

--- a/dashboard/src/app/api/containers/[name]/logs/route.ts
+++ b/dashboard/src/app/api/containers/[name]/logs/route.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/db";
 import { CONTAINER_CONFIG, isValidContainerName } from "@/lib/containers";
 import { execFile } from "child_process";
 import { promisify } from "util";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const execFileAsync = promisify(execFile);
 
@@ -18,10 +19,7 @@ export async function GET(
   const session = await verifySession();
 
   if (!session) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 }
-    );
+    return apiError("Unauthorized", 401);
   }
 
   const user = await prisma.user.findUnique({
@@ -30,19 +28,13 @@ export async function GET(
   });
 
   if (!user?.isAdmin) {
-    return NextResponse.json(
-      { error: "Forbidden: Admin access required" },
-      { status: 403 }
-    );
+    return apiError("Forbidden: Admin access required", 403);
   }
 
   const { name } = await params;
 
   if (!isValidContainerName(name)) {
-    return NextResponse.json(
-      { error: "Invalid or unrecognized container name" },
-      { status: 400 }
-    );
+    return apiError("Invalid or unrecognized container name", 400);
   }
 
   const linesParam = request.nextUrl.searchParams.get("lines");
@@ -51,10 +43,7 @@ export async function GET(
   if (linesParam !== null) {
     const parsed = parseInt(linesParam, 10);
     if (isNaN(parsed) || parsed < 1) {
-      return NextResponse.json(
-        { error: "Parameter 'lines' must be a positive integer" },
-        { status: 400 }
-      );
+      return apiError("Parameter 'lines' must be a positive integer", 400);
     }
     lines = Math.min(parsed, MAX_LINES);
   }
@@ -75,15 +64,12 @@ export async function GET(
     const logLines = allOutput ? allOutput.split("\n") : [];
     const config = CONTAINER_CONFIG[name];
 
-    return NextResponse.json({
+    return apiSuccess({
       lines: logLines,
       containerName: config.displayName,
     });
   } catch (error) {
     logger.error({ err: error, containerName: name }, "Container logs error");
-    return NextResponse.json(
-      { error: "Failed to fetch container logs" },
-      { status: 500 }
-    );
+    return apiError("Failed to fetch container logs", 500);
   }
 }

--- a/dashboard/src/app/api/containers/list/route.ts
+++ b/dashboard/src/app/api/containers/list/route.ts
@@ -5,6 +5,7 @@ import { CONTAINER_CONFIG, getAllowedActions, type ContainerAction } from "@/lib
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const execFileAsync = promisify(execFile);
 const DOCKER_COMMAND_TIMEOUT_MS = 8000;
@@ -33,10 +34,7 @@ export async function GET() {
   const session = await verifySession();
 
   if (!session) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 }
-    );
+    return apiError("Unauthorized", 401);
   }
 
   const user = await prisma.user.findUnique({
@@ -45,10 +43,7 @@ export async function GET() {
   });
 
   if (!user?.isAdmin) {
-    return NextResponse.json(
-      { error: "Forbidden: Admin access required" },
-      { status: 403 }
-    );
+    return apiError("Forbidden: Admin access required", 403);
   }
 
   try {
@@ -127,12 +122,9 @@ export async function GET() {
 
     const containers = results.filter((c): c is ContainerInfo => c !== null);
 
-    return NextResponse.json(containers);
+    return apiSuccess(containers);
   } catch (error) {
     logger.error({ err: error }, "Container list error");
-    return NextResponse.json(
-      { error: "Failed to list containers" },
-      { status: 500 }
-    );
+    return apiError("Failed to list containers", 500);
   }
 }

--- a/dashboard/src/app/api/custom-providers/[id]/route.ts
+++ b/dashboard/src/app/api/custom-providers/[id]/route.ts
@@ -9,6 +9,7 @@ import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
 import { env } from "@/lib/env";
 import { logger } from "@/lib/logger";
 import { syncCustomProviderToProxy } from "@/lib/providers/custom-provider-sync";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const FETCH_TIMEOUT_MS = 10_000;
 
@@ -58,7 +59,7 @@ export async function PATCH(
   const { id } = await params;
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const originError = validateOrigin(request);
@@ -74,11 +75,11 @@ export async function PATCH(
     });
 
     if (!existingProvider) {
-      return NextResponse.json({ error: "Provider not found" }, { status: 404 });
+      return apiError("Provider not found", 404);
     }
 
     if (existingProvider.userId !== session.userId) {
-      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+      return apiError("Access denied", 403);
     }
 
     if (validated.name) {
@@ -91,7 +92,7 @@ export async function PATCH(
       });
 
       if (nameConflict) {
-        return NextResponse.json({ error: "Provider name already exists" }, { status: 409 });
+        return apiError("Provider name already exists", 409);
       }
     }
 
@@ -101,7 +102,7 @@ export async function PATCH(
         select: { id: true },
       });
       if (!groupExists) {
-        return NextResponse.json({ error: "Provider group not found" }, { status: 404 });
+        return apiError("Provider group not found", 404);
       }
     }
 
@@ -219,14 +220,14 @@ export async function PATCH(
       ipAddress: extractIpAddress(request),
     });
 
-    return NextResponse.json({ provider, syncStatus, syncMessage });
+    return apiSuccess({ provider, syncStatus, syncMessage });
 
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: error.issues }, { status: 400 });
+      return apiError("Validation failed", 400, error.issues);
     }
     logger.error({ err: error }, "PATCH /api/custom-providers/[id] error");
-    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    return apiError("Internal Server Error", 500);
   }
 }
 
@@ -237,7 +238,7 @@ export async function DELETE(
   const { id } = await params;
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const originError = validateOrigin(request);
@@ -249,11 +250,11 @@ export async function DELETE(
     });
 
     if (!existingProvider) {
-      return NextResponse.json({ error: "Provider not found" }, { status: 404 });
+      return apiError("Provider not found", 404);
     }
 
     if (existingProvider.userId !== session.userId) {
-      return NextResponse.json({ error: "Access denied" }, { status: 403 });
+      return apiError("Access denied", 403);
     }
 
     await prisma.customProvider.delete({
@@ -325,10 +326,10 @@ export async function DELETE(
       syncMessage = "Backend sync unavailable - management API key not configured";
     }
 
-    return NextResponse.json({ success: true, syncStatus, syncMessage });
+    return apiSuccess({ syncStatus, syncMessage });
 
   } catch (error) {
     logger.error({ err: error }, "DELETE /api/custom-providers/[id] error");
-    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    return apiError("Internal Server Error", 500);
   }
 }

--- a/dashboard/src/app/api/custom-providers/fetch-models/route.ts
+++ b/dashboard/src/app/api/custom-providers/fetch-models/route.ts
@@ -6,6 +6,7 @@ import { checkRateLimitWithPreset } from "@/lib/auth/rate-limit";
 import { logger } from "@/lib/logger";
 import { FetchModelsSchema } from "@/lib/validation/schemas";
 import { lookup } from "dns/promises";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 interface OpenAIModel {
   id: string;
@@ -110,18 +111,12 @@ function isPrivateResolvedIP(ip: string): boolean {
 export async function POST(request: NextRequest) {
   const rateLimit = checkRateLimitWithPreset(request, "custom-providers-fetch-models", "CUSTOM_PROVIDERS");
   if (!rateLimit.allowed) {
-    return NextResponse.json(
-      { error: "Too many fetch requests. Try again later." },
-      {
-        status: 429,
-        headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
-      }
-    );
+    return apiError("Too many fetch requests. Try again later.", 429);
   }
 
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const originError = validateOrigin(request);
@@ -138,15 +133,12 @@ export async function POST(request: NextRequest) {
     try {
       parsedUrl = new URL(`${normalizedBaseUrl}/models`);
     } catch {
-      return NextResponse.json({ error: "Invalid URL" }, { status: 400 });
+      return apiError("Invalid URL", 400);
     }
 
     if (isPrivateHost(parsedUrl.hostname)) {
       logger.warn({ hostname: parsedUrl.hostname }, "Blocked SSRF attempt to private host");
-      return NextResponse.json(
-        { error: "Cannot connect to private or localhost addresses" },
-        { status: 400 }
-      );
+      return apiError("Cannot connect to private or localhost addresses", 400);
     }
 
     // DNS rebinding protection: resolve hostname and verify the IP is not private.
@@ -162,17 +154,11 @@ export async function POST(request: NextRequest) {
             { hostname: parsedUrl.hostname, resolvedIp: resolved.address },
             "Blocked SSRF: hostname resolved to private IP (possible DNS rebinding)"
           );
-          return NextResponse.json(
-            { error: "Cannot connect to private or localhost addresses" },
-            { status: 400 }
-          );
+          return apiError("Cannot connect to private or localhost addresses", 400);
         }
       } catch (dnsError) {
         logger.warn({ hostname: parsedUrl.hostname, err: dnsError }, "DNS resolution failed for provider URL");
-        return NextResponse.json(
-          { error: "Could not resolve hostname" },
-          { status: 400 }
-        );
+        return apiError("Could not resolve hostname", 400);
       }
     }
 
@@ -198,22 +184,13 @@ export async function POST(request: NextRequest) {
       if (!response.ok) {
         await response.body?.cancel();
         if (response.status === 401 || response.status === 403) {
-          return NextResponse.json(
-            { error: "Authentication failed. Check your API key." },
-            { status: 401 }
-          );
+          return apiError("Authentication failed. Check your API key.", 401);
         }
         if (response.status === 404) {
-          return NextResponse.json(
-            { error: "Models endpoint not found. This may not be an OpenAI-compatible API." },
-            { status: 404 }
-          );
+          return apiError("Models endpoint not found. This may not be an OpenAI-compatible API.", 404);
         }
         logger.error({ status: response.status, url: modelsEndpoint }, "Failed to fetch models from provider");
-        return NextResponse.json(
-          { error: `Failed to fetch models (HTTP ${response.status})` },
-          { status: response.status }
-        );
+        return apiError(`Failed to fetch models (HTTP ${response.status})`, response.status);
       }
 
       const responseData: OpenAIModelsResponse = await response.json();
@@ -223,17 +200,11 @@ export async function POST(request: NextRequest) {
 
       if (!Array.isArray(modelList)) {
         logger.error({ responseData }, "Invalid models response format");
-        return NextResponse.json(
-          { error: "Invalid response format from provider" },
-          { status: 500 }
-        );
+        return apiError("Invalid response format from provider", 500);
       }
 
       if (modelList.length === 0) {
-        return NextResponse.json(
-          { error: "No models found from this provider" },
-          { status: 404 }
-        );
+        return apiError("No models found from this provider", 404);
       }
 
       const models = modelList.map(model => ({
@@ -241,7 +212,7 @@ export async function POST(request: NextRequest) {
         name: model.id
       }));
 
-      return NextResponse.json({ models });
+      return apiSuccess({ models });
 
     } catch (fetchError) {
       clearTimeout(timeoutId);
@@ -249,31 +220,22 @@ export async function POST(request: NextRequest) {
       if (fetchError instanceof Error) {
         if (fetchError.name === "AbortError") {
           logger.error({ url: modelsEndpoint }, "Fetch models request timed out");
-          return NextResponse.json(
-            { error: "Request timed out. The provider may be unreachable." },
-            { status: 504 }
-          );
+          return apiError("Request timed out. The provider may be unreachable.", 504);
         }
         
         logger.error({ err: fetchError, url: modelsEndpoint }, "Failed to fetch models from provider");
-        return NextResponse.json(
-          { error: "Network error: unable to reach the provider" },
-          { status: 503 }
-        );
+        return apiError("Network error: unable to reach the provider", 503);
       }
 
       logger.error({ err: fetchError }, "Unknown error fetching models");
-      return NextResponse.json(
-        { error: "Failed to fetch models from provider" },
-        { status: 500 }
-      );
+      return apiError("Failed to fetch models from provider", 500);
     }
 
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: error.issues }, { status: 400 });
+      return apiError("Validation failed", 400, error.issues);
     }
     logger.error({ err: error }, "POST /api/custom-providers/fetch-models error");
-    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    return apiError("Internal Server Error", 500);
   }
 }

--- a/dashboard/src/app/api/custom-providers/reorder/route.ts
+++ b/dashboard/src/app/api/custom-providers/reorder/route.ts
@@ -9,6 +9,7 @@ import { env } from "@/lib/env";
 import { invalidateProxyModelsCache } from "@/lib/cache";
 import { logger } from "@/lib/logger";
 import { z } from "zod";
+import { apiSuccess } from "@/lib/api-response";
 
 const FETCH_TIMEOUT_MS = 10_000;
 
@@ -152,7 +153,7 @@ export async function PUT(request: NextRequest) {
       ipAddress: extractIpAddress(request),
     });
 
-    return NextResponse.json({ success: true, syncStatus });
+    return apiSuccess({ syncStatus });
   } catch (error) {
     if (error instanceof z.ZodError) {
       return Errors.zodValidation(error.issues);

--- a/dashboard/src/app/api/custom-providers/route.ts
+++ b/dashboard/src/app/api/custom-providers/route.ts
@@ -9,11 +9,12 @@ import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
 import { logger } from "@/lib/logger";
 import { syncCustomProviderToProxy } from "@/lib/providers/custom-provider-sync";
 import { CreateCustomProviderSchema } from "@/lib/validation/schemas";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 export async function GET() {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   try {
@@ -26,7 +27,7 @@ export async function GET() {
       orderBy: { sortOrder: "asc" }
     });
 
-    return NextResponse.json({
+    return apiSuccess({
       providers: providers.map(p => ({
         id: p.id,
         name: p.name,
@@ -45,25 +46,19 @@ export async function GET() {
     });
   } catch (error) {
     logger.error({ err: error }, "GET /api/custom-providers error");
-    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    return apiError("Internal Server Error", 500);
   }
 }
 
 export async function POST(request: NextRequest) {
   const rateLimit = checkRateLimitWithPreset(request, "custom-providers", "CUSTOM_PROVIDERS");
   if (!rateLimit.allowed) {
-    return NextResponse.json(
-      { error: "Too many custom provider creation requests. Try again later." },
-      {
-        status: 429,
-        headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
-      }
-    );
+    return apiError("Too many custom provider creation requests. Try again later.", 429);
   }
 
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const originError = validateOrigin(request);
@@ -81,7 +76,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (existingName) {
-      return NextResponse.json({ error: "Provider name already exists" }, { status: 409 });
+      return apiError("Provider name already exists", 409);
     }
 
     const existingId = await prisma.customProvider.findUnique({
@@ -89,7 +84,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (existingId) {
-      return NextResponse.json({ error: "Provider ID already taken" }, { status: 409 });
+      return apiError("Provider ID already taken", 409);
     }
 
     const provider = await prisma.customProvider.create({
@@ -142,13 +137,13 @@ export async function POST(request: NextRequest) {
       excludedModels: provider.excludedModels
     }, "create");
 
-    return NextResponse.json({ provider, syncStatus, syncMessage }, { status: 201 });
+    return apiSuccess({ provider, syncStatus, syncMessage }, undefined, 201);
 
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: error.issues }, { status: 400 });
+      return apiError("Validation failed", 400, error.issues);
     }
     logger.error({ err: error }, "POST /api/custom-providers error");
-    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    return apiError("Internal Server Error", 500);
   }
 }

--- a/dashboard/src/app/api/health/route.ts
+++ b/dashboard/src/app/api/health/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { env } from "@/lib/env";
+import { apiSuccess } from "@/lib/api-response";
 
 const HEALTH_CHECK_TIMEOUT_MS = 5000;
 
@@ -59,5 +60,5 @@ export async function GET() {
 
   const statusCode = healthStatus.status === "ok" ? 200 : 503;
 
-  return NextResponse.json(healthStatus, { status: statusCode });
+  return apiSuccess(healthStatus, undefined, statusCode);
 }

--- a/dashboard/src/app/api/management/[...path]/route.ts
+++ b/dashboard/src/app/api/management/[...path]/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/db";
 import { env } from "@/lib/env";
 import { logger } from "@/lib/logger";
 import { fetchWithRetry } from "@/lib/fetch-utils";
+import { apiError } from "@/lib/api-response";
 
 const BACKEND_API_URL = env.CLIPROXYAPI_MANAGEMENT_URL;
 const MANAGEMENT_API_KEY = env.MANAGEMENT_API_KEY;
@@ -121,10 +122,7 @@ async function proxyRequest(
   const session = await verifySession();
 
   if (!session) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 }
-    );
+    return apiError("Unauthorized", 401);
   }
 
   // CSRF protection: validate Origin header on mutating methods
@@ -143,32 +141,20 @@ async function proxyRequest(
   const normalizedPath = normalizeAndValidateManagementPath(rawPath);
   if (!normalizedPath) {
     logger.warn({ method, rawPath, userId: session.userId }, "Blocked invalid management proxy path");
-    return NextResponse.json(
-      { error: "Invalid request path" },
-      { status: 400 }
-    );
+    return apiError("Invalid request path", 400);
   }
 
   if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 }
-    );
+    return apiError("Unauthorized", 401);
   }
 
   if (!user.isAdmin && !isNonAdminAllowedManagementRequest(method, normalizedPath)) {
-    return NextResponse.json(
-      { error: "Forbidden: Admin access required" },
-      { status: 403 }
-    );
+    return apiError("Forbidden: Admin access required", 403);
   }
 
   if (!MANAGEMENT_API_KEY) {
     logger.error("MANAGEMENT_API_KEY is not configured");
-    return NextResponse.json(
-      { error: "Server configuration error" },
-      { status: 500 }
-    );
+    return apiError("Server configuration error", 500);
   }
 
   const incomingUrl = new URL(request.url);
@@ -182,18 +168,12 @@ async function proxyRequest(
     parsedUrl = new URL(targetUrl.toString());
   } catch {
     logger.error({ targetUrl: targetUrl.toString() }, "Invalid target URL");
-    return NextResponse.json(
-      { error: "Invalid request path" },
-      { status: 400 }
-    );
+    return apiError("Invalid request path", 400);
   }
 
   if (parsedUrl.host !== ALLOWED_HOST) {
     logger.error({ attemptedHost: parsedUrl.host, allowedHost: ALLOWED_HOST }, "SSRF attempt blocked");
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403 }
-    );
+    return apiError("Forbidden", 403);
   }
 
   try {
@@ -202,10 +182,7 @@ async function proxyRequest(
     if (contentLength) {
       const parsedLength = parseInt(contentLength, 10);
       if (Number.isNaN(parsedLength) || parsedLength > MAX_BODY_SIZE) {
-        return NextResponse.json(
-          { error: "Payload too large" },
-          { status: 413 }
-        );
+        return apiError("Payload too large", 413);
       }
     }
 
@@ -224,10 +201,7 @@ async function proxyRequest(
       if (rawBody) {
         const byteLength = new TextEncoder().encode(rawBody).length;
         if (byteLength > MAX_BODY_SIZE) {
-          return NextResponse.json(
-            { error: "Payload too large" },
-            { status: 413 }
-          );
+          return apiError("Payload too large", 413);
         }
         body = rawBody;
       }
@@ -246,10 +220,7 @@ async function proxyRequest(
     } catch (error) {
       if (error instanceof Error && error.name === "AbortError") {
         logger.error({ err: error, path: normalizedPath, timeoutMs: FETCH_TIMEOUT_MS }, "Proxy request timeout");
-        return NextResponse.json(
-          { error: "Request timeout" },
-          { status: 504 }
-        );
+        return apiError("Request timeout", 504);
       }
       throw error;
     }
@@ -261,10 +232,7 @@ async function proxyRequest(
       if (!Number.isNaN(parsedLength) && parsedLength > RESPONSE_SIZE_LIMIT_BYTES) {
         logger.warn({ path: normalizedPath, method, contentLength: parsedLength }, "Proxy response too large");
         await response.body?.cancel();
-        return NextResponse.json(
-          { error: "Response too large" },
-          { status: 502 }
-        );
+        return apiError("Response too large", 502);
       }
     }
 
@@ -272,10 +240,7 @@ async function proxyRequest(
     const responseSize = new TextEncoder().encode(responseData).length;
     if (responseSize > RESPONSE_SIZE_LIMIT_BYTES) {
       logger.warn({ path: normalizedPath, method, responseSize }, "Proxy response exceeded size budget");
-      return NextResponse.json(
-        { error: "Response too large" },
-        { status: 502 }
-      );
+      return apiError("Response too large", 502);
     }
 
     logger.info(
@@ -298,10 +263,7 @@ async function proxyRequest(
     });
   } catch (error) {
     logger.error({ err: error, method, path: rawPath, userId: session.userId, durationMs: Date.now() - startedAt }, "Proxy request error");
-    return NextResponse.json(
-      { error: "Failed to proxy request" },
-      { status: 502 }
-    );
+    return apiError("Failed to proxy request", 502);
   }
 }
 

--- a/dashboard/src/app/api/management/oauth-callback/route.ts
+++ b/dashboard/src/app/api/management/oauth-callback/route.ts
@@ -4,6 +4,7 @@ import { validateOrigin } from "@/lib/auth/origin";
 import { checkRateLimitWithPreset } from "@/lib/auth/rate-limit";
 import { Errors } from "@/lib/errors";
 import { prisma } from "@/lib/db";
+import { apiSuccess } from "@/lib/api-response";
 import { Prisma } from "@/generated/prisma/client";
 import { logger } from "@/lib/logger";
 
@@ -205,7 +206,7 @@ export async function POST(request: NextRequest) {
       if (!response.ok) {
         await response.body?.cancel();
         const payload: OAuthCallbackResponse = { status: responseStatus };
-        return NextResponse.json(payload, { status: responseStatus });
+        return apiSuccess(payload, undefined, responseStatus);
       }
     } else if (!resolvedState) {
       return Errors.validation("State is required for this provider");
@@ -249,7 +250,7 @@ export async function POST(request: NextRequest) {
         { provider, state: resolvedState || null },
         "OAuth callback: auth file not yet available, client should retry"
       );
-      return NextResponse.json({ status: 202 }, { status: 202 });
+      return apiSuccess({ status: 202 }, undefined, 202);
     }
 
     let claimed = false;
@@ -278,7 +279,7 @@ export async function POST(request: NextRequest) {
 
     const payload: OAuthCallbackResponse = { status: responseStatus };
 
-    return NextResponse.json(payload, { status: responseStatus });
+    return apiSuccess(payload, undefined, responseStatus);
   } catch (error) {
     return Errors.internal("Failed to relay OAuth callback", error);
   }

--- a/dashboard/src/app/api/model-preferences/route.ts
+++ b/dashboard/src/app/api/model-preferences/route.ts
@@ -5,13 +5,14 @@ import { prisma } from "@/lib/db";
 import { z } from "zod";
 import { ModelPreferencesSchema, formatZodError } from "@/lib/validation/schemas";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 export async function GET() {
   try {
     const session = await verifySession();
 
     if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return apiError("Unauthorized", 401);
     }
 
     const modelPreference = await prisma.modelPreference.findUnique({
@@ -19,13 +20,13 @@ export async function GET() {
     });
 
     if (!modelPreference) {
-      return NextResponse.json({ excludedModels: [] });
+      return apiSuccess({ excludedModels: [] });
     }
 
-    return NextResponse.json({ excludedModels: modelPreference.excludedModels });
+    return apiSuccess({ excludedModels: modelPreference.excludedModels });
   } catch (error) {
     logger.error({ err: error }, "Get model preferences error");
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    return apiError("Internal server error", 500);
   }
 }
 
@@ -34,7 +35,7 @@ export async function PUT(request: NextRequest) {
     const session = await verifySession();
 
     if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return apiError("Unauthorized", 401);
     }
 
     const originError = validateOrigin(request);
@@ -51,7 +52,7 @@ export async function PUT(request: NextRequest) {
     });
     
     if (!userExists) {
-      return NextResponse.json({ error: "User not found - please log in again" }, { status: 401 });
+      return apiError("User not found - please log in again", 401);
     }
 
     const modelPreference = await prisma.modelPreference.upsert({
@@ -65,15 +66,14 @@ export async function PUT(request: NextRequest) {
       },
     });
 
-    return NextResponse.json({
-      success: true,
+    return apiSuccess({
       excludedModels: modelPreference.excludedModels,
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json(formatZodError(error), { status: 400 });
+      return apiError("Validation failed", 400, formatZodError(error));
     }
     logger.error({ err: error }, "Update model preferences error");
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    return apiError("Internal server error", 500);
   }
 }

--- a/dashboard/src/app/api/provider-groups/[id]/route.ts
+++ b/dashboard/src/app/api/provider-groups/[id]/route.ts
@@ -6,6 +6,7 @@ import { Errors } from "@/lib/errors";
 import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
 import { UpdateProviderGroupSchema } from "@/lib/validation/schemas";
 import { z } from "zod";
+import { apiSuccess } from "@/lib/api-response";
 
 export async function PATCH(
   request: NextRequest,
@@ -87,7 +88,7 @@ export async function PATCH(
       ipAddress: extractIpAddress(request),
     });
 
-    return NextResponse.json({ group });
+    return apiSuccess({ group });
   } catch (error) {
     if (error instanceof z.ZodError) {
       return Errors.zodValidation(error.issues);
@@ -138,7 +139,7 @@ export async function DELETE(
       ipAddress: extractIpAddress(request),
     });
 
-    return NextResponse.json({ success: true });
+    return apiSuccess({ success: true });
   } catch (error) {
     return Errors.internal("DELETE /api/provider-groups/[id]", error);
   }

--- a/dashboard/src/app/api/provider-groups/reorder/route.ts
+++ b/dashboard/src/app/api/provider-groups/reorder/route.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/db";
 import { Errors } from "@/lib/errors";
 import { ReorderProviderGroupsSchema } from "@/lib/validation/schemas";
 import { z } from "zod";
+import { apiSuccess } from "@/lib/api-response";
 
 export async function PUT(request: NextRequest) {
   const session = await verifySession();
@@ -42,7 +43,7 @@ export async function PUT(request: NextRequest) {
       )
     );
 
-    return NextResponse.json({ success: true });
+    return apiSuccess({ success: true });
   } catch (error) {
     if (error instanceof z.ZodError) {
       return Errors.zodValidation(error.issues);

--- a/dashboard/src/app/api/provider-groups/route.ts
+++ b/dashboard/src/app/api/provider-groups/route.ts
@@ -7,6 +7,7 @@ import { Errors } from "@/lib/errors";
 import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
 import { CreateProviderGroupSchema } from "@/lib/validation/schemas";
 import { z } from "zod";
+import { apiSuccess } from "@/lib/api-response";
 
 interface ProviderRecord {
   id: string;
@@ -84,7 +85,7 @@ export async function GET() {
     }));
     const safeUngrouped = ungrouped.map(sanitizeProvider);
 
-    return NextResponse.json({ groups: safeGroups, ungrouped: safeUngrouped });
+    return apiSuccess({ groups: safeGroups, ungrouped: safeUngrouped });
   } catch (error) {
     return Errors.internal("GET /api/provider-groups", error);
   }
@@ -147,7 +148,7 @@ export async function POST(request: NextRequest) {
       ipAddress: extractIpAddress(request),
     });
 
-    return NextResponse.json({ group }, { status: 201 });
+    return apiSuccess({ group }, undefined, 201);
   } catch (error) {
     if (error instanceof z.ZodError) {
       return Errors.zodValidation(error.issues);

--- a/dashboard/src/app/api/providers/keys/[keyHash]/route.ts
+++ b/dashboard/src/app/api/providers/keys/[keyHash]/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/db";
 import { PROVIDER, type Provider } from "@/lib/providers/constants";
 import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 function isValidProvider(provider: string): provider is Provider {
   return Object.values(PROVIDER).includes(provider as Provider);
@@ -17,7 +18,7 @@ export async function DELETE(
 ) {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const originError = validateOrigin(request);
@@ -31,10 +32,7 @@ export async function DELETE(
     const provider = searchParams.get("provider");
 
     if (!keyHash || typeof keyHash !== "string") {
-      return NextResponse.json(
-        { error: "Invalid or missing keyHash parameter" },
-        { status: 400 }
-      );
+      return apiError("Invalid or missing keyHash parameter", 400);
     }
 
     const user = await prisma.user.findUnique({
@@ -58,12 +56,12 @@ export async function DELETE(
 
     if (!result.ok) {
       if (result.error?.includes("Access denied")) {
-        return NextResponse.json({ error: result.error }, { status: 403 });
+        return apiError(result.error, 403);
       }
       if (result.error?.includes("not found")) {
-        return NextResponse.json({ error: result.error }, { status: 404 });
+        return apiError(result.error, 404);
       }
-      return NextResponse.json({ error: result.error }, { status: 500 });
+      return apiError(result.error ?? "Failed to remove key", 500);
     }
 
     logAuditAsync({
@@ -77,12 +75,9 @@ export async function DELETE(
       ipAddress: extractIpAddress(request),
     });
 
-    return NextResponse.json({ success: true });
+    return apiSuccess({ success: true });
   } catch (error) {
     logger.error({ err: error }, "DELETE /api/providers/keys/[keyHash] error");
-    return NextResponse.json(
-      { error: "Failed to remove provider key" },
-      { status: 500 }
-    );
+    return apiError("Failed to remove provider key", 500);
   }
 }

--- a/dashboard/src/app/api/providers/keys/route.ts
+++ b/dashboard/src/app/api/providers/keys/route.ts
@@ -6,6 +6,7 @@ import { PROVIDER, type Provider } from "@/lib/providers/constants";
 import { checkRateLimitWithPreset } from "@/lib/auth/rate-limit";
 import { ERROR_CODE, Errors, apiError } from "@/lib/errors";
 import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
+import { apiSuccess } from "@/lib/api-response";
 
 interface ContributeKeyRequest {
   provider: string;
@@ -51,7 +52,7 @@ export async function GET(request: NextRequest) {
       return apiError(ERROR_CODE.PROVIDER_ERROR, result.error ?? "Provider error", 500);
     }
 
-    return NextResponse.json({ data: { keys: result.keys } });
+    return apiSuccess({ keys: result.keys });
   } catch (error) {
     return Errors.internal("GET /api/providers/keys error", error);
   }
@@ -104,15 +105,10 @@ export async function POST(request: NextRequest) {
       ipAddress: extractIpAddress(request),
     });
 
-    return NextResponse.json(
-      {
-        data: {
-          keyHash: result.keyHash,
-          keyIdentifier: result.keyIdentifier,
-        },
-      },
-      { status: 201 }
-    );
+    return apiSuccess({
+      keyHash: result.keyHash,
+      keyIdentifier: result.keyIdentifier,
+    }, undefined, 201);
   } catch (error) {
     return Errors.internal("POST /api/providers/keys error", error);
   }

--- a/dashboard/src/app/api/providers/oauth/[id]/route.ts
+++ b/dashboard/src/app/api/providers/oauth/[id]/route.ts
@@ -4,6 +4,7 @@ import { validateOrigin } from "@/lib/auth/origin";
 import { removeOAuthAccountByIdOrName, toggleOAuthAccountByIdOrName } from "@/lib/providers/dual-write";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 export async function DELETE(
   request: NextRequest,
@@ -11,7 +12,7 @@ export async function DELETE(
 ) {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const originError = validateOrigin(request);
@@ -23,10 +24,7 @@ export async function DELETE(
     const { id } = await params;
 
     if (!id || typeof id !== "string") {
-      return NextResponse.json(
-        { error: "Invalid or missing id parameter" },
-        { status: 400 }
-      );
+      return apiError("Invalid or missing id parameter", 400);
     }
 
     const user = await prisma.user.findUnique({
@@ -40,21 +38,18 @@ export async function DELETE(
 
     if (!result.ok) {
       if (result.error?.includes("Access denied")) {
-        return NextResponse.json({ error: result.error }, { status: 403 });
+        return apiError(result.error, 403);
       }
       if (result.error?.includes("not found")) {
-        return NextResponse.json({ error: result.error }, { status: 404 });
+        return apiError(result.error, 404);
       }
-      return NextResponse.json({ error: result.error }, { status: 500 });
+      return apiError(result.error ?? "Operation failed", 500);
     }
 
-    return NextResponse.json({ success: true });
+    return apiSuccess({ success: true });
   } catch (error) {
     logger.error({ err: error }, "DELETE /api/providers/oauth/[id] error");
-    return NextResponse.json(
-      { error: "Failed to remove OAuth account" },
-      { status: 500 }
-    );
+    return apiError("Failed to remove OAuth account", 500);
   }
 }
 
@@ -64,7 +59,7 @@ export async function PATCH(
 ) {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const originError = validateOrigin(request);
@@ -76,18 +71,12 @@ export async function PATCH(
     const { id } = await params;
 
     if (!id || typeof id !== "string") {
-      return NextResponse.json(
-        { error: "Invalid or missing id parameter" },
-        { status: 400 }
-      );
+      return apiError("Invalid or missing id parameter", 400);
     }
 
     const body = await request.json().catch(() => null);
     if (!body || typeof body.disabled !== "boolean") {
-      return NextResponse.json(
-        { error: "Request body must include 'disabled' (boolean)" },
-        { status: 400 }
-      );
+      return apiError("Request body must include 'disabled' (boolean)", 400);
     }
 
     const user = await prisma.user.findUnique({
@@ -101,20 +90,17 @@ export async function PATCH(
 
     if (!result.ok) {
       if (result.error?.includes("Access denied")) {
-        return NextResponse.json({ error: result.error }, { status: 403 });
+        return apiError(result.error, 403);
       }
       if (result.error?.includes("not found")) {
-        return NextResponse.json({ error: result.error }, { status: 404 });
+        return apiError(result.error, 404);
       }
-      return NextResponse.json({ error: result.error }, { status: 500 });
+      return apiError(result.error ?? "Operation failed", 500);
     }
 
-    return NextResponse.json({ success: true, disabled: result.disabled });
+    return apiSuccess({ disabled: result.disabled });
   } catch (error) {
     logger.error({ err: error }, "PATCH /api/providers/oauth/[id] error");
-    return NextResponse.json(
-      { error: "Failed to toggle OAuth account" },
-      { status: 500 }
-    );
+    return apiError("Failed to toggle OAuth account", 500);
   }
 }

--- a/dashboard/src/app/api/providers/oauth/import/route.ts
+++ b/dashboard/src/app/api/providers/oauth/import/route.ts
@@ -7,6 +7,7 @@ import { OAUTH_PROVIDER, type OAuthProvider } from "@/lib/providers/constants";
 import { ImportOAuthCredentialSchema } from "@/lib/validation/schemas";
 import { ERROR_CODE, Errors, apiError } from "@/lib/errors";
 import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
+import { apiSuccess } from "@/lib/api-response";
 
 function isValidOAuthProvider(provider: string): provider is OAuthProvider {
   return Object.values(OAUTH_PROVIDER).includes(provider as OAuthProvider);
@@ -83,15 +84,10 @@ export async function POST(request: NextRequest) {
       ipAddress: extractIpAddress(request),
     });
 
-    return NextResponse.json(
-      {
-        data: {
-          id: result.id,
-          accountName: result.accountName,
-        },
-      },
-      { status: 201 }
-    );
+    return apiSuccess({
+      id: result.id,
+      accountName: result.accountName,
+    }, undefined, 201);
   } catch (error) {
     return Errors.internal("POST /api/providers/oauth/import error", error);
   }

--- a/dashboard/src/app/api/providers/oauth/route.ts
+++ b/dashboard/src/app/api/providers/oauth/route.ts
@@ -6,6 +6,7 @@ import { contributeOAuthAccount, listOAuthWithOwnership } from "@/lib/providers/
 import { OAUTH_PROVIDER, type OAuthProvider } from "@/lib/providers/constants";
 import { ERROR_CODE, Errors, apiError } from "@/lib/errors";
 import { prisma } from "@/lib/db";
+import { apiSuccess } from "@/lib/api-response";
 
 interface ContributeOAuthRequest {
   provider: string;
@@ -49,7 +50,7 @@ export async function GET() {
       return apiError(ERROR_CODE.PROVIDER_ERROR, result.error ?? "Provider error", 500);
     }
 
-    return NextResponse.json({ accounts: result.accounts });
+    return apiSuccess({ accounts: result.accounts });
   } catch (error) {
     return Errors.internal("GET /api/providers/oauth error", error);
   }
@@ -96,7 +97,7 @@ export async function POST(request: NextRequest) {
       return apiError(ERROR_CODE.PROVIDER_ERROR, result.error ?? "Provider error", 500);
     }
 
-    return NextResponse.json({ id: result.id }, { status: 201 });
+    return apiSuccess({ id: result.id }, undefined, 201);
   } catch (error) {
     return Errors.internal("POST /api/providers/oauth error", error);
   }

--- a/dashboard/src/app/api/providers/perplexity-cookie/current/route.ts
+++ b/dashboard/src/app/api/providers/perplexity-cookie/current/route.ts
@@ -3,6 +3,7 @@ import { createHmac, timingSafeEqual } from "crypto";
 import { prisma } from "@/lib/db";
 import { Errors } from "@/lib/errors";
 import { env } from "@/lib/env";
+import { apiSuccess } from "@/lib/api-response";
 
 const HMAC_KEY = Buffer.alloc(32);
 
@@ -38,7 +39,7 @@ export async function GET(request: NextRequest) {
     });
 
     if (!activeCookie) {
-      return NextResponse.json({ cookies: null });
+      return apiSuccess({ cookies: null });
     }
 
     await prisma.perplexityCookie.update({
@@ -46,7 +47,7 @@ export async function GET(request: NextRequest) {
       data: { lastUsedAt: new Date() },
     });
 
-    return NextResponse.json({
+    return apiSuccess({
       cookies: JSON.parse(activeCookie.cookieData),
       updatedAt: activeCookie.updatedAt.toISOString(),
     });

--- a/dashboard/src/app/api/providers/perplexity-cookie/route.ts
+++ b/dashboard/src/app/api/providers/perplexity-cookie/route.ts
@@ -7,6 +7,7 @@ import { prisma } from "@/lib/db";
 import { syncCustomProviderToProxy } from "@/lib/providers/custom-provider-sync";
 import { hashProviderKey } from "@/lib/providers/hash";
 import { logger } from "@/lib/logger";
+import { apiSuccess } from "@/lib/api-response";
 
 const REQUIRED_COOKIE_KEYS = ["next-auth.session-token"];
 
@@ -158,7 +159,7 @@ export async function GET() {
       orderBy: { createdAt: "desc" },
     });
 
-    return NextResponse.json({ cookies });
+    return apiSuccess({ cookies });
   } catch (error) {
     return Errors.internal("fetch perplexity cookies", error);
   }
@@ -228,7 +229,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    return NextResponse.json({ cookie, providerProvisioned, modelsUpdated }, { status: 201 });
+    return apiSuccess({ cookie, providerProvisioned, modelsUpdated }, undefined, 201);
   } catch (error) {
     return Errors.internal("save perplexity cookie", error);
   }
@@ -264,7 +265,7 @@ export async function DELETE(request: NextRequest) {
 
     await prisma.perplexityCookie.delete({ where: { id } });
 
-    return NextResponse.json({ success: true });
+    return apiSuccess({ success: true });
   } catch (error) {
     return Errors.internal("delete perplexity cookie", error);
   }

--- a/dashboard/src/app/api/providers/perplexity-cookie/sync-models/route.ts
+++ b/dashboard/src/app/api/providers/perplexity-cookie/sync-models/route.ts
@@ -7,6 +7,7 @@ import { syncCustomProviderToProxy } from "@/lib/providers/custom-provider-sync"
 import { hashProviderKey } from "@/lib/providers/hash";
 import { env } from "@/lib/env";
 import { logger } from "@/lib/logger";
+import { apiSuccess } from "@/lib/api-response";
 
 const SIDECAR_BASE_URL = "http://perplexity-sidecar:8766/v1";
 const SIDECAR_FETCH_TIMEOUT_MS = 5_000;
@@ -89,7 +90,7 @@ export async function PUT(request: NextRequest) {
   try {
     const result = await syncModelsCore();
     logger.info({ result }, "Sidecar-triggered model sync completed");
-    return NextResponse.json(result);
+    return apiSuccess(result);
   } catch (error) {
     return Errors.internal("sidecar-triggered sync perplexity models", error);
   }
@@ -137,7 +138,7 @@ export async function POST(request: NextRequest) {
         "create"
       );
 
-      return NextResponse.json({
+      return apiSuccess({
         synced: true,
         created: true,
         modelCount: models.length,
@@ -155,7 +156,7 @@ export async function POST(request: NextRequest) {
       models.some((m) => !existingNames.has(m.upstreamName));
 
     if (!hasChanges) {
-      return NextResponse.json({
+      return apiSuccess({
         synced: true,
         created: false,
         modelCount: models.length,
@@ -190,7 +191,7 @@ export async function POST(request: NextRequest) {
       (name) => !models.some((m) => m.upstreamName === name)
     );
 
-    return NextResponse.json({
+    return apiSuccess({
       synced: true,
       created: false,
       modelCount: models.length,

--- a/dashboard/src/app/api/proxy/status/route.ts
+++ b/dashboard/src/app/api/proxy/status/route.ts
@@ -3,6 +3,7 @@ import { verifySession } from "@/lib/auth/session";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const execFileAsync = promisify(execFile);
 const CONTAINER_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$/;
@@ -21,10 +22,7 @@ export async function GET() {
   const session = await verifySession();
 
   if (!session) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 }
-    );
+    return apiError("Unauthorized", 401);
   }
 
   try {
@@ -58,19 +56,16 @@ export async function GET() {
       }
     }
 
-    return NextResponse.json({
+    return apiSuccess({
       running: isRunning,
       containerName,
       uptime,
     });
   } catch (error) {
     logger.error({ err: error }, "Status check error");
-    return NextResponse.json(
-      { 
-        running: false,
-        error: "Failed to check container status"
-      },
-      { status: 200 }
-    );
+    return apiSuccess({
+      running: false,
+      error: "Failed to check container status"
+    });
   }
 }

--- a/dashboard/src/app/api/quota/check-alerts/route.ts
+++ b/dashboard/src/app/api/quota/check-alerts/route.ts
@@ -4,6 +4,7 @@ import { validateOrigin } from "@/lib/auth/origin";
 import { prisma } from "@/lib/db";
 import { Errors } from "@/lib/errors";
 import { runAlertCheck } from "@/lib/quota-alerts";
+import { apiSuccess } from "@/lib/api-response";
 
 const MANAGEMENT_API_KEY = process.env.MANAGEMENT_API_KEY;
 
@@ -61,7 +62,7 @@ export async function POST(request: NextRequest) {
     };
 
     const result = await runAlertCheck(quotaFetcher, baseUrl);
-    return NextResponse.json(result);
+    return apiSuccess(result);
   } catch (error) {
     return Errors.internal("check quota alerts", error);
   }

--- a/dashboard/src/app/api/quota/route.ts
+++ b/dashboard/src/app/api/quota/route.ts
@@ -3,6 +3,7 @@ import { timingSafeEqual } from "crypto";
 import { verifySession } from "@/lib/auth/session";
 import { logger } from "@/lib/logger";
 import { quotaCache, CACHE_TTL } from "@/lib/cache";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const CLIPROXYAPI_MANAGEMENT_URL =
   process.env.CLIPROXYAPI_MANAGEMENT_URL ||
@@ -938,22 +939,19 @@ export async function GET(request: NextRequest) {
   if (!isInternalCall) {
     const session = await verifySession();
     if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return apiError("Unauthorized", 401);
     }
   }
 
   if (!MANAGEMENT_API_KEY) {
     logger.error("MANAGEMENT_API_KEY is not configured");
-    return NextResponse.json(
-      { error: "Server configuration error" },
-      { status: 500 }
-    );
+    return apiError("Server configuration error", 500);
   }
 
   const CACHE_KEY = "quota:all";
   const cached = quotaCache.get(CACHE_KEY);
   if (cached) {
-    return NextResponse.json(cached);
+    return apiSuccess(cached);
   }
 
   try {
@@ -973,10 +971,7 @@ export async function GET(request: NextRequest) {
         { status: authFilesResponse.status },
         "Failed to fetch auth files"
       );
-      return NextResponse.json(
-        { error: "Failed to fetch auth files" },
-        { status: 502 }
-      );
+      return apiError("Failed to fetch auth files", 502);
     }
 
     const authFilesData =
@@ -1154,12 +1149,9 @@ export async function GET(request: NextRequest) {
 
     quotaCache.set(CACHE_KEY, response, CACHE_TTL.QUOTA);
 
-    return NextResponse.json(response);
+    return apiSuccess(response);
   } catch (error) {
     logger.error({ err: error }, "Quota fetch error");
-    return NextResponse.json(
-      { error: "Failed to fetch quota data" },
-      { status: 502 }
-    );
+    return apiError("Failed to fetch quota data", 502);
   }
 }

--- a/dashboard/src/app/api/restart/route.ts
+++ b/dashboard/src/app/api/restart/route.ts
@@ -1,10 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { verifySession } from "@/lib/auth/session";
 import { validateOrigin } from "@/lib/auth/origin";
 import { prisma } from "@/lib/db";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
+import { ConfirmActionSchema } from "@/lib/validation/schemas";
 
 const execFileAsync = promisify(execFile);
 
@@ -14,10 +16,7 @@ export async function POST(request: NextRequest) {
   const session = await verifySession();
 
   if (!session) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 }
-    );
+    return apiError("Unauthorized", 401);
   }
 
   const user = await prisma.user.findUnique({
@@ -26,10 +25,7 @@ export async function POST(request: NextRequest) {
   });
 
   if (!user?.isAdmin) {
-    return NextResponse.json(
-      { error: "Forbidden: Admin access required" },
-      { status: 403 }
-    );
+    return apiError("Forbidden: Admin access required", 403);
   }
 
   const originError = validateOrigin(request);
@@ -39,26 +35,19 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { confirm } = body;
-
-    if (confirm !== true) {
-      return NextResponse.json(
-        { error: "Confirmation required" },
-        { status: 400 }
-      );
+    const parsed = ConfirmActionSchema.safeParse(body);
+    if (!parsed.success) {
+      return apiError("Confirmation required", 400);
     }
 
     await execFileAsync("docker", ["restart", CONTAINER_NAME]);
 
-    return NextResponse.json({
+    return apiSuccess({
       success: true,
       message: "Restart completed",
     });
   } catch (error) {
     logger.error({ err: error }, "Restart endpoint error");
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return apiError("Internal server error", 500);
   }
 }

--- a/dashboard/src/app/api/setup-status/route.ts
+++ b/dashboard/src/app/api/setup-status/route.ts
@@ -3,6 +3,7 @@ import { verifySession } from "@/lib/auth/session";
 import { prisma } from "@/lib/db";
 import { getInternalProxyUrl } from "@/lib/config-generators/opencode";
 import { fetchProxyModels } from "@/lib/config-generators/shared";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const CLIPROXYAPI_MANAGEMENT_URL =
   process.env.CLIPROXYAPI_MANAGEMENT_URL ||
@@ -78,7 +79,7 @@ async function fetchProviderCount(): Promise<number> {
 export async function GET(): Promise<NextResponse> {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const [apiKeyCount, providerCount] = await Promise.all([
@@ -104,5 +105,5 @@ export async function GET(): Promise<NextResponse> {
     models: modelCount,
   };
 
-  return NextResponse.json(response);
+  return apiSuccess(response);
 }

--- a/dashboard/src/app/api/setup/route.ts
+++ b/dashboard/src/app/api/setup/route.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/auth/validation";
 import { prisma } from "@/lib/db";
 import { ERROR_CODE, Errors, apiError } from "@/lib/errors";
+import { apiSuccess } from "@/lib/api-response";
 
 const MAX_SETUP_RETRIES = 5;
 
@@ -145,7 +146,7 @@ export async function POST(request: NextRequest) {
       token
     );
 
-    return NextResponse.json(
+    return apiSuccess(
       {
         success: true,
         user: {
@@ -153,7 +154,8 @@ export async function POST(request: NextRequest) {
           username: user.username,
         },
       },
-      { status: 201 }
+      undefined,
+      201
     );
   } catch (error) {
     return Errors.internal("Setup error", error);
@@ -164,7 +166,7 @@ export async function GET() {
   try {
     const userCount = await getUserCount();
 
-    return NextResponse.json({
+    return apiSuccess({
       data: { setupRequired: userCount === 0 },
     });
   } catch (error) {

--- a/dashboard/src/app/api/update/check/route.ts
+++ b/dashboard/src/app/api/update/check/route.ts
@@ -5,6 +5,7 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import { logger } from "@/lib/logger";
 import { updateCheckCache, CACHE_TTL } from "@/lib/cache";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const execFileAsync = promisify(execFile);
 
@@ -110,10 +111,7 @@ export async function GET() {
   const session = await verifySession();
 
   if (!session) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 }
-    );
+    return apiError("Unauthorized", 401);
   }
 
   const user = await prisma.user.findUnique({
@@ -122,10 +120,7 @@ export async function GET() {
   });
 
   if (!user?.isAdmin) {
-    return NextResponse.json(
-      { error: "Forbidden: Admin access required" },
-      { status: 403 }
-    );
+    return apiError("Forbidden: Admin access required", 403);
   }
 
   try {
@@ -181,12 +176,9 @@ export async function GET() {
       availableVersions: versionNames.slice(0, 10),
     };
 
-    return NextResponse.json(versionInfo);
+    return apiSuccess(versionInfo);
   } catch (error) {
     logger.error({ err: error }, "Update check error");
-    return NextResponse.json(
-      { error: "Failed to check for updates" },
-      { status: 500 }
-    );
+    return apiError("Failed to check for updates", 500);
   }
 }

--- a/dashboard/src/app/api/update/dashboard/check/route.ts
+++ b/dashboard/src/app/api/update/dashboard/check/route.ts
@@ -3,6 +3,7 @@ import { verifySession } from "@/lib/auth/session";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { updateCheckCache, CACHE_TTL } from "@/lib/cache";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const GITHUB_REPO = process.env.GITHUB_REPO || "itsmylife44/cliproxyapi-dashboard";
 const DASHBOARD_VERSION = process.env.DASHBOARD_VERSION || "dev";
@@ -71,10 +72,7 @@ export async function GET() {
   const session = await verifySession();
 
   if (!session) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 }
-    );
+    return apiError("Unauthorized", 401);
   }
 
   const user = await prisma.user.findUnique({
@@ -83,10 +81,7 @@ export async function GET() {
   });
 
   if (!user?.isAdmin) {
-    return NextResponse.json(
-      { error: "Forbidden: Admin access required" },
-      { status: 403 }
-    );
+    return apiError("Forbidden: Admin access required", 403);
   }
 
   try {
@@ -108,12 +103,9 @@ export async function GET() {
       releaseNotes: remote?.releaseNotes?.slice(0, 2000) ?? null,
     };
 
-    return NextResponse.json(versionInfo);
+    return apiSuccess(versionInfo);
   } catch (error) {
     logger.error({ err: error }, "Update check error");
-    return NextResponse.json(
-      { error: "Failed to check for updates" },
-      { status: 500 }
-    );
+    return apiError("Failed to check for updates", 500);
   }
 }

--- a/dashboard/src/app/api/update/dashboard/route.ts
+++ b/dashboard/src/app/api/update/dashboard/route.ts
@@ -3,6 +3,7 @@ import { verifySession } from "@/lib/auth/session";
 import { validateOrigin } from "@/lib/auth/origin";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const WEBHOOK_HOST = process.env.WEBHOOK_HOST || "http://localhost:9000";
 const DEPLOY_SECRET = process.env.DEPLOY_SECRET || "";
@@ -11,10 +12,7 @@ export async function POST(request: NextRequest) {
   const session = await verifySession();
 
   if (!session) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401 }
-    );
+    return apiError("Unauthorized", 401);
   }
 
   const user = await prisma.user.findUnique({
@@ -23,10 +21,7 @@ export async function POST(request: NextRequest) {
   });
 
   if (!user?.isAdmin) {
-    return NextResponse.json(
-      { error: "Forbidden: Admin access required" },
-      { status: 403 }
-    );
+    return apiError("Forbidden: Admin access required", 403);
   }
 
   const originError = validateOrigin(request);
@@ -39,17 +34,11 @@ export async function POST(request: NextRequest) {
     const { confirm } = body;
 
     if (confirm !== true) {
-      return NextResponse.json(
-        { error: "Confirmation required" },
-        { status: 400 }
-      );
+      return apiError("Confirmation required", 400);
     }
 
     if (!DEPLOY_SECRET) {
-      return NextResponse.json(
-        { error: "DEPLOY_SECRET not configured. Set up the webhook deploy service first." },
-        { status: 500 }
-      );
+      return apiError("DEPLOY_SECRET not configured. Set up the webhook deploy service first.", 500);
     }
 
     const response = await fetch(`${WEBHOOK_HOST}/hooks/deploy-dashboard`, {
@@ -64,23 +53,17 @@ export async function POST(request: NextRequest) {
     if (!response.ok) {
       const text = await response.text();
       logger.error({ status: response.status, body: text }, "Webhook trigger failed");
-      return NextResponse.json(
-        { error: "Failed to trigger update. Check webhook service." },
-        { status: 502 }
-      );
+      return apiError("Failed to trigger update. Check webhook service.", 502);
     }
 
     await response.body?.cancel();
 
-    return NextResponse.json({
+    return apiSuccess({
       success: true,
       message: "Dashboard update triggered. The container will restart shortly.",
     });
   } catch (error) {
     logger.error({ err: error }, "Dashboard update error");
-    return NextResponse.json(
-      { error: "Failed to reach webhook service. Is it running?" },
-      { status: 500 }
-    );
+    return apiError("Failed to reach webhook service. Is it running?", 500);
   }
 }

--- a/dashboard/src/app/api/update/route.ts
+++ b/dashboard/src/app/api/update/route.ts
@@ -1,10 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { verifySession } from "@/lib/auth/session";
 import { validateOrigin } from "@/lib/auth/origin";
 import { prisma } from "@/lib/db";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
+import { UpdateProxySchema } from "@/lib/validation/schemas";
 
 const execFileAsync = promisify(execFile);
 
@@ -136,7 +138,7 @@ export async function POST(request: NextRequest) {
   const session = await verifySession();
 
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const user = await prisma.user.findUnique({
@@ -145,7 +147,7 @@ export async function POST(request: NextRequest) {
   });
 
   if (!user?.isAdmin) {
-    return NextResponse.json({ error: "Forbidden: Admin access required" }, { status: 403 });
+    return apiError("Forbidden: Admin access required", 403);
   }
 
   const originError = validateOrigin(request);
@@ -156,14 +158,15 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { version = "latest", confirm } = body;
-
-    if (confirm !== true) {
-      return NextResponse.json({ error: "Confirmation required" }, { status: 400 });
+    const parsed = UpdateProxySchema.safeParse(body);
+    if (!parsed.success) {
+      return apiError("Confirmation required or invalid version format", 400);
     }
 
-    if (typeof version !== "string" || !isValidImageTag(version)) {
-      return NextResponse.json({ error: "Invalid version format" }, { status: 400 });
+    const { version } = parsed.data;
+
+    if (!isValidImageTag(version)) {
+      return apiError("Invalid version format", 400);
     }
 
     const imageTag = `${IMAGE_NAME}:${version}`;
@@ -184,7 +187,7 @@ export async function POST(request: NextRequest) {
       await recreateWithDockerRun(configSnapshot, imageTag);
     }
 
-    return NextResponse.json({ success: true, message: `Updated to ${version}`, version });
+    return apiSuccess({ success: true, message: `Updated to ${version}`, version });
   } catch (error) {
     logger.error({ err: error }, "Update error");
 
@@ -200,9 +203,6 @@ export async function POST(request: NextRequest) {
       logger.error({ err: restartError }, "Recovery failed");
     }
 
-    return NextResponse.json(
-      { error: "Update failed. Container may need manual restart." },
-      { status: 500 }
-    );
+    return apiError("Update failed. Container may need manual restart.", 500);
   }
 }

--- a/dashboard/src/app/api/usage/collect/route.ts
+++ b/dashboard/src/app/api/usage/collect/route.ts
@@ -5,6 +5,7 @@ import { syncKeysToCliProxyApi } from "@/lib/api-keys/sync";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { randomUUID, timingSafeEqual } from "crypto";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const CLIPROXYAPI_MANAGEMENT_URL =
   process.env.CLIPROXYAPI_MANAGEMENT_URL ||
@@ -194,7 +195,7 @@ export async function POST(request: NextRequest) {
   if (!isCronAuth) {
     const session = await verifySession();
     if (!session) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return apiError("Unauthorized", 401);
     }
 
     const user = await prisma.user.findUnique({
@@ -203,7 +204,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (!user?.isAdmin) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      return apiError("Forbidden", 403);
     }
 
     const originError = validateOrigin(request);
@@ -212,10 +213,7 @@ export async function POST(request: NextRequest) {
 
   if (!MANAGEMENT_API_KEY) {
     logger.error("MANAGEMENT_API_KEY is not configured");
-    return NextResponse.json(
-      { error: "Server configuration error" },
-      { status: 500 }
-    );
+    return apiError("Server configuration error", 500);
   }
 
   const runId = randomUUID();
@@ -226,17 +224,11 @@ export async function POST(request: NextRequest) {
     const leaseAcquired = await tryAcquireCollectorLease(leaseAcquiredAt);
     if (!leaseAcquired) {
       logger.warn({ runId }, "Usage collection skipped: collector already running");
-      return NextResponse.json(
-        { error: "Collector already running", runId },
-        { status: 202 }
-      );
+      return apiError("Collector already running", 202);
     }
   } catch (error) {
     logger.error({ err: error, runId }, "Failed to acquire collector lease");
-    return NextResponse.json(
-      { error: "Failed to acquire collector lock", runId },
-      { status: 500 }
-    );
+    return apiError("Failed to acquire collector lock", 500);
   }
 
   try {
@@ -258,10 +250,7 @@ export async function POST(request: NextRequest) {
     } catch (fetchError) {
       logger.error({ err: fetchError }, "Failed to connect to CLIProxyAPI");
       await markCollectorError(runId, "Proxy service unavailable");
-      return NextResponse.json(
-        { error: "Proxy service unavailable" },
-        { status: 503 }
-      );
+      return apiError("Proxy service unavailable", 503);
     }
 
     interface AuthFileEntry {
@@ -302,10 +291,7 @@ export async function POST(request: NextRequest) {
         "CLIProxyAPI usage endpoint returned error"
       );
       await markCollectorError(runId, "Failed to fetch usage data");
-      return NextResponse.json(
-        { error: "Failed to fetch usage data" },
-        { status: 502 }
-      );
+      return apiError("Failed to fetch usage data", 502);
     }
 
     const responseJson: unknown = await usageResponse.json();
@@ -323,10 +309,7 @@ export async function POST(request: NextRequest) {
         "Unexpected usage response format from CLIProxyAPI"
       );
       await markCollectorError(runId, "Invalid usage data format");
-      return NextResponse.json(
-        { error: "Invalid usage data format" },
-        { status: 502 }
-      );
+      return apiError("Invalid usage data format", 502);
     }
 
     const syncResult = await syncKeysToCliProxyApi();
@@ -482,7 +465,7 @@ export async function POST(request: NextRequest) {
       "Usage collection completed"
     );
 
-    return NextResponse.json({
+    return apiSuccess({
       runId,
       processed: candidates.length,
       stored: totalStored,
@@ -515,6 +498,6 @@ export async function POST(request: NextRequest) {
       /* state update failed, continue */
     }
 
-    return NextResponse.json({ error: "Internal error", runId }, { status: 500 });
+    return apiError("Internal error", 500);
   }
 }

--- a/dashboard/src/app/api/usage/history/route.ts
+++ b/dashboard/src/app/api/usage/history/route.ts
@@ -3,6 +3,7 @@ import { verifySession } from "@/lib/auth/session";
 import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { usageCache } from "@/lib/cache";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const USAGE_HISTORY_CACHE_TTL_MS = 15_000;
 const USAGE_RECORD_LIMIT = 25_000;
@@ -40,7 +41,7 @@ export async function GET(request: NextRequest) {
   const requestStartedAt = Date.now();
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const searchParams = request.nextUrl.searchParams;
@@ -48,27 +49,18 @@ export async function GET(request: NextRequest) {
   const toParam = searchParams.get("to");
 
   if (!fromParam || !toParam) {
-    return NextResponse.json(
-      { error: "Missing required parameters: from and to" },
-      { status: 400 }
-    );
+    return apiError("Missing required parameters: from and to", 400);
   }
 
   if (!isValidDateParam(fromParam) || !isValidDateParam(toParam)) {
-    return NextResponse.json(
-      { error: "Invalid date format. Use YYYY-MM-DD." },
-      { status: 400 }
-    );
+    return apiError("Invalid date format. Use YYYY-MM-DD.", 400);
   }
 
   const fromDate = new Date(fromParam + "T00:00:00.000Z");
   const toDate = new Date(toParam + "T23:59:59.999Z");
 
   if (fromDate > toDate) {
-    return NextResponse.json(
-      { error: "from date must be before to date" },
-      { status: 400 }
-    );
+    return apiError("from date must be before to date", 400);
   }
 
   try {
@@ -81,7 +73,7 @@ export async function GET(request: NextRequest) {
     const cached = usageCache.get(cacheKey) as { data: unknown; isAdmin: boolean } | null;
     if (cached) {
       logger.debug({ userId: session.userId, from: fromParam, to: toParam }, "Usage history cache hit");
-      return NextResponse.json(cached);
+      return apiSuccess(cached);
     }
 
     let sourceFilter: string[] = [];
@@ -301,12 +293,9 @@ export async function GET(request: NextRequest) {
       "Usage history request completed"
     );
 
-    return NextResponse.json(responseData);
+    return apiSuccess(responseData);
   } catch (error) {
     logger.error({ err: error, userId: session.userId, durationMs: Date.now() - requestStartedAt }, "Failed to fetch usage history");
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return apiError("Internal server error", 500);
   }
 }

--- a/dashboard/src/app/api/usage/route.ts
+++ b/dashboard/src/app/api/usage/route.ts
@@ -9,6 +9,7 @@ import { verifySession } from "@/lib/auth/session";
 import { prisma } from "@/lib/db";
 import { usageCache, CACHE_TTL, CACHE_KEYS } from "@/lib/cache";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 const CLIPROXYAPI_MANAGEMENT_URL =
   process.env.CLIPROXYAPI_MANAGEMENT_URL ||
@@ -346,15 +347,12 @@ function filterAndLabelApis(
 export async function GET() {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   if (!MANAGEMENT_API_KEY) {
     logger.error("MANAGEMENT_API_KEY is not configured");
-    return NextResponse.json(
-      { error: "Server configuration error: management API key not set" },
-      { status: 500 }
-    );
+    return apiError("Server configuration error: management API key not set", 500);
   }
 
   try {
@@ -367,7 +365,7 @@ export async function GET() {
     const cacheKey = `${CACHE_KEYS.usage(session.userId)}:${isAdmin}`;
     const cached = usageCache.get(cacheKey);
     if (cached) {
-      return NextResponse.json(cached);
+      return apiSuccess(cached);
     }
 
     const [usageResponse, userKeys] = await Promise.all([
@@ -411,10 +409,7 @@ export async function GET() {
         { status: usageResponse.status, statusText: usageResponse.statusText },
         "CLIProxyAPI usage endpoint returned error"
       );
-      return NextResponse.json(
-        { error: "Failed to fetch usage data from CLIProxyAPI" },
-        { status: 502 }
-      );
+      return apiError("Failed to fetch usage data from CLIProxyAPI", 502);
     }
 
     const responseJson: unknown = await usageResponse.json();
@@ -428,10 +423,7 @@ export async function GET() {
 
     if (!isRawUsageResponse(rawData)) {
       logger.error({ response: JSON.stringify(responseJson).slice(0, 200) }, "Unexpected usage response format from CLIProxyAPI");
-      return NextResponse.json(
-        { error: "Invalid usage data format from CLIProxyAPI" },
-        { status: 502 }
-      );
+      return apiError("Invalid usage data format from CLIProxyAPI", 502);
     }
 
     const { apis: filteredApis, totals } = filterAndLabelApis(
@@ -460,12 +452,9 @@ export async function GET() {
 
     usageCache.set(cacheKey, responseData, CACHE_TTL.USAGE);
 
-    return NextResponse.json(responseData);
+    return apiSuccess(responseData);
   } catch (error) {
     logger.error({ err: error }, "Failed to fetch usage data");
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return apiError("Internal server error", 500);
   }
 }

--- a/dashboard/src/app/api/user/api-keys/route.ts
+++ b/dashboard/src/app/api/user/api-keys/route.ts
@@ -7,6 +7,7 @@ import { prisma } from "@/lib/db";
 import { checkRateLimitWithPreset } from "@/lib/auth/rate-limit";
 import { logger } from "@/lib/logger";
 import { z } from "zod";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 interface ApiKeyResponse {
   id: string;
@@ -39,7 +40,7 @@ function maskApiKey(key: string): string {
 export async function GET() {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   try {
@@ -63,31 +64,22 @@ export async function GET() {
       lastUsedAt: apiKey.lastUsedAt?.toISOString() || null,
     }));
 
-    return NextResponse.json({ apiKeys: response });
+    return apiSuccess({ apiKeys: response });
   } catch (error) {
     logger.error({ err: error }, "Failed to fetch API keys");
-    return NextResponse.json(
-      { error: "Failed to fetch API keys" },
-      { status: 500 }
-    );
+    return apiError("Failed to fetch API keys", 500);
   }
 }
 
 export async function POST(request: NextRequest) {
   const rateLimit = checkRateLimitWithPreset(request, "api-keys", "API_KEYS");
   if (!rateLimit.allowed) {
-    return NextResponse.json(
-      { error: "Too many API key creation requests. Try again later." },
-      {
-        status: 429,
-        headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
-      }
-    );
+    return apiError("Too many API key creation requests. Try again later.", 429);
   }
 
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const originError = validateOrigin(request);
@@ -100,10 +92,7 @@ export async function POST(request: NextRequest) {
     const parsed = CreateApiKeyRequestSchema.safeParse(body);
 
     if (!parsed.success) {
-      return NextResponse.json(
-        { error: "Invalid request body" },
-        { status: 400 }
-      );
+      return apiError("Invalid request body", 400);
     }
 
     const key = generateApiKey();
@@ -134,20 +123,17 @@ export async function POST(request: NextRequest) {
       syncMessage: "Key created - backend sync in progress",
     };
 
-    return NextResponse.json(response, { status: 201 });
+    return apiSuccess(response, undefined, 201);
   } catch (error) {
     logger.error({ err: error }, "Failed to create API key");
-    return NextResponse.json(
-      { error: "Failed to create API key" },
-      { status: 500 }
-    );
+    return apiError("Failed to create API key", 500);
   }
 }
 
 export async function DELETE(request: NextRequest) {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
 
   const originError = validateOrigin(request);
@@ -160,10 +146,7 @@ export async function DELETE(request: NextRequest) {
     const id = searchParams.get("id");
 
     if (!id || typeof id !== "string") {
-      return NextResponse.json(
-        { error: "Missing or invalid id parameter" },
-        { status: 400 }
-      );
+      return apiError("Missing or invalid id parameter", 400);
     }
 
     const existingKey = await prisma.userApiKey.findFirst({
@@ -175,10 +158,7 @@ export async function DELETE(request: NextRequest) {
     });
 
     if (!existingKey) {
-      return NextResponse.json(
-        { error: "API key not found or access denied" },
-        { status: 404 }
-      );
+      return apiError("API key not found or access denied", 404);
     }
 
     await prisma.userApiKey.delete({
@@ -190,16 +170,13 @@ export async function DELETE(request: NextRequest) {
       logger.error({ error: syncResult.error }, "Sync failed after API key deletion");
     }
 
-    return NextResponse.json({
+    return apiSuccess({
       success: true,
       syncStatus: syncResult.ok ? "ok" : "failed",
       syncMessage: syncResult.ok ? undefined : "Backend sync pending - key deleted but may still work temporarily",
     });
   } catch (error) {
     logger.error({ err: error }, "Failed to delete API key");
-    return NextResponse.json(
-      { error: "Failed to delete API key" },
-      { status: 500 }
-    );
+    return apiError("Failed to delete API key", 500);
   }
 }

--- a/dashboard/src/app/api/user/config/route.ts
+++ b/dashboard/src/app/api/user/config/route.ts
@@ -4,6 +4,7 @@ import { validateOrigin } from "@/lib/auth/origin";
 import { prisma } from "@/lib/db";
 import type { McpEntry } from "@/lib/config-generators/opencode";
 import { logger } from "@/lib/logger";
+import { apiSuccess, apiError } from "@/lib/api-response";
 
 interface UserConfigRequest {
   mcpServers?: McpEntry[];
@@ -63,35 +64,32 @@ function validateUserConfigRequest(body: unknown): UserConfigRequest | null {
 export async function GET() {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
-  
+
   try {
     const override = await prisma.agentModelOverride.findUnique({
       where: { userId: session.userId },
     });
     
     if (!override) {
-      return NextResponse.json({});
+      return apiSuccess({});
     }
-    
+
     const overrides = override.overrides as Record<string, unknown>;
-    return NextResponse.json(overrides);
+    return apiSuccess(overrides);
   } catch (error) {
     logger.error({ err: error }, "Failed to fetch user config");
-    return NextResponse.json(
-      { error: "Failed to fetch config" },
-      { status: 500 }
-    );
+    return apiError("Failed to fetch config", 500);
   }
 }
 
 export async function PUT(request: NextRequest) {
   const session = await verifySession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return apiError("Unauthorized", 401);
   }
-  
+
   const originError = validateOrigin(request);
   if (originError) {
     return originError;
@@ -102,10 +100,7 @@ export async function PUT(request: NextRequest) {
     const validatedConfig = validateUserConfigRequest(body);
     
     if (!validatedConfig) {
-      return NextResponse.json(
-        { error: "Invalid config data" },
-        { status: 400 }
-      );
+      return apiError("Invalid config data", 400);
     }
     
     const userExists = await prisma.user.findUnique({
@@ -114,7 +109,7 @@ export async function PUT(request: NextRequest) {
     });
     
     if (!userExists) {
-      return NextResponse.json({ error: "User not found - please log in again" }, { status: 401 });
+      return apiError("User not found - please log in again", 401);
     }
 
     const existing = await prisma.agentModelOverride.findUnique({
@@ -144,15 +139,12 @@ export async function PUT(request: NextRequest) {
       },
     });
     
-    return NextResponse.json({
+    return apiSuccess({
       success: true,
       overrides: override.overrides,
     });
   } catch (error) {
     logger.error({ err: error }, "Failed to update user config");
-    return NextResponse.json(
-      { error: "Failed to update config" },
-      { status: 500 }
-    );
+    return apiError("Failed to update config", 500);
   }
 }

--- a/dashboard/src/app/dashboard/config/_components/advanced-settings.tsx
+++ b/dashboard/src/app/dashboard/config/_components/advanced-settings.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Toggle, SectionHeader, ConfigField } from "./config-form-controls";
+import type { Config, TlsConfig, PprofConfig, ClaudeHeaderDefaults, AmpcodeConfig } from "./config-types";
+
+interface AdvancedSettingsProps {
+  config: Config;
+  updateTlsConfig: (key: keyof TlsConfig, value: string | boolean) => void;
+  updatePprofConfig: (key: keyof PprofConfig, value: string | boolean) => void;
+  updateClaudeHeaderDefaults: (key: keyof ClaudeHeaderDefaults, value: string) => void;
+  updateAmpcodeConfig: (key: keyof AmpcodeConfig, value: string | boolean | unknown) => void;
+  updateConfig: <K extends keyof Config>(key: K, value: Config[K]) => void;
+}
+
+export function TlsSection({ config, updateTlsConfig }: Pick<AdvancedSettingsProps, "config" | "updateTlsConfig">) {
+  return (
+    <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
+      <SectionHeader title="TLS / HTTPS" />
+      <div className="rounded-sm border border-slate-600/40 bg-slate-800/30 p-3 text-xs text-slate-400">
+        TLS is typically handled by Caddy reverse proxy. Only configure this for direct TLS termination.
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <ConfigField label="Enable TLS" description="Enable TLS">
+          <Toggle enabled={config.tls?.enable ?? false} onChange={(value) => updateTlsConfig("enable", value)} />
+        </ConfigField>
+        <ConfigField label="Certificate Path" description="Path to TLS certificate file">
+          <Input type="text" name="tls-cert" value={config.tls?.cert ?? ""} onChange={(value) => updateTlsConfig("cert", value)} placeholder="/path/to/cert.pem" className="font-mono" />
+        </ConfigField>
+        <ConfigField label="Private Key Path" description="Path to TLS private key file">
+          <Input type="text" name="tls-key" value={config.tls?.key ?? ""} onChange={(value) => updateTlsConfig("key", value)} placeholder="/path/to/key.pem" className="font-mono" />
+        </ConfigField>
+      </div>
+    </section>
+  );
+}
+
+export function KiroSection({ config, updateConfig }: Pick<AdvancedSettingsProps, "config" | "updateConfig">) {
+  return (
+    <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
+      <SectionHeader title="Kiro" />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <ConfigField label="Preferred Endpoint" description="Preferred Kiro API endpoint URL">
+          <Input type="text" name="kiro-preferred-endpoint" value={config["kiro-preferred-endpoint"] ?? ""} onChange={(value) => updateConfig("kiro-preferred-endpoint", value)} placeholder="https://..." className="font-mono" />
+        </ConfigField>
+      </div>
+    </section>
+  );
+}
+
+export function ClaudeHeadersSection({ config, updateClaudeHeaderDefaults }: Pick<AdvancedSettingsProps, "config" | "updateClaudeHeaderDefaults">) {
+  return (
+    <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
+      <SectionHeader title="Claude Header Defaults" />
+      <p className="text-xs text-slate-500">Custom headers sent with all Claude API requests</p>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <ConfigField label="User-Agent" description="Custom User-Agent header">
+          <Input type="text" name="claude-header-user-agent" value={config["claude-header-defaults"]?.["user-agent"] ?? ""} onChange={(value) => updateClaudeHeaderDefaults("user-agent", value)} className="font-mono" />
+        </ConfigField>
+        <ConfigField label="Package Version" description="Package version header">
+          <Input type="text" name="claude-header-package-version" value={config["claude-header-defaults"]?.["package-version"] ?? ""} onChange={(value) => updateClaudeHeaderDefaults("package-version", value)} className="font-mono" />
+        </ConfigField>
+        <ConfigField label="Runtime Version" description="Runtime version header">
+          <Input type="text" name="claude-header-runtime-version" value={config["claude-header-defaults"]?.["runtime-version"] ?? ""} onChange={(value) => updateClaudeHeaderDefaults("runtime-version", value)} className="font-mono" />
+        </ConfigField>
+        <ConfigField label="Timeout" description="Request timeout header">
+          <Input type="text" name="claude-header-timeout" value={config["claude-header-defaults"]?.["timeout"] ?? ""} onChange={(value) => updateClaudeHeaderDefaults("timeout", value)} className="font-mono" />
+        </ConfigField>
+      </div>
+    </section>
+  );
+}
+
+export function AmpcodeSection({ config, updateAmpcodeConfig }: Pick<AdvancedSettingsProps, "config" | "updateAmpcodeConfig">) {
+  return (
+    <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
+      <SectionHeader title="Amp Code" />
+      <p className="text-xs text-slate-500">Configuration for Amp Code upstream integration</p>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <ConfigField label="Upstream URL" description="Upstream Amp Code URL">
+          <Input type="text" name="ampcode-upstream-url" value={config.ampcode?.["upstream-url"] ?? ""} onChange={(value) => updateAmpcodeConfig("upstream-url", value)} className="font-mono" />
+        </ConfigField>
+        <ConfigField label="Upstream API Key" description="Upstream API key">
+          <Input type="password" name="ampcode-upstream-api-key" value={config.ampcode?.["upstream-api-key"] ?? ""} onChange={(value) => updateAmpcodeConfig("upstream-api-key", value)} className="font-mono" />
+        </ConfigField>
+        <ConfigField label="Restrict Management to Localhost" description="Restrict management API to localhost only">
+          <Toggle enabled={config.ampcode?.["restrict-management-to-localhost"] ?? false} onChange={(value) => updateAmpcodeConfig("restrict-management-to-localhost", value)} />
+        </ConfigField>
+        <ConfigField label="Force Model Mappings" description="Force model mappings">
+          <Toggle enabled={config.ampcode?.["force-model-mappings"] ?? false} onChange={(value) => updateAmpcodeConfig("force-model-mappings", value)} />
+        </ConfigField>
+      </div>
+    </section>
+  );
+}
+
+export function PprofSection({ config, updatePprofConfig }: Pick<AdvancedSettingsProps, "config" | "updatePprofConfig">) {
+  return (
+    <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
+      <SectionHeader title="Profiling (pprof)" />
+      <div className="rounded-sm border border-slate-600/40 bg-slate-800/30 p-3 text-xs text-slate-400">
+        Go runtime profiling. Only enable for debugging.
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <ConfigField label="Enable pprof" description="Enable pprof endpoint">
+          <Toggle enabled={config.pprof?.enable ?? false} onChange={(value) => updatePprofConfig("enable", value)} />
+        </ConfigField>
+        <ConfigField label="Listen Address" description="pprof listen address">
+          <Input type="text" name="pprof-addr" value={config.pprof?.addr ?? ""} onChange={(value) => updatePprofConfig("addr", value)} placeholder="127.0.0.1:8316" className="font-mono" />
+        </ConfigField>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/src/app/dashboard/config/_components/config-form-controls.tsx
+++ b/dashboard/src/app/dashboard/config/_components/config-form-controls.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React from "react";
+
+interface ToggleProps {
+  enabled: boolean;
+  onChange: (value: boolean) => void;
+  disabled?: boolean;
+}
+
+export function Toggle({ enabled, onChange, disabled = false }: ToggleProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={enabled}
+      onClick={() => onChange(!enabled)}
+      disabled={disabled}
+      className={`
+        relative inline-flex h-7 w-12 shrink-0 cursor-pointer rounded-full
+        border-2 border-transparent transition-colors duration-200 ease-in-out
+        focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-transparent
+        disabled:cursor-not-allowed disabled:opacity-50
+        ${enabled ? 'bg-emerald-500' : 'bg-slate-700'}
+      `}
+    >
+      <span
+        className={`
+          pointer-events-none inline-block h-6 w-6 transform rounded-full
+          bg-white shadow-lg ring-0 transition duration-200 ease-in-out
+          ${enabled ? 'translate-x-5' : 'translate-x-0'}
+        `}
+      />
+    </button>
+  );
+}
+
+interface SelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: Array<{ value: string; label: string }>;
+  disabled?: boolean;
+}
+
+export function Select({ value, onChange, options, disabled = false }: SelectProps) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      className="
+        w-full rounded-sm border border-slate-700/70 bg-slate-900/50 px-3 py-2 text-sm
+        text-slate-200
+        focus:outline-none focus:border-blue-400/50 focus:ring-1 focus:ring-blue-400/30
+        disabled:opacity-50 disabled:cursor-not-allowed
+        transition-colors duration-200
+      "
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value} className="bg-[#0f172a] text-slate-100">
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export function SectionHeader({ title }: { title: string }) {
+  return (
+    <div className="mb-3">
+      <h3 className="text-sm font-semibold uppercase tracking-[0.08em] text-slate-400">{title}</h3>
+    </div>
+  );
+}
+
+interface ConfigFieldProps {
+  label: string;
+  description?: string;
+  children: React.ReactNode;
+}
+
+export function ConfigField({ label, description, children }: ConfigFieldProps) {
+  return (
+    <div className="space-y-2">
+      <div className="block text-sm font-semibold text-slate-200">{label}</div>
+      {description && <p className="text-xs text-slate-500">{description}</p>}
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/dashboard/src/app/dashboard/config/_components/config-types.ts
+++ b/dashboard/src/app/dashboard/config/_components/config-types.ts
@@ -1,0 +1,85 @@
+export interface StreamingConfig {
+  "keepalive-seconds": number;
+  "bootstrap-retries": number;
+  "nonstream-keepalive-interval": number;
+}
+
+export interface QuotaExceededConfig {
+  "switch-project": boolean;
+  "switch-preview-model": boolean;
+}
+
+export interface RoutingConfig {
+  strategy: string;
+}
+
+export interface TlsConfig {
+  enable: boolean;
+  cert: string;
+  key: string;
+}
+
+export interface PprofConfig {
+  enable: boolean;
+  addr: string;
+}
+
+export interface ClaudeHeaderDefaults {
+  "user-agent": string;
+  "package-version": string;
+  "runtime-version": string;
+  timeout: string;
+}
+
+export interface AmpcodeConfig {
+  "upstream-url": string;
+  "upstream-api-key": string;
+  "restrict-management-to-localhost": boolean;
+  "model-mappings": unknown;
+  "force-model-mappings": boolean;
+}
+
+export interface PayloadConfig {
+  default: unknown;
+  "default-raw": unknown;
+  override: unknown;
+  "override-raw": unknown;
+  filter: unknown;
+}
+
+export interface OAuthModelAliasEntry {
+  name: string;
+  alias: string;
+  fork?: boolean;
+}
+
+export interface Config {
+  "proxy-url": string;
+  "auth-dir": string;
+  "force-model-prefix": boolean;
+  streaming: StreamingConfig;
+  debug: boolean;
+  "commercial-mode": boolean;
+  "logging-to-file": boolean;
+  "logs-max-total-size-mb": number;
+  "error-logs-max-files": number;
+  "usage-statistics-enabled": boolean;
+  "request-retry": number;
+  "max-retry-interval": number;
+  "quota-exceeded": QuotaExceededConfig;
+  routing: RoutingConfig;
+  "ws-auth": boolean;
+  "disable-cooling": boolean;
+  "request-log": boolean;
+  "max-retry-credentials": number;
+  "passthrough-headers": boolean;
+  "incognito-browser": boolean;
+  "kiro-preferred-endpoint": string;
+  kiro: unknown;
+  tls: TlsConfig;
+  pprof: PprofConfig;
+  "claude-header-defaults": ClaudeHeaderDefaults;
+  ampcode: AmpcodeConfig;
+  payload: PayloadConfig;
+  "oauth-model-alias": Record<string, OAuthModelAliasEntry[]>;
+}

--- a/dashboard/src/app/dashboard/config/_components/core-settings.tsx
+++ b/dashboard/src/app/dashboard/config/_components/core-settings.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Toggle, Select, SectionHeader, ConfigField } from "./config-form-controls";
+import type { Config, StreamingConfig, QuotaExceededConfig, RoutingConfig } from "./config-types";
+
+interface CoreSettingsProps {
+  config: Config;
+  updateConfig: <K extends keyof Config>(key: K, value: Config[K]) => void;
+  updateStreamingConfig: (key: keyof StreamingConfig, value: number) => void;
+  updateQuotaConfig: (key: keyof QuotaExceededConfig, value: boolean) => void;
+  updateRoutingConfig: (key: keyof RoutingConfig, value: string) => void;
+}
+
+export function GeneralSettingsSection({ config, updateConfig }: Pick<CoreSettingsProps, "config" | "updateConfig">) {
+  return (
+    <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
+      <SectionHeader title="General Settings" />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <ConfigField label="Upstream Proxy" description="Optional SOCKS5/HTTP/HTTPS proxy for outbound requests to AI providers. Leave empty for direct connection.">
+          <Input type="text" name="proxy-url" value={config["proxy-url"]} onChange={(value) => updateConfig("proxy-url", value)} placeholder="socks5://proxy:1080 or http://proxy:8080" className="font-mono" />
+        </ConfigField>
+        <ConfigField label="Force Model Prefix" description="Require model names to include a provider prefix">
+          <Toggle enabled={config["force-model-prefix"]} onChange={(value) => updateConfig("force-model-prefix", value)} />
+        </ConfigField>
+        <ConfigField label="Debug Mode" description="Enable verbose debug logging">
+          <Toggle enabled={config.debug} onChange={(value) => updateConfig("debug", value)} />
+        </ConfigField>
+        <ConfigField label="Commercial Mode" description="Enable commercial features and licensing">
+          <Toggle enabled={config["commercial-mode"]} onChange={(value) => updateConfig("commercial-mode", value)} />
+        </ConfigField>
+        <ConfigField label="WebSocket Authentication" description="Require authentication for WebSocket connections">
+          <Toggle enabled={config["ws-auth"]} onChange={(value) => updateConfig("ws-auth", value)} />
+        </ConfigField>
+        <ConfigField label="Disable Cooling" description="Disable cooldown between retry attempts">
+          <Toggle enabled={config["disable-cooling"] ?? false} onChange={(value) => updateConfig("disable-cooling", value)} />
+        </ConfigField>
+        <ConfigField label="Request Log" description="Log all incoming requests">
+          <Toggle enabled={config["request-log"] ?? false} onChange={(value) => updateConfig("request-log", value)} />
+        </ConfigField>
+        <ConfigField label="Passthrough Headers" description="Forward client headers to upstream providers">
+          <Toggle enabled={config["passthrough-headers"] ?? false} onChange={(value) => updateConfig("passthrough-headers", value)} />
+        </ConfigField>
+        <ConfigField label="Incognito Browser" description="Use incognito mode for browser-based OAuth flows">
+          <Toggle enabled={config["incognito-browser"] ?? false} onChange={(value) => updateConfig("incognito-browser", value)} />
+        </ConfigField>
+      </div>
+    </section>
+  );
+}
+
+export function StreamingSection({ config, updateStreamingConfig }: Pick<CoreSettingsProps, "config" | "updateStreamingConfig">) {
+  return (
+    <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
+      <SectionHeader title="Streaming" />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <ConfigField label="Keepalive Seconds" description="SSE keepalive interval in seconds">
+          <Input type="number" name="keepalive-seconds" value={String(config.streaming["keepalive-seconds"])} onChange={(value) => updateStreamingConfig("keepalive-seconds", Number(value))} className="font-mono" />
+        </ConfigField>
+        <ConfigField label="Bootstrap Retries" description="Number of bootstrap retry attempts">
+          <Input type="number" name="bootstrap-retries" value={String(config.streaming["bootstrap-retries"])} onChange={(value) => updateStreamingConfig("bootstrap-retries", Number(value))} className="font-mono" />
+        </ConfigField>
+        <ConfigField label="Non-Stream Keepalive Interval" description="Emit blank lines every N seconds for non-streaming responses to prevent idle timeouts (0 = disabled)">
+          <Input type="number" name="nonstream-keepalive-interval" value={String(config.streaming["nonstream-keepalive-interval"] ?? 0)} onChange={(value) => updateStreamingConfig("nonstream-keepalive-interval", Number(value))} className="font-mono" />
+        </ConfigField>
+      </div>
+    </section>
+  );
+}
+
+export function RetryResilienceSection({ config, updateConfig, updateQuotaConfig, updateRoutingConfig }: CoreSettingsProps) {
+  return (
+    <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
+      <SectionHeader title="Retry & Resilience" />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <ConfigField label="Request Retry Attempts" description="Maximum number of retry attempts for failed requests">
+          <Input type="number" name="request-retry" value={String(config["request-retry"])} onChange={(value) => updateConfig("request-retry", Number(value))} className="font-mono" />
+        </ConfigField>
+        <ConfigField label="Max Retry Interval (seconds)" description="Maximum interval between retry attempts">
+          <Input type="number" name="max-retry-interval" value={String(config["max-retry-interval"])} onChange={(value) => updateConfig("max-retry-interval", Number(value))} className="font-mono" />
+        </ConfigField>
+        <ConfigField label="Routing Strategy" description="Load balancing strategy for multiple providers">
+          <Select
+            value={config.routing.strategy}
+            onChange={(value) => updateRoutingConfig("strategy", value)}
+            options={[
+              { value: "round-robin", label: "Round Robin" },
+              { value: "random", label: "Random" },
+              { value: "least-loaded", label: "Least Loaded" },
+            ]}
+          />
+        </ConfigField>
+        <ConfigField label="Switch Project on Quota Exceeded" description="Automatically switch to another project when quota is exceeded">
+          <Toggle enabled={config["quota-exceeded"]["switch-project"]} onChange={(value) => updateQuotaConfig("switch-project", value)} />
+        </ConfigField>
+        <ConfigField label="Switch Preview Model on Quota Exceeded" description="Fall back to preview models when quota is exceeded">
+          <Toggle enabled={config["quota-exceeded"]["switch-preview-model"]} onChange={(value) => updateQuotaConfig("switch-preview-model", value)} />
+        </ConfigField>
+        <ConfigField label="Max Retry Credentials" description="Maximum credential rotation retries (0 = disabled)">
+          <Input type="number" name="max-retry-credentials" value={String(config["max-retry-credentials"] ?? 0)} onChange={(value) => updateConfig("max-retry-credentials", Number(value))} className="font-mono" />
+        </ConfigField>
+      </div>
+    </section>
+  );
+}
+
+export function LoggingSection({ config, updateConfig }: Pick<CoreSettingsProps, "config" | "updateConfig">) {
+  return (
+    <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
+      <SectionHeader title="Logging" />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <ConfigField label="Logging to File" description="Enable persistent file-based logging">
+          <Toggle enabled={config["logging-to-file"]} onChange={(value) => updateConfig("logging-to-file", value)} />
+        </ConfigField>
+        <ConfigField label="Usage Statistics" description="Collect anonymous usage statistics">
+          <Toggle enabled={config["usage-statistics-enabled"]} onChange={(value) => updateConfig("usage-statistics-enabled", value)} />
+        </ConfigField>
+        <ConfigField label="Max Total Log Size (MB)" description="Maximum total size of all log files (0 = unlimited)">
+          <Input type="number" name="logs-max-total-size-mb" value={String(config["logs-max-total-size-mb"])} onChange={(value) => updateConfig("logs-max-total-size-mb", Number(value))} className="font-mono" />
+        </ConfigField>
+        <ConfigField label="Max Error Log Files" description="Maximum number of error log files to retain">
+          <Input type="number" name="error-logs-max-files" value={String(config["error-logs-max-files"])} onChange={(value) => updateConfig("error-logs-max-files", Number(value))} className="font-mono" />
+        </ConfigField>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/src/app/dashboard/config/_components/oauth-payload-settings.tsx
+++ b/dashboard/src/app/dashboard/config/_components/oauth-payload-settings.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { SectionHeader, ConfigField } from "./config-form-controls";
+import type { Config, OAuthModelAliasEntry, PayloadConfig } from "./config-types";
+
+interface OAuthAliasProps {
+  config: Config;
+  updateOAuthAliasEntry: (provider: string, index: number, field: keyof OAuthModelAliasEntry, value: string | boolean) => void;
+  addOAuthAliasEntry: (provider: string) => void;
+  removeOAuthAliasEntry: (provider: string, index: number) => void;
+}
+
+export function OAuthAliasesSection({ config, updateOAuthAliasEntry, addOAuthAliasEntry, removeOAuthAliasEntry }: OAuthAliasProps) {
+  const [expandedProviders, setExpandedProviders] = useState<Record<string, boolean>>({});
+
+  const toggleProviderExpanded = (provider: string) => {
+    setExpandedProviders((prev) => ({ ...prev, [provider]: !prev[provider] }));
+  };
+
+  return (
+    <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
+      <SectionHeader title="OAuth Model Aliases" />
+      <p className="text-xs text-slate-500">Override model names for OAuth providers. Each provider has a list of model name mappings.</p>
+      <div className="space-y-3">
+        {Object.keys(config["oauth-model-alias"] ?? {}).length === 0 && (
+          <p className="text-xs text-slate-500 italic">No OAuth model aliases configured.</p>
+        )}
+        {Object.entries(config["oauth-model-alias"] ?? {}).map(([provider, entries]) => (
+          <div key={provider} className="rounded-sm border border-slate-700/50 bg-slate-900/40">
+            <button
+              type="button"
+              onClick={() => toggleProviderExpanded(provider)}
+              className="flex w-full items-center justify-between px-4 py-3 text-left text-sm font-semibold text-slate-200 hover:bg-slate-800/30 transition-colors"
+            >
+              <span>{provider}</span>
+              <span className="text-slate-400 text-xs">
+                {entries.length} {entries.length === 1 ? "alias" : "aliases"}
+                <span className="ml-2">{expandedProviders[provider] ? "▲" : "▼"}</span>
+              </span>
+            </button>
+            {expandedProviders[provider] && (
+              <div className="border-t border-slate-700/50 p-4 space-y-3">
+                {entries.length > 0 && (
+                  <div className="grid grid-cols-[1fr_1fr_auto_auto] gap-2 text-xs font-semibold text-slate-400 uppercase tracking-wide pb-1 border-b border-slate-700/30">
+                    <span>Name</span>
+                    <span>Alias</span>
+                    <span>Fork</span>
+                    <span></span>
+                  </div>
+                )}
+                {entries.map((entry, index) => (
+                  <div key={index} className="grid grid-cols-[1fr_1fr_auto_auto] gap-2 items-center">
+                    <input
+                      type="text"
+                      value={entry.name}
+                      onChange={(e) => updateOAuthAliasEntry(provider, index, "name", e.target.value)}
+                      placeholder="model-name"
+                      className="rounded-sm border border-slate-700/70 bg-slate-900/50 px-2 py-1 text-xs text-slate-200 font-mono focus:outline-none focus:border-blue-400/50 focus:ring-1 focus:ring-blue-400/30"
+                    />
+                    <input
+                      type="text"
+                      value={entry.alias}
+                      onChange={(e) => updateOAuthAliasEntry(provider, index, "alias", e.target.value)}
+                      placeholder="alias-name"
+                      className="rounded-sm border border-slate-700/70 bg-slate-900/50 px-2 py-1 text-xs text-slate-200 font-mono focus:outline-none focus:border-blue-400/50 focus:ring-1 focus:ring-blue-400/30"
+                    />
+                    <input
+                      type="checkbox"
+                      checked={entry.fork ?? false}
+                      onChange={(e) => updateOAuthAliasEntry(provider, index, "fork", e.target.checked)}
+                      className="size-4 rounded accent-emerald-500"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removeOAuthAliasEntry(provider, index)}
+                      className="flex size-6 items-center justify-center rounded text-slate-500 hover:text-rose-400 hover:bg-rose-500/10 transition-colors"
+                      title="Remove entry"
+                    >
+                      <svg viewBox="0 0 16 16" fill="currentColor" className="size-3.5">
+                        <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+                      </svg>
+                    </button>
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => addOAuthAliasEntry(provider)}
+                  className="mt-1 flex items-center gap-1.5 rounded-sm border border-dashed border-slate-600/60 px-3 py-1.5 text-xs text-slate-400 hover:border-blue-400/50 hover:text-blue-400 transition-colors"
+                >
+                  <svg viewBox="0 0 16 16" fill="currentColor" className="size-3">
+                    <path d="M7.75 2a.75.75 0 0 1 .75.75V7h4.25a.75.75 0 0 1 0 1.5H8.5v4.25a.75.75 0 0 1-1.5 0V8.5H2.75a.75.75 0 0 1 0-1.5H7V2.75A.75.75 0 0 1 7.75 2Z" />
+                  </svg>
+                  Add entry
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+interface PayloadSectionProps {
+  config: Config;
+  updatePayloadConfig: (key: keyof PayloadConfig, value: unknown) => void;
+}
+
+export function PayloadSection({ config, updatePayloadConfig }: PayloadSectionProps) {
+  return (
+    <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
+      <SectionHeader title="Payload Manipulation" />
+      <p className="text-xs text-slate-500">Override or filter request payloads sent to upstream providers. Values are JSON.</p>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {(["default", "default-raw", "override", "override-raw", "filter"] as const).map((key) => (
+          <ConfigField
+            key={key}
+            label={key}
+            description={
+              key === "default" ? "Default payload fields merged into every request" :
+              key === "default-raw" ? "Raw default payload (overrides default)" :
+              key === "override" ? "Payload fields that override request values" :
+              key === "override-raw" ? "Raw override payload (overrides override)" :
+              "Fields to filter/remove from requests"
+            }
+          >
+            <textarea
+              value={
+                config.payload?.[key] == null
+                  ? ""
+                  : typeof config.payload[key] === "string"
+                    ? (config.payload[key] as string)
+                    : JSON.stringify(config.payload[key], null, 2)
+              }
+              onChange={(e) => {
+                const raw = e.target.value;
+                if (raw.trim() === "") {
+                  updatePayloadConfig(key, null);
+                  return;
+                }
+                try {
+                  updatePayloadConfig(key, JSON.parse(raw));
+                } catch {
+                  updatePayloadConfig(key, raw);
+                }
+              }}
+              placeholder="null"
+              spellCheck={false}
+              className="h-28 w-full rounded-sm border border-slate-700/70 bg-slate-900/40 p-3 font-mono text-xs text-slate-200 focus:border-blue-400/50 focus:outline-none focus:ring-1 focus:ring-blue-400/30 transition-colors resize-y"
+            />
+          </ConfigField>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+interface RawJsonSectionProps {
+  rawJson: string;
+  showAdvanced: boolean;
+  setShowAdvanced: (value: boolean) => void;
+}
+
+export function RawJsonSection({ rawJson, showAdvanced, setShowAdvanced }: RawJsonSectionProps) {
+  return (
+    <section className="space-y-3 rounded-md border border-rose-500/40 bg-rose-500/5 p-4">
+      <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-center">
+        <SectionHeader title="Advanced: Raw JSON Editor" />
+        <Button variant="ghost" onClick={() => setShowAdvanced(!showAdvanced)} className="text-xs">
+          {showAdvanced ? "Hide" : "Show"} Raw JSON
+        </Button>
+      </div>
+      {showAdvanced && (
+        <div className="space-y-4">
+          <div className="rounded-sm border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-200">
+            <strong>Warning:</strong>{" "}
+            <span>
+              This section shows the complete configuration including fields managed on other pages.
+              Only edit this if you know what you&apos;re doing. Changes here will NOT be saved from this editor.
+            </span>
+          </div>
+          <textarea
+            value={rawJson}
+            readOnly
+            className="h-96 w-full rounded-sm border border-slate-700/70 bg-slate-900/40 p-4 font-mono text-xs text-slate-200 focus:border-blue-400/50 focus:outline-none"
+            spellCheck={false}
+          />
+          <p className="text-xs text-slate-500">
+            This is a read-only view of the full configuration. Use the structured forms above to make changes.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/dashboard/src/app/dashboard/config/page.tsx
+++ b/dashboard/src/app/dashboard/config/page.tsx
@@ -2,194 +2,23 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/toast";
 import yaml from "js-yaml";
-
-// Config shape (excluding fields managed elsewhere)
-interface StreamingConfig {
-  "keepalive-seconds": number;
-  "bootstrap-retries": number;
-  "nonstream-keepalive-interval": number;
-}
-
-interface QuotaExceededConfig {
-  "switch-project": boolean;
-  "switch-preview-model": boolean;
-}
-
-interface RoutingConfig {
-  strategy: string;
-}
-
-interface TlsConfig {
-  enable: boolean;
-  cert: string;
-  key: string;
-}
-
-interface PprofConfig {
-  enable: boolean;
-  addr: string;
-}
-
-interface ClaudeHeaderDefaults {
-  "user-agent": string;
-  "package-version": string;
-  "runtime-version": string;
-  timeout: string;
-}
-
-interface AmpcodeConfig {
-  "upstream-url": string;
-  "upstream-api-key": string;
-  "restrict-management-to-localhost": boolean;
-  "model-mappings": unknown;
-  "force-model-mappings": boolean;
-}
-
-interface PayloadConfig {
-  default: unknown;
-  "default-raw": unknown;
-  override: unknown;
-  "override-raw": unknown;
-  filter: unknown;
-}
-
-interface OAuthModelAliasEntry {
-  name: string;
-  alias: string;
-  fork?: boolean;
-}
-
-interface Config {
-  "proxy-url": string;
-  "auth-dir": string;
-  "force-model-prefix": boolean;
-  streaming: StreamingConfig;
-  debug: boolean;
-  "commercial-mode": boolean;
-  "logging-to-file": boolean;
-  "logs-max-total-size-mb": number;
-  "error-logs-max-files": number;
-  "usage-statistics-enabled": boolean;
-  "request-retry": number;
-  "max-retry-interval": number;
-  "quota-exceeded": QuotaExceededConfig;
-  routing: RoutingConfig;
-  "ws-auth": boolean;
-  "disable-cooling": boolean;
-  "request-log": boolean;
-  "max-retry-credentials": number;
-  "passthrough-headers": boolean;
-  "incognito-browser": boolean;
-  "kiro-preferred-endpoint": string;
-  kiro: unknown;
-  tls: TlsConfig;
-  pprof: PprofConfig;
-  "claude-header-defaults": ClaudeHeaderDefaults;
-  ampcode: AmpcodeConfig;
-  payload: PayloadConfig;
-  "oauth-model-alias": Record<string, OAuthModelAliasEntry[]>;
-}
-
-// Toggle Switch Component
-function Toggle({ 
-  enabled, 
-  onChange, 
-  disabled = false 
-}: { 
-  enabled: boolean; 
-  onChange: (value: boolean) => void; 
-  disabled?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={enabled}
-      onClick={() => onChange(!enabled)}
-      disabled={disabled}
-      className={`
-        relative inline-flex h-7 w-12 shrink-0 cursor-pointer rounded-full
-        border-2 border-transparent transition-colors duration-200 ease-in-out
-        focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-transparent
-        disabled:cursor-not-allowed disabled:opacity-50
-        ${enabled ? 'bg-emerald-500' : 'bg-slate-700'}
-      `}
-    >
-      <span
-        className={`
-          pointer-events-none inline-block h-6 w-6 transform rounded-full
-          bg-white shadow-lg ring-0 transition duration-200 ease-in-out
-          ${enabled ? 'translate-x-5' : 'translate-x-0'}
-        `}
-      />
-    </button>
-  );
-}
-
-// Dropdown Select Component
-function Select({
-  value,
-  onChange,
-  options,
-  disabled = false
-}: {
-  value: string;
-  onChange: (value: string) => void;
-  options: Array<{ value: string; label: string }>;
-  disabled?: boolean;
-}) {
-  return (
-    <select
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      disabled={disabled}
-      className="
-        w-full rounded-sm border border-slate-700/70 bg-slate-900/50 px-3 py-2 text-sm
-        text-slate-200
-        focus:outline-none focus:border-blue-400/50 focus:ring-1 focus:ring-blue-400/30
-        disabled:opacity-50 disabled:cursor-not-allowed
-        transition-colors duration-200
-      "
-    >
-      {options.map((option) => (
-        <option key={option.value} value={option.value} className="bg-[#0f172a] text-slate-100">
-          {option.label}
-        </option>
-      ))}
-    </select>
-  );
-}
-
-// Section Header Component
-function SectionHeader({ title }: { title: string }) {
-  return (
-    <div className="mb-3">
-      <h3 className="text-sm font-semibold uppercase tracking-[0.08em] text-slate-400">{title}</h3>
-    </div>
-  );
-}
-
-// Config Field Component
-function ConfigField({
-  label,
-  description,
-  children
-}: {
-  label: string;
-  description?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="space-y-2">
-      <div className="block text-sm font-semibold text-slate-200">{label}</div>
-      {description && <p className="text-xs text-slate-500">{description}</p>}
-      <div>{children}</div>
-    </div>
-  );
-}
+import type {
+  Config,
+  StreamingConfig,
+  QuotaExceededConfig,
+  RoutingConfig,
+  TlsConfig,
+  PprofConfig,
+  ClaudeHeaderDefaults,
+  AmpcodeConfig,
+  PayloadConfig,
+  OAuthModelAliasEntry,
+} from "./_components/config-types";
+import { GeneralSettingsSection, StreamingSection, RetryResilienceSection, LoggingSection } from "./_components/core-settings";
+import { TlsSection, KiroSection, ClaudeHeadersSection, AmpcodeSection, PprofSection } from "./_components/advanced-settings";
+import { OAuthAliasesSection, PayloadSection, RawJsonSection } from "./_components/oauth-payload-settings";
 
 export default function ConfigPage() {
   const [config, setConfig] = useState<Config | null>(null);
@@ -198,7 +27,6 @@ export default function ConfigPage() {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [expandedProviders, setExpandedProviders] = useState<Record<string, boolean>>({});
   const { showToast } = useToast();
 
   const hasUnsavedChanges = config && originalConfig && JSON.stringify(config) !== JSON.stringify(originalConfig);
@@ -214,7 +42,6 @@ export default function ConfigPage() {
       }
 
       const data = await res.json();
-      // Ensure auth-dir is always present (required by CLIProxyAPI v6.8.42+)
       if (!data["auth-dir"]) {
         data["auth-dir"] = "~/.cli-proxy-api";
       }
@@ -232,30 +59,23 @@ export default function ConfigPage() {
     const timeoutId = window.setTimeout(() => {
       void fetchConfig();
     }, 0);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
+    return () => { window.clearTimeout(timeoutId); };
   }, [fetchConfig]);
 
   const handleSave = async () => {
     if (!config) return;
-
     setSaving(true);
-
     try {
       const res = await fetch("/api/management/config.yaml", {
         method: "PUT",
         headers: { "Content-Type": "text/yaml" },
         body: yaml.dump(config, { lineWidth: -1, noRefs: true }),
       });
-
       if (!res.ok) {
         showToast("Failed to save configuration", "error");
         setSaving(false);
         return;
       }
-
       showToast("Configuration saved successfully", "success");
       setOriginalConfig(config);
       setRawJson(JSON.stringify(config, null, 2));
@@ -267,11 +87,10 @@ export default function ConfigPage() {
   };
 
   const handleDiscard = () => {
-    if (originalConfig) {
-      setConfig(originalConfig);
-      setRawJson(JSON.stringify(originalConfig, null, 2));
-      showToast("Changes discarded", "info");
-    }
+    if (!originalConfig) return;
+    setConfig(originalConfig);
+    setRawJson(JSON.stringify(originalConfig, null, 2));
+    showToast("Changes discarded", "info");
   };
 
   const updateConfig = <K extends keyof Config>(key: K, value: Config[K]) => {
@@ -281,35 +100,17 @@ export default function ConfigPage() {
 
   const updateStreamingConfig = (key: keyof StreamingConfig, value: number) => {
     if (!config) return;
-    setConfig({
-      ...config,
-      streaming: {
-        ...config.streaming,
-        [key]: value,
-      },
-    });
+    setConfig({ ...config, streaming: { ...config.streaming, [key]: value } });
   };
 
   const updateQuotaConfig = (key: keyof QuotaExceededConfig, value: boolean) => {
     if (!config) return;
-    setConfig({
-      ...config,
-      "quota-exceeded": {
-        ...config["quota-exceeded"],
-        [key]: value,
-      },
-    });
+    setConfig({ ...config, "quota-exceeded": { ...config["quota-exceeded"], [key]: value } });
   };
 
   const updateRoutingConfig = (key: keyof RoutingConfig, value: string) => {
     if (!config) return;
-    setConfig({
-      ...config,
-      routing: {
-        ...config.routing,
-        [key]: value,
-      },
-    });
+    setConfig({ ...config, routing: { ...config.routing, [key]: value } });
   };
 
   const updateTlsConfig = (key: keyof TlsConfig, value: string | boolean) => {
@@ -337,10 +138,6 @@ export default function ConfigPage() {
     setConfig({ ...config, payload: { ...config.payload, [key]: value } });
   };
 
-  const toggleProviderExpanded = (provider: string) => {
-    setExpandedProviders((prev) => ({ ...prev, [provider]: !prev[provider] }));
-  };
-
   const updateOAuthAliasEntry = (
     provider: string,
     index: number,
@@ -351,30 +148,21 @@ export default function ConfigPage() {
     const aliases = config["oauth-model-alias"] ?? {};
     const entries = [...(aliases[provider] ?? [])];
     entries[index] = { ...entries[index], [field]: value };
-    setConfig({
-      ...config,
-      "oauth-model-alias": { ...aliases, [provider]: entries },
-    });
+    setConfig({ ...config, "oauth-model-alias": { ...aliases, [provider]: entries } });
   };
 
   const addOAuthAliasEntry = (provider: string) => {
     if (!config) return;
     const aliases = config["oauth-model-alias"] ?? {};
     const entries = [...(aliases[provider] ?? []), { name: "", alias: "" }];
-    setConfig({
-      ...config,
-      "oauth-model-alias": { ...aliases, [provider]: entries },
-    });
+    setConfig({ ...config, "oauth-model-alias": { ...aliases, [provider]: entries } });
   };
 
   const removeOAuthAliasEntry = (provider: string, index: number) => {
     if (!config) return;
     const aliases = config["oauth-model-alias"] ?? {};
     const entries = (aliases[provider] ?? []).filter((_, i) => i !== index);
-    setConfig({
-      ...config,
-      "oauth-model-alias": { ...aliases, [provider]: entries },
-    });
+    setConfig({ ...config, "oauth-model-alias": { ...aliases, [provider]: entries } });
   };
 
   if (loading) {
@@ -403,9 +191,7 @@ export default function ConfigPage() {
         </section>
         <div className="rounded-md border border-slate-700/70 bg-slate-900/25 p-4 text-center">
           <p className="text-slate-300">Failed to load configuration</p>
-          <Button onClick={fetchConfig} className="mt-4 px-2.5 py-1 text-xs">
-            Retry
-          </Button>
+          <Button onClick={fetchConfig} className="mt-4 px-2.5 py-1 text-xs">Retry</Button>
         </div>
       </div>
     );
@@ -422,692 +208,41 @@ export default function ConfigPage() {
             </p>
           </div>
           <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap">
-          {hasUnsavedChanges && (
-            <>
-              <span className="flex items-center gap-2 rounded-sm border border-amber-500/40 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-300">
-                <span className="size-1.5 rounded-full bg-amber-400"></span>
-                Unsaved changes
-              </span>
-              <Button variant="ghost" onClick={handleDiscard} disabled={saving} className="px-2.5 py-1 text-xs">
-                Discard Changes
-              </Button>
-            </>
-          )}
-          <Button onClick={handleSave} disabled={saving || !hasUnsavedChanges} className="px-2.5 py-1 text-xs">
-            {saving ? "Saving..." : "Save Changes"}
-          </Button>
+            {hasUnsavedChanges && (
+              <>
+                <span className="flex items-center gap-2 rounded-sm border border-amber-500/40 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-300">
+                  <span className="size-1.5 rounded-full bg-amber-400"></span>
+                  Unsaved changes
+                </span>
+                <Button variant="ghost" onClick={handleDiscard} disabled={saving} className="px-2.5 py-1 text-xs">
+                  Discard Changes
+                </Button>
+              </>
+            )}
+            <Button onClick={handleSave} disabled={saving || !hasUnsavedChanges} className="px-2.5 py-1 text-xs">
+              {saving ? "Saving..." : "Save Changes"}
+            </Button>
           </div>
         </div>
       </section>
 
       <div className="rounded-sm border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-200">
         <strong>Warning:</strong>{" "}
-        <span>
-          Invalid configuration may prevent the service from starting. Review changes carefully before saving.
-        </span>
+        <span>Invalid configuration may prevent the service from starting. Review changes carefully before saving.</span>
       </div>
 
-      {/* General Settings */}
-      <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
-        <SectionHeader title="General Settings" />
-           <div className="grid gap-4 sm:grid-cols-2">
-              <ConfigField
-                label="Upstream Proxy"
-               description="Optional SOCKS5/HTTP/HTTPS proxy for outbound requests to AI providers. Leave empty for direct connection."
-             >
-               <Input
-                 type="text"
-                 name="proxy-url"
-                 value={config["proxy-url"]}
-                 onChange={(value) => updateConfig("proxy-url", value)}
-                 placeholder="socks5://proxy:1080 or http://proxy:8080"
-                 className="font-mono"
-               />
-             </ConfigField>
-
-             <ConfigField
-               label="Force Model Prefix"
-               description="Require model names to include a provider prefix"
-             >
-               <Toggle
-                 enabled={config["force-model-prefix"]}
-                 onChange={(value) => updateConfig("force-model-prefix", value)}
-               />
-             </ConfigField>
-
-             <ConfigField
-               label="Debug Mode"
-               description="Enable verbose debug logging"
-             >
-               <Toggle
-                 enabled={config.debug}
-                 onChange={(value) => updateConfig("debug", value)}
-               />
-             </ConfigField>
-
-            <ConfigField
-              label="Commercial Mode"
-              description="Enable commercial features and licensing"
-            >
-              <Toggle
-                enabled={config["commercial-mode"]}
-                onChange={(value) => updateConfig("commercial-mode", value)}
-              />
-            </ConfigField>
-
-            <ConfigField
-              label="WebSocket Authentication"
-              description="Require authentication for WebSocket connections"
-            >
-              <Toggle
-                enabled={config["ws-auth"]}
-                onChange={(value) => updateConfig("ws-auth", value)}
-              />
-            </ConfigField>
-
-            <ConfigField
-              label="Disable Cooling"
-              description="Disable cooldown between retry attempts"
-            >
-              <Toggle
-                enabled={config["disable-cooling"] ?? false}
-                onChange={(value) => updateConfig("disable-cooling", value)}
-              />
-            </ConfigField>
-
-            <ConfigField
-              label="Request Log"
-              description="Log all incoming requests"
-            >
-              <Toggle
-                enabled={config["request-log"] ?? false}
-                onChange={(value) => updateConfig("request-log", value)}
-              />
-            </ConfigField>
-
-            <ConfigField
-              label="Passthrough Headers"
-              description="Forward client headers to upstream providers"
-            >
-              <Toggle
-                enabled={config["passthrough-headers"] ?? false}
-                onChange={(value) => updateConfig("passthrough-headers", value)}
-              />
-            </ConfigField>
-
-            <ConfigField
-              label="Incognito Browser"
-              description="Use incognito mode for browser-based OAuth flows"
-            >
-              <Toggle
-                enabled={config["incognito-browser"] ?? false}
-                onChange={(value) => updateConfig("incognito-browser", value)}
-              />
-            </ConfigField>
-          </div>
-      </section>
-
-      {/* Streaming Settings */}
-      <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
-        <SectionHeader title="Streaming" />
-           <div className="grid gap-4 sm:grid-cols-2">
-             <ConfigField
-               label="Keepalive Seconds"
-              description="SSE keepalive interval in seconds"
-            >
-              <Input
-                type="number"
-                name="keepalive-seconds"
-                value={String(config.streaming["keepalive-seconds"])}
-                onChange={(value) =>
-                  updateStreamingConfig("keepalive-seconds", Number(value))
-                }
-                className="font-mono"
-              />
-            </ConfigField>
-
-             <ConfigField
-               label="Bootstrap Retries"
-               description="Number of bootstrap retry attempts"
-             >
-               <Input
-                 type="number"
-                 name="bootstrap-retries"
-                 value={String(config.streaming["bootstrap-retries"])}
-                 onChange={(value) =>
-                   updateStreamingConfig("bootstrap-retries", Number(value))
-                 }
-                 className="font-mono"
-               />
-             </ConfigField>
-
-             <ConfigField
-               label="Non-Stream Keepalive Interval"
-               description="Emit blank lines every N seconds for non-streaming responses to prevent idle timeouts (0 = disabled)"
-             >
-               <Input
-                 type="number"
-                 name="nonstream-keepalive-interval"
-                 value={String(config.streaming["nonstream-keepalive-interval"] ?? 0)}
-                 onChange={(value) =>
-                   updateStreamingConfig("nonstream-keepalive-interval", Number(value))
-                 }
-                 className="font-mono"
-               />
-             </ConfigField>
-           </div>
-      </section>
-
-      {/* Retry & Resilience */}
-      <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
-        <SectionHeader title="Retry & Resilience" />
-           <div className="grid gap-4 sm:grid-cols-2">
-             <ConfigField
-               label="Request Retry Attempts"
-              description="Maximum number of retry attempts for failed requests"
-            >
-              <Input
-                type="number"
-                name="request-retry"
-                value={String(config["request-retry"])}
-                onChange={(value) => updateConfig("request-retry", Number(value))}
-                className="font-mono"
-              />
-            </ConfigField>
-
-            <ConfigField
-              label="Max Retry Interval (seconds)"
-              description="Maximum interval between retry attempts"
-            >
-              <Input
-                type="number"
-                name="max-retry-interval"
-                value={String(config["max-retry-interval"])}
-                onChange={(value) => updateConfig("max-retry-interval", Number(value))}
-                className="font-mono"
-              />
-            </ConfigField>
-
-             <ConfigField
-               label="Routing Strategy"
-               description="Load balancing strategy for multiple providers"
-             >
-               <Select
-                 value={config.routing.strategy}
-                 onChange={(value) => updateRoutingConfig("strategy", value)}
-                 options={[
-                   { value: "round-robin", label: "Round Robin" },
-                   { value: "random", label: "Random" },
-                   { value: "least-loaded", label: "Least Loaded" },
-                 ]}
-               />
-             </ConfigField>
-
-             <ConfigField
-               label="Switch Project on Quota Exceeded"
-               description="Automatically switch to another project when quota is exceeded"
-             >
-               <Toggle
-                 enabled={config["quota-exceeded"]["switch-project"]}
-                 onChange={(value) =>
-                   updateQuotaConfig("switch-project", value)
-                 }
-               />
-             </ConfigField>
-
-            <ConfigField
-              label="Switch Preview Model on Quota Exceeded"
-              description="Fall back to preview models when quota is exceeded"
-            >
-              <Toggle
-                enabled={config["quota-exceeded"]["switch-preview-model"]}
-                onChange={(value) =>
-                  updateQuotaConfig("switch-preview-model", value)
-                }
-              />
-            </ConfigField>
-
-            <ConfigField
-              label="Max Retry Credentials"
-              description="Maximum credential rotation retries (0 = disabled)"
-            >
-              <Input
-                type="number"
-                name="max-retry-credentials"
-                value={String(config["max-retry-credentials"] ?? 0)}
-                onChange={(value) => updateConfig("max-retry-credentials", Number(value))}
-                className="font-mono"
-              />
-            </ConfigField>
-          </div>
-      </section>
-
-      {/* Logging */}
-      <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
-        <SectionHeader title="Logging" />
-           <div className="grid gap-4 sm:grid-cols-2">
-             <ConfigField
-               label="Logging to File"
-              description="Enable persistent file-based logging"
-            >
-              <Toggle
-                enabled={config["logging-to-file"]}
-                onChange={(value) => updateConfig("logging-to-file", value)}
-              />
-            </ConfigField>
-
-            <ConfigField
-              label="Usage Statistics"
-              description="Collect anonymous usage statistics"
-            >
-              <Toggle
-                enabled={config["usage-statistics-enabled"]}
-                onChange={(value) => updateConfig("usage-statistics-enabled", value)}
-              />
-            </ConfigField>
-
-            <ConfigField
-              label="Max Total Log Size (MB)"
-              description="Maximum total size of all log files (0 = unlimited)"
-            >
-              <Input
-                type="number"
-                name="logs-max-total-size-mb"
-                value={String(config["logs-max-total-size-mb"])}
-                onChange={(value) => updateConfig("logs-max-total-size-mb", Number(value))}
-                className="font-mono"
-              />
-            </ConfigField>
-
-            <ConfigField
-              label="Max Error Log Files"
-              description="Maximum number of error log files to retain"
-            >
-              <Input
-                type="number"
-                name="error-logs-max-files"
-                value={String(config["error-logs-max-files"])}
-                onChange={(value) => updateConfig("error-logs-max-files", Number(value))}
-                className="font-mono"
-              />
-            </ConfigField>
-          </div>
-      </section>
-
-      {/* TLS / HTTPS */}
-      <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
-        <SectionHeader title="TLS / HTTPS" />
-        <div className="rounded-sm border border-slate-600/40 bg-slate-800/30 p-3 text-xs text-slate-400">
-          TLS is typically handled by Caddy reverse proxy. Only configure this for direct TLS termination.
-        </div>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <ConfigField
-            label="Enable TLS"
-            description="Enable TLS"
-          >
-            <Toggle
-              enabled={config.tls?.enable ?? false}
-              onChange={(value) => updateTlsConfig("enable", value)}
-            />
-          </ConfigField>
-
-          <ConfigField
-            label="Certificate Path"
-            description="Path to TLS certificate file"
-          >
-            <Input
-              type="text"
-              name="tls-cert"
-              value={config.tls?.cert ?? ""}
-              onChange={(value) => updateTlsConfig("cert", value)}
-              placeholder="/path/to/cert.pem"
-              className="font-mono"
-            />
-          </ConfigField>
-
-          <ConfigField
-            label="Private Key Path"
-            description="Path to TLS private key file"
-          >
-            <Input
-              type="text"
-              name="tls-key"
-              value={config.tls?.key ?? ""}
-              onChange={(value) => updateTlsConfig("key", value)}
-              placeholder="/path/to/key.pem"
-              className="font-mono"
-            />
-          </ConfigField>
-        </div>
-      </section>
-
-      {/* Kiro */}
-      <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
-        <SectionHeader title="Kiro" />
-        <div className="grid gap-4 sm:grid-cols-2">
-          <ConfigField
-            label="Preferred Endpoint"
-            description="Preferred Kiro API endpoint URL"
-          >
-            <Input
-              type="text"
-              name="kiro-preferred-endpoint"
-              value={config["kiro-preferred-endpoint"] ?? ""}
-              onChange={(value) => updateConfig("kiro-preferred-endpoint", value)}
-              placeholder="https://..."
-              className="font-mono"
-            />
-          </ConfigField>
-        </div>
-      </section>
-
-      {/* Claude Header Defaults */}
-      <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
-        <SectionHeader title="Claude Header Defaults" />
-        <p className="text-xs text-slate-500">Custom headers sent with all Claude API requests</p>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <ConfigField
-            label="User-Agent"
-            description="Custom User-Agent header"
-          >
-            <Input
-              type="text"
-              name="claude-header-user-agent"
-              value={config["claude-header-defaults"]?.["user-agent"] ?? ""}
-              onChange={(value) => updateClaudeHeaderDefaults("user-agent", value)}
-              className="font-mono"
-            />
-          </ConfigField>
-
-          <ConfigField
-            label="Package Version"
-            description="Package version header"
-          >
-            <Input
-              type="text"
-              name="claude-header-package-version"
-              value={config["claude-header-defaults"]?.["package-version"] ?? ""}
-              onChange={(value) => updateClaudeHeaderDefaults("package-version", value)}
-              className="font-mono"
-            />
-          </ConfigField>
-
-          <ConfigField
-            label="Runtime Version"
-            description="Runtime version header"
-          >
-            <Input
-              type="text"
-              name="claude-header-runtime-version"
-              value={config["claude-header-defaults"]?.["runtime-version"] ?? ""}
-              onChange={(value) => updateClaudeHeaderDefaults("runtime-version", value)}
-              className="font-mono"
-            />
-          </ConfigField>
-
-          <ConfigField
-            label="Timeout"
-            description="Request timeout header"
-          >
-            <Input
-              type="text"
-              name="claude-header-timeout"
-              value={config["claude-header-defaults"]?.["timeout"] ?? ""}
-              onChange={(value) => updateClaudeHeaderDefaults("timeout", value)}
-              className="font-mono"
-            />
-          </ConfigField>
-        </div>
-      </section>
-
-      {/* Amp Code */}
-      <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
-        <SectionHeader title="Amp Code" />
-        <p className="text-xs text-slate-500">Configuration for Amp Code upstream integration</p>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <ConfigField
-            label="Upstream URL"
-            description="Upstream Amp Code URL"
-          >
-            <Input
-              type="text"
-              name="ampcode-upstream-url"
-              value={config.ampcode?.["upstream-url"] ?? ""}
-              onChange={(value) => updateAmpcodeConfig("upstream-url", value)}
-              className="font-mono"
-            />
-          </ConfigField>
-
-          <ConfigField
-            label="Upstream API Key"
-            description="Upstream API key"
-          >
-            <Input
-              type="password"
-              name="ampcode-upstream-api-key"
-              value={config.ampcode?.["upstream-api-key"] ?? ""}
-              onChange={(value) => updateAmpcodeConfig("upstream-api-key", value)}
-              className="font-mono"
-            />
-          </ConfigField>
-
-          <ConfigField
-            label="Restrict Management to Localhost"
-            description="Restrict management API to localhost only"
-          >
-            <Toggle
-              enabled={config.ampcode?.["restrict-management-to-localhost"] ?? false}
-              onChange={(value) => updateAmpcodeConfig("restrict-management-to-localhost", value)}
-            />
-          </ConfigField>
-
-          <ConfigField
-            label="Force Model Mappings"
-            description="Force model mappings"
-          >
-            <Toggle
-              enabled={config.ampcode?.["force-model-mappings"] ?? false}
-              onChange={(value) => updateAmpcodeConfig("force-model-mappings", value)}
-            />
-          </ConfigField>
-        </div>
-      </section>
-
-      {/* Profiling (pprof) */}
-      <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
-        <SectionHeader title="Profiling (pprof)" />
-        <div className="rounded-sm border border-slate-600/40 bg-slate-800/30 p-3 text-xs text-slate-400">
-          Go runtime profiling. Only enable for debugging.
-        </div>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <ConfigField
-            label="Enable pprof"
-            description="Enable pprof endpoint"
-          >
-            <Toggle
-              enabled={config.pprof?.enable ?? false}
-              onChange={(value) => updatePprofConfig("enable", value)}
-            />
-          </ConfigField>
-
-          <ConfigField
-            label="Listen Address"
-            description="pprof listen address"
-          >
-            <Input
-              type="text"
-              name="pprof-addr"
-              value={config.pprof?.addr ?? ""}
-              onChange={(value) => updatePprofConfig("addr", value)}
-              placeholder="127.0.0.1:8316"
-              className="font-mono"
-            />
-          </ConfigField>
-        </div>
-      </section>
-
-      {/* OAuth Model Aliases */}
-      <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
-        <SectionHeader title="OAuth Model Aliases" />
-        <p className="text-xs text-slate-500">Override model names for OAuth providers. Each provider has a list of model name mappings.</p>
-        <div className="space-y-3">
-          {Object.keys(config["oauth-model-alias"] ?? {}).length === 0 && (
-            <p className="text-xs text-slate-500 italic">No OAuth model aliases configured.</p>
-          )}
-          {Object.entries(config["oauth-model-alias"] ?? {}).map(([provider, entries]) => (
-            <div key={provider} className="rounded-sm border border-slate-700/50 bg-slate-900/40">
-              <button
-                type="button"
-                onClick={() => toggleProviderExpanded(provider)}
-                className="flex w-full items-center justify-between px-4 py-3 text-left text-sm font-semibold text-slate-200 hover:bg-slate-800/30 transition-colors"
-              >
-                <span>{provider}</span>
-                <span className="text-slate-400 text-xs">
-                  {entries.length} {entries.length === 1 ? "alias" : "aliases"}
-                  <span className="ml-2">{expandedProviders[provider] ? "▲" : "▼"}</span>
-                </span>
-              </button>
-              {expandedProviders[provider] && (
-                <div className="border-t border-slate-700/50 p-4 space-y-3">
-                  {entries.length > 0 && (
-                    <div className="grid grid-cols-[1fr_1fr_auto_auto] gap-2 text-xs font-semibold text-slate-400 uppercase tracking-wide pb-1 border-b border-slate-700/30">
-                      <span>Name</span>
-                      <span>Alias</span>
-                      <span>Fork</span>
-                      <span></span>
-                    </div>
-                  )}
-                  {entries.map((entry, index) => (
-                    <div key={index} className="grid grid-cols-[1fr_1fr_auto_auto] gap-2 items-center">
-                      <input
-                        type="text"
-                        value={entry.name}
-                        onChange={(e) => updateOAuthAliasEntry(provider, index, "name", e.target.value)}
-                        placeholder="model-name"
-                        className="rounded-sm border border-slate-700/70 bg-slate-900/50 px-2 py-1 text-xs text-slate-200 font-mono focus:outline-none focus:border-blue-400/50 focus:ring-1 focus:ring-blue-400/30"
-                      />
-                      <input
-                        type="text"
-                        value={entry.alias}
-                        onChange={(e) => updateOAuthAliasEntry(provider, index, "alias", e.target.value)}
-                        placeholder="alias-name"
-                        className="rounded-sm border border-slate-700/70 bg-slate-900/50 px-2 py-1 text-xs text-slate-200 font-mono focus:outline-none focus:border-blue-400/50 focus:ring-1 focus:ring-blue-400/30"
-                      />
-                      <input
-                        type="checkbox"
-                        checked={entry.fork ?? false}
-                        onChange={(e) => updateOAuthAliasEntry(provider, index, "fork", e.target.checked)}
-                        className="size-4 rounded accent-emerald-500"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => removeOAuthAliasEntry(provider, index)}
-                        className="flex size-6 items-center justify-center rounded text-slate-500 hover:text-rose-400 hover:bg-rose-500/10 transition-colors"
-                        title="Remove entry"
-                      >
-                        <svg viewBox="0 0 16 16" fill="currentColor" className="size-3.5">
-                          <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
-                        </svg>
-                      </button>
-                    </div>
-                  ))}
-                  <button
-                    type="button"
-                    onClick={() => addOAuthAliasEntry(provider)}
-                    className="mt-1 flex items-center gap-1.5 rounded-sm border border-dashed border-slate-600/60 px-3 py-1.5 text-xs text-slate-400 hover:border-blue-400/50 hover:text-blue-400 transition-colors"
-                  >
-                    <svg viewBox="0 0 16 16" fill="currentColor" className="size-3">
-                      <path d="M7.75 2a.75.75 0 0 1 .75.75V7h4.25a.75.75 0 0 1 0 1.5H8.5v4.25a.75.75 0 0 1-1.5 0V8.5H2.75a.75.75 0 0 1 0-1.5H7V2.75A.75.75 0 0 1 7.75 2Z" />
-                    </svg>
-                    Add entry
-                  </button>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* Payload Manipulation */}
-      <section className="space-y-3 rounded-md border border-slate-700/70 bg-slate-900/25 p-4">
-        <SectionHeader title="Payload Manipulation" />
-        <p className="text-xs text-slate-500">Override or filter request payloads sent to upstream providers. Values are JSON.</p>
-        <div className="grid gap-4 sm:grid-cols-2">
-          {(["default", "default-raw", "override", "override-raw", "filter"] as const).map((key) => (
-            <ConfigField
-              key={key}
-              label={key}
-              description={
-                key === "default" ? "Default payload fields merged into every request" :
-                key === "default-raw" ? "Raw default payload (overrides default)" :
-                key === "override" ? "Payload fields that override request values" :
-                key === "override-raw" ? "Raw override payload (overrides override)" :
-                "Fields to filter/remove from requests"
-              }
-            >
-              <textarea
-                value={
-                  config.payload?.[key] == null
-                    ? ""
-                    : typeof config.payload[key] === "string"
-                      ? (config.payload[key] as string)
-                      : JSON.stringify(config.payload[key], null, 2)
-                }
-                onChange={(e) => {
-                  const raw = e.target.value;
-                  if (raw.trim() === "") {
-                    updatePayloadConfig(key, null);
-                    return;
-                  }
-                  try {
-                    updatePayloadConfig(key, JSON.parse(raw));
-                  } catch {
-                    // allow partial editing — update as raw string temporarily
-                    updatePayloadConfig(key, raw);
-                  }
-                }}
-                placeholder="null"
-                spellCheck={false}
-                className="h-28 w-full rounded-sm border border-slate-700/70 bg-slate-900/40 p-3 font-mono text-xs text-slate-200 focus:border-blue-400/50 focus:outline-none focus:ring-1 focus:ring-blue-400/30 transition-colors resize-y"
-              />
-            </ConfigField>
-          ))}
-        </div>
-      </section>
-
-      {/* Advanced: Raw JSON Editor */}
-      <section className="space-y-3 rounded-md border border-rose-500/40 bg-rose-500/5 p-4">
-            <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-center">
-              <SectionHeader title="Advanced: Raw JSON Editor" />
-              <Button
-                variant="ghost"
-                onClick={() => setShowAdvanced(!showAdvanced)}
-                className="text-xs"
-              >
-                {showAdvanced ? "Hide" : "Show"} Raw JSON
-              </Button>
-            </div>
-        {showAdvanced && (
-            <div className="space-y-4">
-              <div className="rounded-sm border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-200">
-                <strong>Warning:</strong>{" "}
-                <span>
-                  This section shows the complete configuration including fields managed on other pages.
-                  Only edit this if you know what you&apos;re doing. Changes here will NOT be saved from this editor.
-                </span>
-              </div>
-              <textarea
-                value={rawJson}
-                readOnly
-                className="h-96 w-full rounded-sm border border-slate-700/70 bg-slate-900/40 p-4 font-mono text-xs text-slate-200 focus:border-blue-400/50 focus:outline-none"
-                spellCheck={false}
-              />
-              <p className="text-xs text-slate-500">
-                This is a read-only view of the full configuration. Use the structured forms above to make changes.
-              </p>
-            </div>
-        )}
-      </section>
+      <GeneralSettingsSection config={config} updateConfig={updateConfig} />
+      <StreamingSection config={config} updateStreamingConfig={updateStreamingConfig} />
+      <RetryResilienceSection config={config} updateConfig={updateConfig} updateStreamingConfig={updateStreamingConfig} updateQuotaConfig={updateQuotaConfig} updateRoutingConfig={updateRoutingConfig} />
+      <LoggingSection config={config} updateConfig={updateConfig} />
+      <TlsSection config={config} updateTlsConfig={updateTlsConfig} />
+      <KiroSection config={config} updateConfig={updateConfig} />
+      <ClaudeHeadersSection config={config} updateClaudeHeaderDefaults={updateClaudeHeaderDefaults} />
+      <AmpcodeSection config={config} updateAmpcodeConfig={updateAmpcodeConfig} />
+      <PprofSection config={config} updatePprofConfig={updatePprofConfig} />
+      <OAuthAliasesSection config={config} updateOAuthAliasEntry={updateOAuthAliasEntry} addOAuthAliasEntry={addOAuthAliasEntry} removeOAuthAliasEntry={removeOAuthAliasEntry} />
+      <PayloadSection config={config} updatePayloadConfig={updatePayloadConfig} />
+      <RawJsonSection rawJson={rawJson} showAdvanced={showAdvanced} setShowAdvanced={setShowAdvanced} />
 
       <div className="rounded-sm border border-slate-700/70 bg-slate-900/25 p-4 text-xs text-slate-400">
         <strong>TIP:</strong> Changes are saved immediately to the management API. The service may need to be

--- a/dashboard/src/app/dashboard/quota/_components/quota-types.ts
+++ b/dashboard/src/app/dashboard/quota/_components/quota-types.ts
@@ -1,0 +1,88 @@
+export interface QuotaModel {
+  id: string;
+  displayName: string;
+  remainingFraction?: number | null;
+  resetTime: string | null;
+}
+
+export interface QuotaGroup {
+  id: string;
+  label: string;
+  remainingFraction?: number | null;
+  resetTime: string | null;
+  models: QuotaModel[];
+}
+
+export interface QuotaAccount {
+  auth_index: string;
+  provider: string;
+  email?: string | null;
+  supported: boolean;
+  error?: string;
+  groups?: QuotaGroup[];
+  raw?: unknown;
+}
+
+export interface QuotaResponse {
+  accounts: QuotaAccount[];
+}
+
+export const PROVIDERS = {
+  ALL: "all",
+  ANTIGRAVITY: "antigravity",
+  CLAUDE: "claude",
+  CODEX: "codex",
+  COPILOT: "github-copilot",
+  KIMI: "kimi",
+} as const;
+
+export type ProviderType = (typeof PROVIDERS)[keyof typeof PROVIDERS];
+
+export interface WindowCapacity {
+  id: string;
+  label: string;
+  capacity: number;
+  resetTime: string | null;
+  isShortTerm: boolean;
+}
+
+export interface ProviderSummary {
+  provider: string;
+  totalAccounts: number;
+  healthyAccounts: number;
+  errorAccounts: number;
+  windowCapacities: WindowCapacity[];
+}
+
+export interface TelegramSettings {
+  botToken: string;
+  chatId: string;
+  threshold: number;
+  enabled: boolean;
+  providers: string[];
+  checkInterval: number;
+  cooldown: number;
+}
+
+export interface CheckAlertResult {
+  checked?: boolean;
+  skipped?: boolean;
+  reason?: string;
+  alertsSent?: number;
+  breachedCount?: number;
+  accounts?: Array<{
+    provider: string;
+    account: string;
+    window: string;
+    capacity: number;
+    belowThreshold: boolean;
+  }>;
+}
+
+export const ALERT_PROVIDERS = [
+  { key: "claude", label: "Claude" },
+  { key: "antigravity", label: "Antigravity" },
+  { key: "codex", label: "Codex" },
+  { key: "github-copilot", label: "Copilot" },
+  { key: "kimi", label: "Kimi" },
+] as const;

--- a/dashboard/src/app/dashboard/quota/_components/quota-utils.ts
+++ b/dashboard/src/app/dashboard/quota/_components/quota-utils.ts
@@ -1,0 +1,196 @@
+import type { QuotaGroup, QuotaAccount, WindowCapacity, ProviderSummary } from "./quota-types";
+
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 3_600_000;
+const MS_PER_DAY = 86_400_000;
+
+const CAPACITY_HIGH_THRESHOLD = 0.6;
+const CAPACITY_LOW_THRESHOLD = 0.2;
+
+export function normalizeFraction(value: unknown): number | null {
+  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
+    return null;
+  }
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+export function maskEmail(email: unknown): string {
+  if (typeof email !== "string") return "unknown";
+  const trimmed = email.trim();
+  if (trimmed === "") return "unknown";
+
+  const atIndex = trimmed.indexOf("@");
+  if (atIndex <= 0 || atIndex === trimmed.length - 1) {
+    return trimmed;
+  }
+
+  const local = trimmed.slice(0, atIndex);
+  const domain = trimmed.slice(atIndex + 1);
+  const VISIBLE_CHARS = 3;
+  const maskedLocal = local.length <= VISIBLE_CHARS ? `${local}***` : `${local.slice(0, VISIBLE_CHARS)}***`;
+  return `${maskedLocal}@${domain}`;
+}
+
+export function formatRelativeTime(isoDate: string | null): string {
+  if (!isoDate) return "Unknown";
+
+  try {
+    const resetDate = new Date(isoDate);
+    const now = new Date();
+    const diffMs = resetDate.getTime() - now.getTime();
+
+    if (diffMs <= 0) return "Resetting...";
+
+    const days = Math.floor(diffMs / MS_PER_DAY);
+    const hours = Math.floor((diffMs % MS_PER_DAY) / MS_PER_HOUR);
+    const minutes = Math.floor((diffMs % MS_PER_HOUR) / MS_PER_MINUTE);
+
+    if (days > 0) return `Resets in ${days}d ${hours}h`;
+    if (hours > 0) return `Resets in ${hours}h ${minutes}m`;
+    return `Resets in ${minutes}m`;
+  } catch {
+    return "Unknown";
+  }
+}
+
+export function isShortTermGroup(group: QuotaGroup): boolean {
+  const id = group.id.toLowerCase();
+  const label = group.label.toLowerCase();
+  return (
+    id.includes("five-hour") ||
+    id.includes("primary") ||
+    id.includes("request") ||
+    id.includes("token") ||
+    label.includes("5h") ||
+    label.includes("5m") ||
+    label.includes("request") ||
+    label.includes("token")
+  );
+}
+
+export function calcAccountWindowScores(groups: QuotaGroup[]): Record<string, { score: number; label: string; isShortTerm: boolean }> {
+  const result: Record<string, { score: number; label: string; isShortTerm: boolean }> = {};
+  for (const group of groups) {
+    if (group.id === "extra-usage") continue;
+    const score = normalizeFraction(group.remainingFraction);
+    if (score === null) continue;
+    result[group.id] = { score, label: group.label, isShortTerm: isShortTermGroup(group) };
+  }
+  return result;
+}
+
+export function calcProviderSummary(accounts: QuotaAccount[]): ProviderSummary {
+  const totalAccounts = accounts.length;
+  const healthy = accounts.filter(
+    (a) => a.supported && !a.error && a.groups && a.groups.length > 0
+  );
+  const errorAccounts = totalAccounts - healthy.length;
+
+  const allWindowIds = new Set<string>();
+  for (const a of healthy) {
+    for (const g of a.groups ?? []) {
+      if (g.id !== "extra-usage") allWindowIds.add(g.id);
+    }
+  }
+
+  const windowCapacities: WindowCapacity[] = [];
+
+  for (const windowId of allWindowIds) {
+    const relevantAccounts = healthy.filter((a) =>
+      a.groups?.some((g) => g.id === windowId)
+    );
+    if (relevantAccounts.length === 0) continue;
+
+    const scores = relevantAccounts
+      .map((a) => {
+        const group = a.groups?.find((g) => g.id === windowId);
+        return normalizeFraction(group?.remainingFraction);
+      })
+      .filter((score): score is number => score !== null);
+
+    if (scores.length === 0) continue;
+
+    const exhaustedProduct = scores.reduce((prod, score) => prod * (1 - score), 1);
+    const capacity = 1 - exhaustedProduct;
+
+    let earliestReset: string | null = null;
+    let minResetTime = Infinity;
+    let label = "";
+    let shortTerm = false;
+
+    for (const a of relevantAccounts) {
+      const g = a.groups?.find((g) => g.id === windowId);
+      if (g) {
+        if (!label) {
+          label = g.label;
+          shortTerm = isShortTermGroup(g);
+        }
+        if (g.resetTime) {
+          const t = new Date(g.resetTime).getTime();
+          if (t < minResetTime) {
+            minResetTime = t;
+            earliestReset = g.resetTime;
+          }
+        }
+      }
+    }
+
+    windowCapacities.push({
+      id: windowId,
+      label,
+      capacity: Math.max(0, Math.min(1, capacity)),
+      resetTime: earliestReset,
+      isShortTerm: shortTerm,
+    });
+  }
+
+  windowCapacities.sort((a, b) => {
+    if (a.isShortTerm !== b.isShortTerm) return a.isShortTerm ? 1 : -1;
+    return a.label.localeCompare(b.label);
+  });
+
+  return {
+    provider: accounts[0]?.provider ?? "unknown",
+    totalAccounts,
+    healthyAccounts: healthy.length,
+    errorAccounts,
+    windowCapacities,
+  };
+}
+
+export function calcOverallCapacity(summaries: ProviderSummary[]): { value: number; label: string; provider: string } {
+  if (summaries.length === 0) return { value: 0, label: "No Data", provider: "" };
+
+  let weightedCapacity = 0;
+  let weightedAccounts = 0;
+
+  for (const summary of summaries) {
+    if (summary.healthyAccounts === 0) continue;
+
+    const longTerm = summary.windowCapacities.filter((w) => !w.isShortTerm);
+    const shortTerm = summary.windowCapacities.filter((w) => w.isShortTerm);
+    const relevantWindows = longTerm.length > 0 ? longTerm : shortTerm;
+
+    if (relevantWindows.length === 0) continue;
+
+    const providerCapacity = Math.min(...relevantWindows.map((w) => w.capacity));
+    weightedCapacity += providerCapacity * summary.healthyAccounts;
+    weightedAccounts += summary.healthyAccounts;
+  }
+
+  if (weightedAccounts === 0) return { value: 0, label: "No Data", provider: "" };
+
+  return {
+    value: weightedCapacity / weightedAccounts,
+    label: "Weighted capacity",
+    provider: "all",
+  };
+}
+
+export function getCapacityBarClass(value: number): string {
+  if (value > CAPACITY_HIGH_THRESHOLD) return "bg-emerald-500/80";
+  if (value > CAPACITY_LOW_THRESHOLD) return "bg-amber-500/80";
+  return "bg-rose-500/80";
+}

--- a/dashboard/src/app/dashboard/quota/_components/telegram-alerts-section.tsx
+++ b/dashboard/src/app/dashboard/quota/_components/telegram-alerts-section.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/toast";
+import { cn } from "@/lib/utils";
+import type { TelegramSettings, CheckAlertResult } from "./quota-types";
+import { ALERT_PROVIDERS } from "./quota-types";
+
+const DEFAULT_THRESHOLD = 20;
+const DEFAULT_CHECK_INTERVAL = 5;
+const DEFAULT_COOLDOWN = 60;
+const MIN_INTERVAL = 1;
+const MAX_INTERVAL = 1440;
+
+function parseSettings(data: Record<string, unknown>): TelegramSettings {
+  return {
+    botToken: (data.botToken as string) ?? "",
+    chatId: (data.chatId as string) ?? "",
+    threshold: (data.threshold as number) ?? DEFAULT_THRESHOLD,
+    enabled: (data.enabled as boolean) ?? false,
+    providers: Array.isArray(data.providers) ? data.providers : ALERT_PROVIDERS.map((p) => p.key),
+    checkInterval: (data.checkInterval as number) ?? DEFAULT_CHECK_INTERVAL,
+    cooldown: (data.cooldown as number) ?? DEFAULT_COOLDOWN,
+  };
+}
+
+export function TelegramAlertsSection() {
+  const { showToast } = useToast();
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [settings, setSettings] = useState<TelegramSettings>({
+    botToken: "",
+    chatId: "",
+    threshold: DEFAULT_THRESHOLD,
+    enabled: false,
+    providers: ALERT_PROVIDERS.map((p) => p.key),
+    checkInterval: DEFAULT_CHECK_INTERVAL,
+    cooldown: DEFAULT_COOLDOWN,
+  });
+  const [showToken, setShowToken] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [checkResult, setCheckResult] = useState<CheckAlertResult | null>(null);
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const meRes = await fetch("/api/auth/me");
+        if (!meRes.ok) return;
+        const meData = await meRes.json();
+        if (!meData.isAdmin) return;
+        setIsAdmin(true);
+
+        const res = await fetch("/api/admin/telegram");
+        if (res.ok) {
+          const data = await res.json();
+          setSettings(parseSettings(data));
+        }
+      } catch {
+        // non-admin users won't see the section
+      } finally {
+        setLoaded(true);
+      }
+    };
+    init();
+  }, []);
+
+  if (!loaded || !isAdmin) return null;
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const body: Record<string, unknown> = {
+        chatId: settings.chatId,
+        threshold: settings.threshold,
+        enabled: settings.enabled,
+        providers: settings.providers,
+        checkInterval: settings.checkInterval,
+        cooldown: settings.cooldown,
+      };
+      if (settings.botToken && !settings.botToken.startsWith("*")) {
+        body.botToken = settings.botToken;
+      }
+      const res = await fetch("/api/admin/telegram", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (res.ok) {
+        showToast("Telegram settings saved", "success");
+        const refreshRes = await fetch("/api/admin/telegram");
+        if (refreshRes.ok) {
+          const refreshData = await refreshRes.json();
+          setSettings(parseSettings(refreshData));
+          setShowToken(false);
+        }
+      } else {
+        const errData = await res.json();
+        const msg = errData?.error?.message ?? errData?.error ?? "Failed to save";
+        showToast(msg, "error");
+      }
+    } catch {
+      showToast("Failed to save settings", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    try {
+      const res = await fetch("/api/admin/telegram", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (res.ok) {
+        showToast("Test message sent! Check your Telegram.", "success");
+      } else {
+        const errData = await res.json();
+        const msg = errData?.error?.message ?? errData?.error ?? "Test failed";
+        showToast(msg, "error");
+      }
+    } catch {
+      showToast("Failed to send test message", "error");
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleCheckNow = async () => {
+    setChecking(true);
+    setCheckResult(null);
+    try {
+      const res = await fetch("/api/quota/check-alerts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) {
+        const errData = await res.json().catch(() => null);
+        const msg = errData?.error?.message ?? errData?.error ?? "Check failed";
+        showToast(msg, "error");
+        return;
+      }
+      const data = await res.json();
+      setCheckResult(data);
+      if (data.skipped) {
+        showToast(`Check skipped: ${data.reason}`, "info");
+      } else if (data.breachedCount > 0) {
+        showToast(`Alert sent for ${data.breachedCount} account(s)`, "success");
+      } else {
+        showToast("All accounts above threshold", "success");
+      }
+    } catch {
+      showToast("Failed to check alerts", "error");
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const hasSavedConfig = settings.botToken.length > 0 && settings.chatId.length > 0;
+
+  const handleNumericChange = (field: "threshold" | "checkInterval" | "cooldown", raw: string) => {
+    const num = parseInt(raw, 10);
+    if (raw === "") {
+      setSettings((s) => ({ ...s, [field]: MIN_INTERVAL }));
+    } else if (!Number.isNaN(num) && num >= MIN_INTERVAL && num <= (field === "threshold" ? 100 : MAX_INTERVAL)) {
+      setSettings((s) => ({ ...s, [field]: num }));
+    }
+  };
+
+  return (
+    <section className="space-y-3 rounded-lg border border-slate-700/70 bg-slate-900/40 p-4">
+      <div>
+        <h2 className="text-sm font-semibold tracking-tight text-slate-100">Telegram Alerts</h2>
+        <p className="mt-0.5 text-xs text-slate-400">Get notified when quota drops below a threshold.</p>
+      </div>
+
+      <div className="space-y-3">
+        <label className="flex items-center gap-2 cursor-pointer">
+          <button
+            type="button"
+            role="switch"
+            aria-checked={settings.enabled}
+            onClick={() => setSettings((s) => ({ ...s, enabled: !s.enabled }))}
+            className={cn(
+              "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors",
+              settings.enabled ? "bg-blue-500/60 border-blue-400/50" : "bg-slate-700/60 border-slate-600/50"
+            )}
+          >
+            <span className={cn("inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform", settings.enabled ? "translate-x-4" : "translate-x-0.5")} />
+          </button>
+          <span className="text-xs text-slate-300">Enable alerts</span>
+        </label>
+
+        <div className="space-y-1">
+          <label htmlFor="tg-bot-token" className="text-xs font-medium text-slate-400">Bot Token</label>
+          <div className="flex gap-2">
+            <Input type={showToken ? "text" : "password"} name="tg-bot-token" value={settings.botToken} onChange={(v) => setSettings((s) => ({ ...s, botToken: v }))} placeholder="123456789:ABCdef..." autoComplete="off" />
+            <Button variant="ghost" onClick={() => setShowToken((v) => !v)} className="shrink-0 px-2 text-xs">{showToken ? "Hide" : "Show"}</Button>
+          </div>
+          <p className="text-[10px] text-slate-500">Create a bot via @BotFather on Telegram</p>
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="tg-chat-id" className="text-xs font-medium text-slate-400">Chat ID</label>
+          <Input name="tg-chat-id" value={settings.chatId} onChange={(v) => setSettings((s) => ({ ...s, chatId: v }))} placeholder="-1001234567890" />
+          <p className="text-[10px] text-slate-500">Your Telegram user/group ID. Use @userinfobot to find it</p>
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="tg-threshold" className="text-xs font-medium text-slate-400">Threshold %</label>
+          <Input type="number" name="tg-threshold" value={String(settings.threshold)} onChange={(v) => handleNumericChange("threshold", v)} placeholder="20" />
+          <p className="text-[10px] text-slate-500">Alert when any account drops below this capacity</p>
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="tg-check-interval" className="text-xs font-medium text-slate-400">Check Interval (minutes)</label>
+          <Input type="number" name="tg-check-interval" value={String(settings.checkInterval)} onChange={(v) => handleNumericChange("checkInterval", v)} placeholder="5" />
+          <p className="text-[10px] text-slate-500">How often to check quota levels (1-1440 min, default: 5)</p>
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="tg-cooldown" className="text-xs font-medium text-slate-400">Cooldown (minutes)</label>
+          <Input type="number" name="tg-cooldown" value={String(settings.cooldown)} onChange={(v) => handleNumericChange("cooldown", v)} placeholder="60" />
+          <p className="text-[10px] text-slate-500">Minimum time between notifications (1-1440 min, default: 60)</p>
+        </div>
+
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium text-slate-400">Monitored Providers</p>
+          <div className="flex flex-wrap gap-x-4 gap-y-1.5">
+            {ALERT_PROVIDERS.map((provider) => {
+              const isChecked = settings.providers.includes(provider.key);
+              return (
+                <label key={provider.key} className="flex items-center gap-1.5 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={isChecked}
+                    onChange={() => {
+                      setSettings((s) => ({
+                        ...s,
+                        providers: isChecked
+                          ? s.providers.filter((p) => p !== provider.key)
+                          : [...s.providers, provider.key],
+                      }));
+                    }}
+                    className="size-3.5 rounded border-slate-600 bg-slate-800 text-blue-500 focus:ring-blue-500/30 focus:ring-offset-0"
+                  />
+                  <span className="text-xs text-slate-300">{provider.label}</span>
+                </label>
+              );
+            })}
+          </div>
+          <p className="text-[10px] text-slate-500">Only selected providers will trigger alerts</p>
+        </div>
+
+        <div className="flex flex-wrap gap-2 pt-1">
+          <Button onClick={handleSave} disabled={saving} className="text-xs">{saving ? "Saving..." : "Save"}</Button>
+          <Button variant="secondary" onClick={handleTest} disabled={testing || !hasSavedConfig} className="text-xs">{testing ? "Sending..." : "Send Test"}</Button>
+          <Button variant="secondary" onClick={handleCheckNow} disabled={checking || !hasSavedConfig} className="text-xs">{checking ? "Checking..." : "Check Now"}</Button>
+        </div>
+
+        {checkResult && checkResult.accounts && checkResult.accounts.length > 0 && (
+          <div className="mt-2 space-y-1 rounded-md border border-slate-700/70 bg-slate-900/25 p-3">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-slate-400">
+              Check Result — {checkResult.breachedCount ?? 0} account(s) breached
+            </p>
+            <div className="space-y-0.5">
+              {checkResult.accounts.map((a) => (
+                <div key={`${a.provider}-${a.account}-${a.window}`} className="flex items-center justify-between text-xs">
+                  <span className="text-slate-300">{a.provider} / {a.account} / {a.window}</span>
+                  <span className={cn("font-medium", a.belowThreshold ? "text-rose-300" : "text-emerald-300")}>{a.capacity}%</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/dashboard/src/app/dashboard/quota/page.tsx
+++ b/dashboard/src/app/dashboard/quota/page.tsx
@@ -1,740 +1,32 @@
 "use client";
 
-import { RadialBarChart, RadialBar, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Cell, Legend } from "recharts";
+import { RadialBarChart, RadialBar, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from "recharts";
 import { Button } from "@/components/ui/button";
 import { ChartContainer, ChartEmpty, CHART_COLORS, TOOLTIP_STYLE, AXIS_TICK_STYLE } from "@/components/ui/chart-theme";
 import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
-import { Input } from "@/components/ui/input";
-import { useToast } from "@/components/ui/toast";
 import { HelpTooltip } from "@/components/ui/tooltip";
+import type { QuotaResponse, QuotaAccount, ProviderSummary, ProviderType } from "./_components/quota-types";
+import { PROVIDERS } from "./_components/quota-types";
+import { normalizeFraction, maskEmail, formatRelativeTime, calcAccountWindowScores, calcProviderSummary, calcOverallCapacity, getCapacityBarClass } from "./_components/quota-utils";
+import { TelegramAlertsSection } from "./_components/telegram-alerts-section";
 
-interface QuotaModel {
-  id: string;
-  displayName: string;
-  remainingFraction?: number | null;
-  resetTime: string | null;
-}
+const REFRESH_INTERVAL_MS = 120_000;
+const SCROLL_DELAY_MS = 50;
+const LOW_CAPACITY_THRESHOLD = 0.2;
 
-interface QuotaGroup {
-  id: string;
-  label: string;
-  remainingFraction?: number | null;
-  resetTime: string | null;
-  models: QuotaModel[];
-}
-
-interface QuotaAccount {
-  auth_index: string;
-  provider: string;
-  email?: string | null;
-  supported: boolean;
-  error?: string;
-  groups?: QuotaGroup[];
-  raw?: unknown;
-}
-
-interface QuotaResponse {
-  accounts: QuotaAccount[];
-}
-
-const PROVIDERS = {
-  ALL: "all",
-  ANTIGRAVITY: "antigravity",
-  CLAUDE: "claude",
-  CODEX: "codex",
-  COPILOT: "github-copilot",
-  KIMI: "kimi",
-} as const;
-
-type ProviderType = (typeof PROVIDERS)[keyof typeof PROVIDERS];
-
-function normalizeFraction(value: unknown): number | null {
-  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
-    return null;
-  }
-  if (value < 0) return 0;
-  if (value > 1) return 1;
-  return value;
-}
-
-function maskEmail(email: unknown): string {
-  if (typeof email !== "string") return "unknown";
-  const trimmed = email.trim();
-  if (trimmed === "") return "unknown";
-
-  const atIndex = trimmed.indexOf("@");
-  if (atIndex <= 0 || atIndex === trimmed.length - 1) {
-    return trimmed;
-  }
-
-  const local = trimmed.slice(0, atIndex);
-  const domain = trimmed.slice(atIndex + 1);
-  const maskedLocal = local.length <= 3 ? `${local}***` : `${local.slice(0, 3)}***`;
-  return `${maskedLocal}@${domain}`;
-}
-
-function formatRelativeTime(isoDate: string | null): string {
-  if (!isoDate) return "Unknown";
-  
-  try {
-    const resetDate = new Date(isoDate);
-    const now = new Date();
-    const diffMs = resetDate.getTime() - now.getTime();
-    
-    if (diffMs <= 0) return "Resetting...";
-    
-    const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-    const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-    const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-    
-    if (days > 0) {
-      return `Resets in ${days}d ${hours}h`;
-    }
-    if (hours > 0) {
-      return `Resets in ${hours}h ${minutes}m`;
-    }
-    return `Resets in ${minutes}m`;
-  } catch {
-    return "Unknown";
-  }
-}
-
-// Classify a group as short-term (≤6h) or long-term based on its id/label
-function isShortTermGroup(group: QuotaGroup): boolean {
-  const id = group.id.toLowerCase();
-  const label = group.label.toLowerCase();
-  // Short-term: 5h session, primary window, 5m window, requests, tokens
-  return (
-    id.includes("five-hour") ||
-    id.includes("primary") ||
-    id.includes("request") ||
-    id.includes("token") ||
-    label.includes("5h") ||
-    label.includes("5m") ||
-    label.includes("request") ||
-    label.includes("token")
-  );
-}
-
-function calcAccountWindowScores(groups: QuotaGroup[]): Record<string, { score: number; label: string; isShortTerm: boolean }> {
-  const result: Record<string, { score: number; label: string; isShortTerm: boolean }> = {};
-  for (const group of groups) {
-    if (group.id === "extra-usage") continue;
-    const score = normalizeFraction(group.remainingFraction);
-    if (score === null) continue;
-    result[group.id] = {
-      score,
-      label: group.label,
-      isShortTerm: isShortTermGroup(group),
-    };
-  }
-  return result;
-}
-
-interface WindowCapacity {
-  id: string;
-  label: string;
-  capacity: number;
-  resetTime: string | null;
-  isShortTerm: boolean;
-}
-
-interface ProviderSummary {
-  provider: string;
-  totalAccounts: number;
-  healthyAccounts: number;
-  errorAccounts: number;
-  windowCapacities: WindowCapacity[];
-}
-
-function calcProviderSummary(accounts: QuotaAccount[]): ProviderSummary {
-  const totalAccounts = accounts.length;
-  const healthy = accounts.filter(
-    (a) => a.supported && !a.error && a.groups && a.groups.length > 0
-  );
-  const errorAccounts = totalAccounts - healthy.length;
-
-  const allWindowIds = new Set<string>();
-  for (const a of healthy) {
-    for (const g of a.groups ?? []) {
-      if (g.id !== "extra-usage") allWindowIds.add(g.id);
-    }
-  }
-
-  const windowCapacities: WindowCapacity[] = [];
-
-  for (const windowId of allWindowIds) {
-    const relevantAccounts = healthy.filter((a) =>
-      a.groups?.some((g) => g.id === windowId)
-    );
-    if (relevantAccounts.length === 0) continue;
-
-    const scores = relevantAccounts.map((a) => {
-      const group = a.groups?.find((g) => g.id === windowId);
-      return normalizeFraction(group?.remainingFraction);
-    }).filter((score): score is number => score !== null);
-
-    if (scores.length === 0) {
-      continue;
-    }
-
-    const exhaustedProduct = scores.reduce((prod, score) => prod * (1 - score), 1);
-    const capacity = 1 - exhaustedProduct;
-
-    let earliestReset: string | null = null;
-    let minResetTime = Infinity;
-    let label = "";
-    let isShortTerm = false;
-
-    for (const a of relevantAccounts) {
-      const g = a.groups?.find((g) => g.id === windowId);
-      if (g) {
-        if (!label) {
-          label = g.label;
-          isShortTerm = isShortTermGroup(g);
-        }
-        if (g.resetTime) {
-          const t = new Date(g.resetTime).getTime();
-          if (t < minResetTime) {
-            minResetTime = t;
-            earliestReset = g.resetTime;
-          }
-        }
-      }
-    }
-
-    windowCapacities.push({
-      id: windowId,
-      label,
-      capacity: Math.max(0, Math.min(1, capacity)),
-      resetTime: earliestReset,
-      isShortTerm,
-    });
-  }
-
-  windowCapacities.sort((a, b) => {
-    if (a.isShortTerm !== b.isShortTerm) return a.isShortTerm ? 1 : -1;
-    return a.label.localeCompare(b.label);
-  });
-
-  return {
-    provider: accounts[0]?.provider ?? "unknown",
-    totalAccounts,
-    healthyAccounts: healthy.length,
-    errorAccounts,
-    windowCapacities,
-  };
-}
-
-function calcOverallCapacity(summaries: ProviderSummary[]): { value: number; label: string; provider: string } {
-  if (summaries.length === 0) return { value: 0, label: "No Data", provider: "" };
-
-  let weightedCapacity = 0;
-  let weightedAccounts = 0;
-
-  for (const summary of summaries) {
-    if (summary.healthyAccounts === 0) {
-      continue;
-    }
-
-    const longTerm = summary.windowCapacities.filter((w) => !w.isShortTerm);
-    const shortTerm = summary.windowCapacities.filter((w) => w.isShortTerm);
-    const relevantWindows = longTerm.length > 0 ? longTerm : shortTerm;
-
-    if (relevantWindows.length === 0) {
-      continue;
-    }
-
-    const providerCapacity = Math.min(...relevantWindows.map((w) => w.capacity));
-    weightedCapacity += providerCapacity * summary.healthyAccounts;
-    weightedAccounts += summary.healthyAccounts;
-  }
-
-  if (weightedAccounts === 0) {
-    return { value: 0, label: "No Data", provider: "" };
-  }
-
-  return {
-    value: weightedCapacity / weightedAccounts,
-    label: "Weighted capacity",
-    provider: "all",
-  };
-}
-
-function getCapacityBarClass(value: number): string {
-  if (value > 0.6) return "bg-emerald-500/80";
-  if (value > 0.2) return "bg-amber-500/80";
-  return "bg-rose-500/80";
-}
-
-interface TelegramSettings {
-  botToken: string;
-  chatId: string;
-  threshold: number;
-  enabled: boolean;
-  providers: string[];
-  checkInterval: number;
-  cooldown: number;
-}
-
-const ALERT_PROVIDERS = [
-  { key: "claude", label: "Claude" },
-  { key: "antigravity", label: "Antigravity" },
-  { key: "codex", label: "Codex" },
-  { key: "github-copilot", label: "Copilot" },
-  { key: "kimi", label: "Kimi" },
+const PROVIDER_FILTERS = [
+  { key: PROVIDERS.ALL, label: "All" },
+  { key: PROVIDERS.ANTIGRAVITY, label: "Antigravity" },
+  { key: PROVIDERS.CLAUDE, label: "Claude" },
+  { key: PROVIDERS.CODEX, label: "Codex" },
+  { key: PROVIDERS.COPILOT, label: "Copilot" },
+  { key: PROVIDERS.KIMI, label: "Kimi" },
 ] as const;
 
-interface CheckAlertResult {
-  checked?: boolean;
-  skipped?: boolean;
-  reason?: string;
-  alertsSent?: number;
-  breachedCount?: number;
-  accounts?: Array<{
-    provider: string;
-    account: string;
-    window: string;
-    capacity: number;
-    belowThreshold: boolean;
-  }>;
-}
-
-function TelegramAlertsSection() {
-  const { showToast } = useToast();
-  const [isAdmin, setIsAdmin] = useState(false);
-  const [loaded, setLoaded] = useState(false);
-  const [settings, setSettings] = useState<TelegramSettings>({
-    botToken: "",
-    chatId: "",
-    threshold: 20,
-    enabled: false,
-    providers: ALERT_PROVIDERS.map((p) => p.key),
-    checkInterval: 5,
-    cooldown: 60,
-  });
-  const [showToken, setShowToken] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [testing, setTesting] = useState(false);
-  const [checking, setChecking] = useState(false);
-  const [checkResult, setCheckResult] = useState<CheckAlertResult | null>(null);
-
-  useEffect(() => {
-    const init = async () => {
-      try {
-        const meRes = await fetch("/api/auth/me");
-        if (!meRes.ok) return;
-        const meData = await meRes.json();
-        if (!meData.isAdmin) return;
-        setIsAdmin(true);
-
-        const res = await fetch("/api/admin/telegram");
-        if (res.ok) {
-          const data = await res.json();
-          setSettings({
-            botToken: data.botToken ?? "",
-            chatId: data.chatId ?? "",
-            threshold: data.threshold ?? 20,
-            enabled: data.enabled ?? false,
-            providers: Array.isArray(data.providers) ? data.providers : ALERT_PROVIDERS.map((p) => p.key),
-            checkInterval: data.checkInterval ?? 5,
-            cooldown: data.cooldown ?? 60,
-          });
-        }
-      } catch {
-        // silently fail — non-admin users won't see the section
-      } finally {
-        setLoaded(true);
-      }
-    };
-    init();
-  }, []);
-
-  if (!loaded || !isAdmin) return null;
-
-  const handleSave = async () => {
-    setSaving(true);
-    try {
-      const body: Record<string, unknown> = {
-        chatId: settings.chatId,
-        threshold: settings.threshold,
-        enabled: settings.enabled,
-        providers: settings.providers,
-        checkInterval: settings.checkInterval,
-        cooldown: settings.cooldown,
-      };
-      // Only send botToken if user changed it (not the masked version)
-      if (settings.botToken && !settings.botToken.startsWith("*")) {
-        body.botToken = settings.botToken;
-      }
-      const res = await fetch("/api/admin/telegram", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-      if (res.ok) {
-        showToast("Telegram settings saved", "success");
-        // Re-fetch to get masked token
-        const refreshRes = await fetch("/api/admin/telegram");
-        if (refreshRes.ok) {
-          const refreshData = await refreshRes.json();
-          setSettings({
-            botToken: refreshData.botToken ?? "",
-            chatId: refreshData.chatId ?? "",
-            threshold: refreshData.threshold ?? 20,
-            enabled: refreshData.enabled ?? false,
-            providers: Array.isArray(refreshData.providers) ? refreshData.providers : ALERT_PROVIDERS.map((p) => p.key),
-            checkInterval: refreshData.checkInterval ?? 5,
-            cooldown: refreshData.cooldown ?? 60,
-          });
-          setShowToken(false);
-        }
-      } else {
-        const errData = await res.json();
-        const msg = errData?.error?.message ?? errData?.error ?? "Failed to save";
-        showToast(msg, "error");
-      }
-    } catch {
-      showToast("Failed to save settings", "error");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleTest = async () => {
-    setTesting(true);
-    try {
-      const res = await fetch("/api/admin/telegram", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      if (res.ok) {
-        showToast("Test message sent! Check your Telegram.", "success");
-      } else {
-        const errData = await res.json();
-        const msg = errData?.error?.message ?? errData?.error ?? "Test failed";
-        showToast(msg, "error");
-      }
-    } catch {
-      showToast("Failed to send test message", "error");
-    } finally {
-      setTesting(false);
-    }
-  };
-
-  const handleCheckNow = async () => {
-    setChecking(true);
-    setCheckResult(null);
-    try {
-      const res = await fetch("/api/quota/check-alerts", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      if (!res.ok) {
-        const errData = await res.json().catch(() => null);
-        const msg = errData?.error?.message ?? errData?.error ?? "Check failed";
-        showToast(msg, "error");
-        return;
-      }
-      const data = await res.json();
-      setCheckResult(data);
-      if (data.skipped) {
-        showToast(`Check skipped: ${data.reason}`, "info");
-      } else if (data.breachedCount > 0) {
-        showToast(`Alert sent for ${data.breachedCount} account(s)`, "success");
-      } else {
-        showToast("All accounts above threshold", "success");
-      }
-    } catch {
-      showToast("Failed to check alerts", "error");
-    } finally {
-      setChecking(false);
-    }
-  };
-
-  const hasSavedConfig = settings.botToken.length > 0 && settings.chatId.length > 0;
-
-  return (
-    <section className="space-y-3 rounded-lg border border-slate-700/70 bg-slate-900/40 p-4">
-      <div>
-        <h2 className="text-sm font-semibold tracking-tight text-slate-100">Telegram Alerts</h2>
-        <p className="mt-0.5 text-xs text-slate-400">Get notified when quota drops below a threshold.</p>
-      </div>
-
-      <div className="space-y-3">
-        {/* Enable/Disable toggle */}
-        <label className="flex items-center gap-2 cursor-pointer">
-          <button
-            type="button"
-            role="switch"
-            aria-checked={settings.enabled}
-            onClick={() => setSettings((s) => ({ ...s, enabled: !s.enabled }))}
-            className={cn(
-              "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors",
-              settings.enabled
-                ? "bg-blue-500/60 border-blue-400/50"
-                : "bg-slate-700/60 border-slate-600/50"
-            )}
-          >
-            <span
-              className={cn(
-                "inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform",
-                settings.enabled ? "translate-x-4" : "translate-x-0.5"
-              )}
-            />
-          </button>
-          <span className="text-xs text-slate-300">Enable alerts</span>
-        </label>
-
-        {/* Bot Token */}
-        <div className="space-y-1">
-          <label htmlFor="tg-bot-token" className="text-xs font-medium text-slate-400">Bot Token</label>
-          <div className="flex gap-2">
-            <Input
-              type={showToken ? "text" : "password"}
-              name="tg-bot-token"
-              value={settings.botToken}
-              onChange={(v) => setSettings((s) => ({ ...s, botToken: v }))}
-              placeholder="123456789:ABCdef..."
-              autoComplete="off"
-            />
-            <Button
-              variant="ghost"
-              onClick={() => setShowToken((v) => !v)}
-              className="shrink-0 px-2 text-xs"
-            >
-              {showToken ? "Hide" : "Show"}
-            </Button>
-          </div>
-          <p className="text-[10px] text-slate-500">Create a bot via @BotFather on Telegram</p>
-        </div>
-
-        {/* Chat ID */}
-        <div className="space-y-1">
-          <label htmlFor="tg-chat-id" className="text-xs font-medium text-slate-400">Chat ID</label>
-          <Input
-            name="tg-chat-id"
-            value={settings.chatId}
-            onChange={(v) => setSettings((s) => ({ ...s, chatId: v }))}
-            placeholder="-1001234567890"
-          />
-          <p className="text-[10px] text-slate-500">Your Telegram user/group ID. Use @userinfobot to find it</p>
-        </div>
-
-        {/* Threshold */}
-        <div className="space-y-1">
-          <label htmlFor="tg-threshold" className="text-xs font-medium text-slate-400">Threshold %</label>
-          <Input
-            type="number"
-            name="tg-threshold"
-            value={String(settings.threshold)}
-            onChange={(v) => {
-              const num = parseInt(v, 10);
-              if (!Number.isNaN(num) && num >= 1 && num <= 100) {
-                setSettings((s) => ({ ...s, threshold: num }));
-              } else if (v === "") {
-                setSettings((s) => ({ ...s, threshold: 1 }));
-              }
-            }}
-            placeholder="20"
-          />
-          <p className="text-[10px] text-slate-500">Alert when any account drops below this capacity</p>
-        </div>
-
-        {/* Check Interval */}
-        <div className="space-y-1">
-          <label htmlFor="tg-check-interval" className="text-xs font-medium text-slate-400">Check Interval (minutes)</label>
-          <Input
-            type="number"
-            name="tg-check-interval"
-            value={String(settings.checkInterval)}
-            onChange={(v) => {
-              const num = parseInt(v, 10);
-              if (!Number.isNaN(num) && num >= 1 && num <= 1440) {
-                setSettings((s) => ({ ...s, checkInterval: num }));
-              } else if (v === "") {
-                setSettings((s) => ({ ...s, checkInterval: 1 }));
-              }
-            }}
-            placeholder="5"
-          />
-          <p className="text-[10px] text-slate-500">How often to check quota levels (1–1440 min, default: 5)</p>
-        </div>
-
-        {/* Cooldown */}
-        <div className="space-y-1">
-          <label htmlFor="tg-cooldown" className="text-xs font-medium text-slate-400">Cooldown (minutes)</label>
-          <Input
-            type="number"
-            name="tg-cooldown"
-            value={String(settings.cooldown)}
-            onChange={(v) => {
-              const num = parseInt(v, 10);
-              if (!Number.isNaN(num) && num >= 1 && num <= 1440) {
-                setSettings((s) => ({ ...s, cooldown: num }));
-              } else if (v === "") {
-                setSettings((s) => ({ ...s, cooldown: 1 }));
-              }
-            }}
-            placeholder="60"
-          />
-          <p className="text-[10px] text-slate-500">Minimum time between notifications (1–1440 min, default: 60)</p>
-        </div>
-
-        {/* Provider selection */}
-        <div className="space-y-1.5">
-          <p className="text-xs font-medium text-slate-400">Monitored Providers</p>
-          <div className="flex flex-wrap gap-x-4 gap-y-1.5">
-            {ALERT_PROVIDERS.map((provider) => {
-              const isChecked = settings.providers.includes(provider.key);
-              return (
-                <label key={provider.key} className="flex items-center gap-1.5 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={isChecked}
-                    onChange={() => {
-                      setSettings((s) => ({
-                        ...s,
-                        providers: isChecked
-                          ? s.providers.filter((p) => p !== provider.key)
-                          : [...s.providers, provider.key],
-                      }));
-                    }}
-                    className="size-3.5 rounded border-slate-600 bg-slate-800 text-blue-500 focus:ring-blue-500/30 focus:ring-offset-0"
-                  />
-                  <span className="text-xs text-slate-300">{provider.label}</span>
-                </label>
-              );
-            })}
-          </div>
-          <p className="text-[10px] text-slate-500">Only selected providers will trigger alerts</p>
-        </div>
-
-        {/* Action buttons */}
-        <div className="flex flex-wrap gap-2 pt-1">
-          <Button onClick={handleSave} disabled={saving} className="text-xs">
-            {saving ? "Saving..." : "Save"}
-          </Button>
-          <Button
-            variant="secondary"
-            onClick={handleTest}
-            disabled={testing || !hasSavedConfig}
-            className="text-xs"
-          >
-            {testing ? "Sending..." : "Send Test"}
-          </Button>
-          <Button
-            variant="secondary"
-            onClick={handleCheckNow}
-            disabled={checking || !hasSavedConfig}
-            className="text-xs"
-          >
-            {checking ? "Checking..." : "Check Now"}
-          </Button>
-        </div>
-
-        {/* Check result */}
-        {checkResult && checkResult.accounts && checkResult.accounts.length > 0 && (
-          <div className="mt-2 space-y-1 rounded-md border border-slate-700/70 bg-slate-900/25 p-3">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-slate-400">
-              Check Result — {checkResult.breachedCount ?? 0} account(s) breached
-            </p>
-            <div className="space-y-0.5">
-              {checkResult.accounts.map((a) => (
-                <div
-                  key={`${a.provider}-${a.account}-${a.window}`}
-                  className="flex items-center justify-between text-xs"
-                >
-                  <span className="text-slate-300">
-                    {a.provider} / {a.account} / {a.window}
-                  </span>
-                  <span
-                    className={cn(
-                      "font-medium",
-                      a.belowThreshold ? "text-rose-300" : "text-emerald-300"
-                    )}
-                  >
-                    {a.capacity}%
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
-    </section>
-  );
-}
-
-export default function QuotaPage() {
+function useQuotaData() {
   const [quotaData, setQuotaData] = useState<QuotaResponse | null>(null);
   const [loading, setLoading] = useState(true);
-  const [selectedProvider, setSelectedProvider] = useState<ProviderType>(PROVIDERS.ALL);
-  const [expandedCards, setExpandedCards] = useState<Record<string, boolean>>({});
-
-  useEffect(() => {
-    const fetchQuota = async () => {
-      setLoading(true);
-      try {
-        const res = await fetch("/api/quota");
-        if (res.ok) {
-          const data = await res.json();
-          setQuotaData(data);
-        }
-      } catch {
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchQuota();
-    const interval = setInterval(fetchQuota, 120_000);
-    return () => clearInterval(interval);
-  }, []);
-
-
-  const filteredAccounts = quotaData?.accounts.filter((account) => {
-    if (selectedProvider === PROVIDERS.ALL) return true;
-    if (selectedProvider === PROVIDERS.COPILOT) {
-      return account.provider === "github" || account.provider === "github-copilot";
-    }
-    return account.provider === selectedProvider;
-  }) || [];
-
-  const activeAccounts = filteredAccounts.filter((account) => account.supported && !account.error).length;
-
-  const providerGroups = new Map<string, QuotaAccount[]>();
-  for (const account of filteredAccounts) {
-    const existing = providerGroups.get(account.provider) ?? [];
-    existing.push(account);
-    providerGroups.set(account.provider, existing);
-  }
-
-  const providerSummaries = Array.from(providerGroups.entries())
-    .map(([, accounts]) => calcProviderSummary(accounts))
-    .sort((a, b) => b.healthyAccounts - a.healthyAccounts);
-
-  const overallCapacity = calcOverallCapacity(providerSummaries);
-
-  const lowCapacityCount = providerSummaries.filter(
-    (s) => s.windowCapacities.some((w) => w.capacity < 0.2) && s.totalAccounts > 0
-  ).length;
-
-  const providerFilters = [
-    { key: PROVIDERS.ALL, label: "All" },
-    { key: PROVIDERS.ANTIGRAVITY, label: "Antigravity" },
-    { key: PROVIDERS.CLAUDE, label: "Claude" },
-    { key: PROVIDERS.CODEX, label: "Codex" },
-    { key: PROVIDERS.COPILOT, label: "Copilot" },
-    { key: PROVIDERS.KIMI, label: "Kimi" },
-  ] as const;
-
-  const toggleCard = (accountId: string) => {
-    setExpandedCards((prev) => ({ ...prev, [accountId]: !prev[accountId] }));
-  };
 
   const fetchQuota = async () => {
     setLoading(true);
@@ -745,9 +37,177 @@ export default function QuotaPage() {
         setQuotaData(data);
       }
     } catch {
+      // silently fail
     } finally {
       setLoading(false);
     }
+  };
+
+  useEffect(() => {
+    fetchQuota();
+    const interval = setInterval(fetchQuota, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  return { quotaData, loading, fetchQuota };
+}
+
+function filterAccounts(accounts: QuotaAccount[] | undefined, provider: ProviderType): QuotaAccount[] {
+  if (!accounts) return [];
+  if (provider === PROVIDERS.ALL) return accounts;
+  if (provider === PROVIDERS.COPILOT) {
+    return accounts.filter((a) => a.provider === "github" || a.provider === "github-copilot");
+  }
+  return accounts.filter((a) => a.provider === provider);
+}
+
+function buildProviderSummaries(accounts: QuotaAccount[]): ProviderSummary[] {
+  const providerGroups = new Map<string, QuotaAccount[]>();
+  for (const account of accounts) {
+    const existing = providerGroups.get(account.provider) ?? [];
+    providerGroups.set(account.provider, [...existing, account]);
+  }
+  return Array.from(providerGroups.values())
+    .map((group) => calcProviderSummary(group))
+    .sort((a, b) => b.healthyAccounts - a.healthyAccounts);
+}
+
+function CapacityGauge({ summaries }: { summaries: ProviderSummary[] }) {
+  const overallCapacity = calcOverallCapacity(summaries);
+
+  if (summaries.length === 0) return <ChartEmpty message="No provider data" />;
+
+  const pct = Math.round(overallCapacity.value * 100);
+  const gaugeColor = overallCapacity.value > 0.6 ? CHART_COLORS.success : overallCapacity.value > 0.2 ? CHART_COLORS.warning : CHART_COLORS.danger;
+  const gaugeData = [{ value: pct, fill: gaugeColor }];
+
+  return (
+    <div className="relative flex h-48 items-center justify-center">
+      <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 320, height: 200 }}>
+        <RadialBarChart cx="50%" cy="60%" innerRadius="55%" outerRadius="80%" startAngle={210} endAngle={-30} data={[{ value: 100, fill: "rgba(148,163,184,0.1)" }, ...gaugeData]} barSize={14}>
+          <RadialBar dataKey="value" background={false} cornerRadius={4} />
+        </RadialBarChart>
+      </ResponsiveContainer>
+      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+        <span className="text-3xl font-bold" style={{ color: gaugeColor }}>{pct}%</span>
+        <span className="mt-0.5 text-[10px] uppercase tracking-widest" style={{ color: CHART_COLORS.text.dimmed }}>Capacity</span>
+      </div>
+    </div>
+  );
+}
+
+function ProviderCapacityChart({ summaries }: { summaries: ProviderSummary[] }) {
+  if (summaries.length === 0) return <ChartEmpty message="No provider data" />;
+
+  const barData = summaries.map((s) => {
+    const longTerm = s.windowCapacities.filter((w) => !w.isShortTerm);
+    const shortTerm = s.windowCapacities.filter((w) => w.isShortTerm);
+    return {
+      provider: s.provider,
+      longTerm: longTerm.length > 0 ? Math.round(Math.min(...longTerm.map((w) => w.capacity)) * 100) : null,
+      shortTerm: shortTerm.length > 0 ? Math.round(Math.min(...shortTerm.map((w) => w.capacity)) * 100) : null,
+      healthy: s.healthyAccounts,
+      total: s.totalAccounts,
+      issues: s.errorAccounts,
+    };
+  });
+
+  return (
+    <div className="h-48">
+      <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 320, height: 200 }}>
+        <BarChart data={barData} layout="vertical" margin={{ top: 4, right: 12, bottom: 4, left: 4 }} barSize={8} barGap={2}>
+          <XAxis type="number" domain={[0, 100]} tick={AXIS_TICK_STYLE} tickLine={false} axisLine={{ stroke: CHART_COLORS.border }} tickFormatter={(v) => `${v}%`} />
+          <YAxis type="category" dataKey="provider" tick={{ ...AXIS_TICK_STYLE, fontSize: 10 }} tickLine={false} axisLine={false} width={72} />
+          <Tooltip
+            {...TOOLTIP_STYLE}
+            formatter={(value, name, props) => {
+              if (value === null) return ["-", name];
+              const label = name === "longTerm" ? "Long-Term" : "Short-Term";
+              const extra = name === "longTerm" ? ` (${props.payload.healthy}/${props.payload.total} healthy${props.payload.issues > 0 ? `, ${props.payload.issues} issues` : ""})` : "";
+              return [`${value}%${extra}`, label];
+            }}
+          />
+          <Legend verticalAlign="top" height={24} formatter={(value: string) => value === "longTerm" ? "Long-Term" : "Short-Term"} wrapperStyle={{ fontSize: 10, color: CHART_COLORS.text.dimmed }} />
+          <Bar dataKey="longTerm" radius={[0, 3, 3, 0]} fill={CHART_COLORS.success} />
+          <Bar dataKey="shortTerm" radius={[0, 3, 3, 0]} fill={CHART_COLORS.cyan} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function AccountRow({ account, isExpanded, onToggle }: { account: QuotaAccount; isExpanded: boolean; onToggle: () => void }) {
+  const scores = account.groups ? Object.values(calcAccountWindowScores(account.groups)) : [];
+  const longScores = scores.filter((s) => !s.isShortTerm);
+  const shortScores = scores.filter((s) => s.isShortTerm);
+  const longMin = longScores.length > 0 ? Math.min(...longScores.map((s) => s.score)) : null;
+  const shortMin = shortScores.length > 0 ? Math.min(...shortScores.map((s) => s.score)) : null;
+  const statusLabel = account.supported ? (account.error ? "Error" : "Active") : "Unsupported";
+
+  return (
+    <div className="border-b border-slate-700/60 last:border-b-0">
+      <button type="button" onClick={onToggle} className="grid w-full grid-cols-[24px_minmax(0,1fr)_120px_120px_140px_140px] items-center px-3 py-2 text-left transition-colors hover:bg-slate-800/40">
+        <span className={cn("text-xs text-slate-500 transition-transform", isExpanded && "rotate-180")}>⌄</span>
+        <span className="truncate text-xs text-slate-200">{maskEmail(account.email)}</span>
+        <span className="truncate text-xs capitalize text-slate-300">{account.provider}</span>
+        <span className={cn("text-xs", account.error ? "text-rose-300" : account.supported ? "text-emerald-300" : "text-amber-300")}>{statusLabel}</span>
+        <CapacityCell value={longMin} />
+        <CapacityCell value={shortMin} />
+      </button>
+      {isExpanded && (
+        <div className="border-t border-slate-700/60 bg-slate-900/30 px-4 py-3">
+          {account.error && <p className="mb-2 break-all text-xs text-rose-300">{account.error}</p>}
+          {!account.supported && !account.error && <p className="mb-2 text-xs text-amber-300">Quota monitoring not available for this provider.</p>}
+          {account.groups && account.groups.length > 0 && (
+            <div className="overflow-x-auto rounded-sm border border-slate-700/70">
+              <div className="min-w-[400px]">
+                {account.groups.map((group) => {
+                  const fraction = normalizeFraction(group.remainingFraction);
+                  const pct = fraction === null ? null : Math.round(fraction * 100);
+                  return (
+                    <div key={group.id} className="grid grid-cols-[minmax(0,1fr)_80px_160px] items-center border-b border-slate-700/60 bg-slate-900/20 px-3 py-2 last:border-b-0">
+                      <span className="truncate text-xs text-slate-200">{group.label}</span>
+                      <span className="text-xs text-slate-300">{pct === null ? "-" : `${pct}%`}</span>
+                      <span className="truncate text-xs text-slate-500">{formatRelativeTime(group.resetTime)}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CapacityCell({ value }: { value: number | null }) {
+  if (value === null) return <span className="text-xs text-slate-500">-</span>;
+  return (
+    <div className="pr-3">
+      <span className="text-xs text-slate-300">{Math.round(value * 100)}%</span>
+      <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-slate-700/70">
+        <div className={cn("h-full", getCapacityBarClass(value))} style={{ width: `${Math.round(value * 100)}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export default function QuotaPage() {
+  const { quotaData, loading, fetchQuota } = useQuotaData();
+  const [selectedProvider, setSelectedProvider] = useState<ProviderType>(PROVIDERS.ALL);
+  const [expandedCards, setExpandedCards] = useState<Record<string, boolean>>({});
+
+  const filteredAccounts = filterAccounts(quotaData?.accounts, selectedProvider);
+  const activeAccounts = filteredAccounts.filter((a) => a.supported && !a.error).length;
+  const providerSummaries = buildProviderSummaries(filteredAccounts);
+  const overallCapacity = calcOverallCapacity(providerSummaries);
+  const lowCapacityCount = providerSummaries.filter(
+    (s) => s.windowCapacities.some((w) => w.capacity < LOW_CAPACITY_THRESHOLD) && s.totalAccounts > 0
+  ).length;
+
+  const toggleCard = (accountId: string) => {
+    setExpandedCards((prev) => ({ ...prev, [accountId]: !prev[accountId] }));
   };
 
   return (
@@ -760,7 +220,7 @@ export default function QuotaPage() {
           </div>
           <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
             <div className="flex flex-wrap gap-1">
-              {providerFilters.map((filter) => (
+              {PROVIDER_FILTERS.map((filter) => (
                 <Button
                   key={filter.key}
                   variant={selectedProvider === filter.key ? "secondary" : "ghost"}
@@ -769,7 +229,7 @@ export default function QuotaPage() {
                     if (filter.key !== PROVIDERS.ALL) {
                       setTimeout(() => {
                         document.getElementById("quota-accounts")?.scrollIntoView({ behavior: "smooth", block: "nearest" });
-                      }, 50);
+                      }, SCROLL_DELAY_MS);
                     }
                   }}
                   className="px-2.5 py-1 text-xs"
@@ -786,9 +246,7 @@ export default function QuotaPage() {
       </section>
 
       {loading && !quotaData ? (
-        <div className="rounded-md border border-slate-700/70 bg-slate-900/25 p-6 text-center text-sm text-slate-400">
-          Loading quota data...
-        </div>
+        <div className="rounded-md border border-slate-700/70 bg-slate-900/25 p-6 text-center text-sm text-slate-400">Loading quota data...</div>
       ) : (
         <>
           <section className="grid grid-cols-2 gap-2 lg:grid-cols-4">
@@ -810,113 +268,12 @@ export default function QuotaPage() {
             </div>
           </section>
 
-          {/* Charts: Capacity Gauge + Provider Comparison */}
           <section className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-            {/* Radial Gauge: Overall Capacity */}
             <ChartContainer title="Overall Capacity" subtitle="Weighted across all providers">
-              {providerSummaries.length === 0 ? (
-                <ChartEmpty message="No provider data" />
-              ) : (() => {
-                const pct = Math.round(overallCapacity.value * 100);
-                const gaugeColor =
-                  overallCapacity.value > 0.6
-                    ? CHART_COLORS.success
-                    : overallCapacity.value > 0.2
-                    ? CHART_COLORS.warning
-                    : CHART_COLORS.danger;
-                const gaugeData = [{ value: pct, fill: gaugeColor }];
-                return (
-                  <div className="relative flex h-48 items-center justify-center">
-                    <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 320, height: 200 }}>
-                      <RadialBarChart
-                        cx="50%"
-                        cy="60%"
-                        innerRadius="55%"
-                        outerRadius="80%"
-                        startAngle={210}
-                        endAngle={-30}
-                        data={[{ value: 100, fill: "rgba(148,163,184,0.1)" }, ...gaugeData]}
-                        barSize={14}
-                      >
-                        <RadialBar dataKey="value" background={false} cornerRadius={4} />
-                      </RadialBarChart>
-                    </ResponsiveContainer>
-                    <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
-                      <span className="text-3xl font-bold" style={{ color: gaugeColor }}>{pct}%</span>
-                      <span className="mt-0.5 text-[10px] uppercase tracking-widest" style={{ color: CHART_COLORS.text.dimmed }}>Capacity</span>
-                    </div>
-                  </div>
-                );
-              })()}
+              <CapacityGauge summaries={providerSummaries} />
             </ChartContainer>
-
-            {/* Horizontal BarChart: Provider capacity with long-term and short-term */}
             <ChartContainer title="Provider Capacity" subtitle="Long-term & short-term window minimum per provider">
-              {providerSummaries.length === 0 ? (
-                <ChartEmpty message="No provider data" />
-              ) : (() => {
-                const barData = providerSummaries.map((s) => {
-                  const longTerm = s.windowCapacities.filter((w) => !w.isShortTerm);
-                  const shortTerm = s.windowCapacities.filter((w) => w.isShortTerm);
-                  const longMin = longTerm.length > 0 ? Math.round(Math.min(...longTerm.map((w) => w.capacity)) * 100) : null;
-                  const shortMin = shortTerm.length > 0 ? Math.round(Math.min(...shortTerm.map((w) => w.capacity)) * 100) : null;
-                  return {
-                    provider: s.provider,
-                    longTerm: longMin,
-                    shortTerm: shortMin,
-                    healthy: s.healthyAccounts,
-                    total: s.totalAccounts,
-                    issues: s.errorAccounts,
-                  };
-                });
-                return (
-                  <div className="h-48">
-                    <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 320, height: 200 }}>
-                      <BarChart
-                        data={barData}
-                        layout="vertical"
-                        margin={{ top: 4, right: 12, bottom: 4, left: 4 }}
-                        barSize={8}
-                        barGap={2}
-                      >
-                        <XAxis
-                          type="number"
-                          domain={[0, 100]}
-                          tick={AXIS_TICK_STYLE}
-                          tickLine={false}
-                          axisLine={{ stroke: CHART_COLORS.border }}
-                          tickFormatter={(v) => `${v}%`}
-                        />
-                        <YAxis
-                          type="category"
-                          dataKey="provider"
-                          tick={{ ...AXIS_TICK_STYLE, fontSize: 10 }}
-                          tickLine={false}
-                          axisLine={false}
-                          width={72}
-                        />
-                        <Tooltip
-                          {...TOOLTIP_STYLE}
-                          formatter={(value, name, props) => {
-                            if (value === null) return ["-", name];
-                            const label = name === "longTerm" ? "Long-Term" : "Short-Term";
-                            const extra = name === "longTerm" ? ` (${props.payload.healthy}/${props.payload.total} healthy${props.payload.issues > 0 ? `, ${props.payload.issues} issues` : ""})` : "";
-                            return [`${value}%${extra}`, label];
-                          }}
-                        />
-                        <Legend
-                          verticalAlign="top"
-                          height={24}
-                          formatter={(value: string) => value === "longTerm" ? "Long-Term" : "Short-Term"}
-                          wrapperStyle={{ fontSize: 10, color: CHART_COLORS.text.dimmed }}
-                        />
-                        <Bar dataKey="longTerm" radius={[0, 3, 3, 0]} fill={CHART_COLORS.success} />
-                        <Bar dataKey="shortTerm" radius={[0, 3, 3, 0]} fill={CHART_COLORS.cyan} />
-                      </BarChart>
-                    </ResponsiveContainer>
-                  </div>
-                );
-              })()}
+              <ProviderCapacityChart summaries={providerSummaries} />
             </ChartContainer>
           </section>
 
@@ -924,106 +281,32 @@ export default function QuotaPage() {
             <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-slate-400">Accounts</h2>
             <div className="overflow-x-auto rounded-md border border-slate-700/70 bg-slate-900/25">
               <div className="min-w-[650px]">
-              <div className="grid grid-cols-[24px_minmax(0,1fr)_120px_120px_140px_140px] border-b border-slate-700/70 bg-slate-900/60 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-slate-400">
-                <span></span>
-                <span>Account</span>
-                <span>Provider</span>
-                <span>Status</span>
-                <span>Long-Term</span>
-                <span>Short-Term</span>
+                <div className="grid grid-cols-[24px_minmax(0,1fr)_120px_120px_140px_140px] border-b border-slate-700/70 bg-slate-900/60 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-slate-400">
+                  <span></span>
+                  <span>Account</span>
+                  <span>Provider</span>
+                  <span>Status</span>
+                  <span>Long-Term</span>
+                  <span>Short-Term</span>
+                </div>
+                {filteredAccounts.map((account) => (
+                  <AccountRow
+                    key={account.auth_index}
+                    account={account}
+                    isExpanded={!!expandedCards[account.auth_index]}
+                    onToggle={() => toggleCard(account.auth_index)}
+                  />
+                ))}
               </div>
-
-              {filteredAccounts.map((account) => {
-                const isRowExpanded = expandedCards[account.auth_index];
-                const scores = account.groups ? Object.values(calcAccountWindowScores(account.groups)) : [];
-                const longScores = scores.filter((s) => !s.isShortTerm);
-                const shortScores = scores.filter((s) => s.isShortTerm);
-                const longMin = longScores.length > 0 ? Math.min(...longScores.map((s) => s.score)) : null;
-                const shortMin = shortScores.length > 0 ? Math.min(...shortScores.map((s) => s.score)) : null;
-                const statusLabel = account.supported ? (account.error ? "Error" : "Active") : "Unsupported";
-
-                return (
-                  <div key={account.auth_index} className="border-b border-slate-700/60 last:border-b-0">
-                    <button
-                      type="button"
-                      onClick={() => toggleCard(account.auth_index)}
-                      className="grid w-full grid-cols-[24px_minmax(0,1fr)_120px_120px_140px_140px] items-center px-3 py-2 text-left transition-colors hover:bg-slate-800/40"
-                    >
-                      <span className={cn("text-xs text-slate-500 transition-transform", isRowExpanded && "rotate-180")}>⌄</span>
-                      <span className="truncate text-xs text-slate-200">{maskEmail(account.email)}</span>
-                      <span className="truncate text-xs capitalize text-slate-300">{account.provider}</span>
-                      <span className={cn("text-xs", account.error ? "text-rose-300" : account.supported ? "text-emerald-300" : "text-amber-300")}>{statusLabel}</span>
-                      <div className="pr-3">
-                        {longMin !== null ? (
-                          <>
-                            <span className="text-xs text-slate-300">{Math.round(longMin * 100)}%</span>
-                            <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-slate-700/70">
-                              <div className={cn("h-full", getCapacityBarClass(longMin))} style={{ width: `${Math.round(longMin * 100)}%` }} />
-                            </div>
-                          </>
-                        ) : (
-                          <span className="text-xs text-slate-500">-</span>
-                        )}
-                      </div>
-                      <div className="pr-3">
-                        {shortMin !== null ? (
-                          <>
-                            <span className="text-xs text-slate-300">{Math.round(shortMin * 100)}%</span>
-                            <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-slate-700/70">
-                              <div className={cn("h-full", getCapacityBarClass(shortMin))} style={{ width: `${Math.round(shortMin * 100)}%` }} />
-                            </div>
-                          </>
-                        ) : (
-                          <span className="text-xs text-slate-500">-</span>
-                        )}
-                      </div>
-                     </button>
-
-                      {isRowExpanded && (
-                        <div className="border-t border-slate-700/60 bg-slate-900/30 px-4 py-3">
-                          {account.error && (
-                            <p className="mb-2 break-all text-xs text-rose-300">{account.error}</p>
-                          )}
-                          {!account.supported && !account.error && (
-                            <p className="mb-2 text-xs text-amber-300">Quota monitoring not available for this provider.</p>
-                          )}
-
-                          {account.groups && account.groups.length > 0 && (
-                            <div className="overflow-x-auto rounded-sm border border-slate-700/70">
-                              <div className="min-w-[400px]">
-                              {account.groups.map((group) => {
-                                const fraction = normalizeFraction(group.remainingFraction);
-                                const pct = fraction === null ? null : Math.round(fraction * 100);
-                                return (
-                                  <div key={group.id} className="grid grid-cols-[minmax(0,1fr)_80px_160px] items-center border-b border-slate-700/60 bg-slate-900/20 px-3 py-2 last:border-b-0">
-                                    <span className="truncate text-xs text-slate-200">{group.label}</span>
-                                    <span className="text-xs text-slate-300">{pct === null ? "-" : `${pct}%`}</span>
-                                    <span className="truncate text-xs text-slate-500">{formatRelativeTime(group.resetTime)}</span>
-                                  </div>
-                                );
-                              })}
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                      )}
-                   </div>
-                 );
-                })}
-              </div>
-              </div>
-
+            </div>
             {filteredAccounts.length === 0 && !loading && (
-              <div className="rounded-md border border-slate-700/70 bg-slate-900/25 p-6 text-center text-sm text-slate-400">
-                No accounts found for the selected filter.
-              </div>
+              <div className="rounded-md border border-slate-700/70 bg-slate-900/25 p-6 text-center text-sm text-slate-400">No accounts found for the selected filter.</div>
             )}
           </section>
         </>
       )}
 
       <TelegramAlertsSection />
-
     </div>
   );
 }

--- a/dashboard/src/components/oh-my-opencode/_components/lsp-section.tsx
+++ b/dashboard/src/components/oh-my-opencode/_components/lsp-section.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import type { OhMyOpenCodeFullConfig } from "@/lib/config-generators/oh-my-opencode-types";
+
+const LSP_PRESETS = [
+  { language: "typescript", command: "typescript-language-server --stdio", extensions: ".ts,.tsx", color: "emerald" },
+  { language: "tailwindcss", command: "tailwindcss-language-server --stdio", extensions: "", color: "cyan" },
+  { language: "prisma", command: "npx -y @prisma/language-server --stdio", extensions: ".prisma", color: "teal" },
+  { language: "markdown", command: "npx -y remark-language-server --stdio", extensions: ".md", color: "blue" },
+] as const;
+
+const PRESET_CLASSES: Record<string, string> = {
+  emerald: "bg-emerald-500/10 border-emerald-400/20 text-emerald-300 hover:bg-emerald-500/20 hover:border-emerald-400/40",
+  cyan: "bg-cyan-500/10 border-cyan-400/20 text-cyan-300 hover:bg-cyan-500/20 hover:border-cyan-400/40",
+  teal: "bg-teal-500/10 border-teal-400/20 text-teal-300 hover:bg-teal-500/20 hover:border-teal-400/40",
+  blue: "bg-blue-500/10 border-blue-400/20 text-blue-300 hover:bg-blue-500/20 hover:border-blue-400/40",
+};
+
+interface LspSectionProps {
+  overrides: OhMyOpenCodeFullConfig;
+  onLspAdd: (language: string, command: string, extensions: string) => boolean;
+  onLspRemove: (language: string) => void;
+}
+
+export function LspSection({ overrides, onLspAdd, onLspRemove }: LspSectionProps) {
+  const [lspLanguage, setLspLanguage] = useState("");
+  const [lspCommand, setLspCommand] = useState("");
+  const [lspExtensions, setLspExtensions] = useState("");
+
+  const handleLspAdd = () => {
+    const shouldClear = onLspAdd(lspLanguage, lspCommand, lspExtensions);
+    if (shouldClear) {
+      setLspLanguage("");
+      setLspCommand("");
+      setLspExtensions("");
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-emerald-400/30 bg-emerald-500/5 p-4 space-y-3">
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-emerald-300 flex items-center gap-2">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <polyline points="16 18 22 12 16 6" />
+              <polyline points="8 6 2 12 8 18" />
+            </svg>
+            LSP Servers
+          </h3>
+          <p className="text-xs text-white/50 mt-1">Configure Language Server Protocol for code intelligence</p>
+          <code className="text-[10px] text-emerald-300/60 font-mono block mt-1.5 bg-black/20 px-2 py-1 rounded">
+            {`"lsp": { "typescript": { "command": ["typescript-language-server", "--stdio"] } }`}
+          </code>
+        </div>
+        <span className="px-2 py-1 rounded-lg bg-emerald-500/10 border border-emerald-400/20 text-emerald-300 text-xs font-mono shrink-0">
+          {Object.keys(overrides.lsp ?? {}).length} configured
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+        {LSP_PRESETS.map((preset) => (
+          <button
+            key={preset.language}
+            type="button"
+            onClick={() => {
+              setLspLanguage(preset.language);
+              setLspCommand(preset.command);
+              setLspExtensions(preset.extensions);
+            }}
+            className={`px-3 py-2 rounded-lg border text-xs font-medium transition-all ${PRESET_CLASSES[preset.color]}`}
+          >
+            {preset.language.charAt(0).toUpperCase() + preset.language.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-[1fr,2fr,1.5fr,auto] gap-2">
+        <input
+          type="text"
+          placeholder="language"
+          value={lspLanguage}
+          onChange={(e) => setLspLanguage(e.target.value)}
+          className="px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white placeholder:text-white/30 focus:outline-none focus:border-emerald-400/40"
+        />
+        <input
+          type="text"
+          placeholder="command"
+          value={lspCommand}
+          onChange={(e) => setLspCommand(e.target.value)}
+          className="px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white placeholder:text-white/30 focus:outline-none focus:border-emerald-400/40"
+        />
+        <input
+          type="text"
+          placeholder=".ts,.tsx (optional)"
+          value={lspExtensions}
+          onChange={(e) => setLspExtensions(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleLspAdd();
+            }
+          }}
+          className="px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white placeholder:text-white/30 focus:outline-none focus:border-emerald-400/40"
+        />
+        <button
+          type="button"
+          onClick={handleLspAdd}
+          className="px-3 py-1.5 text-xs bg-emerald-500/20 text-emerald-300 rounded-lg hover:bg-emerald-500/30"
+        >
+          Add
+        </button>
+      </div>
+
+      {Object.keys(overrides.lsp ?? {}).length > 0 && (
+        <div className="space-y-1.5">
+          {Object.entries(overrides.lsp ?? {}).map(([language, entry]) => (
+            <div
+              key={language}
+              className="flex items-center justify-between px-3 py-2 rounded-lg bg-emerald-500/10 border border-emerald-400/20"
+            >
+              <div className="flex items-center gap-2 text-xs font-mono">
+                <span className="text-emerald-300">{language}</span>
+                <span className="text-white/30">&rarr;</span>
+                <span className="text-white/60">{entry.command.join(" ")}</span>
+                {entry.extensions && entry.extensions.length > 0 && (
+                  <>
+                    <span className="text-white/30">|</span>
+                    <span className="text-white/50">{entry.extensions.join(", ")}</span>
+                  </>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => onLspRemove(language)}
+                className="text-white/40 hover:text-red-400 transition-colors"
+              >
+                &times;
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/oh-my-opencode/_components/toggle-ui.tsx
+++ b/dashboard/src/components/oh-my-opencode/_components/toggle-ui.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+export function ChevronIcon({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`transition-transform duration-200 ${expanded ? "rotate-90" : ""}`}
+      aria-hidden="true"
+    >
+      <polyline points="9 18 15 12 9 6" />
+    </svg>
+  );
+}
+
+export function ToggleSwitch({ enabled, onToggle }: { enabled: boolean; onToggle: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={`w-9 h-5 rounded-full transition-colors relative ${
+        enabled ? "bg-emerald-500/60" : "bg-white/10"
+      }`}
+    >
+      <span
+        className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform ${
+          enabled ? "translate-x-4 bg-emerald-200" : "bg-white/40"
+        }`}
+      />
+    </button>
+  );
+}
+
+interface CollapsibleSectionProps {
+  label: string;
+  expanded: boolean;
+  onToggle: () => void;
+  badge?: ReactNode;
+  children: ReactNode;
+}
+
+export function CollapsibleSection({ label, expanded, onToggle, badge, children }: CollapsibleSectionProps) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/[0.02] overflow-hidden transition-all hover:border-white/15">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full flex items-center gap-2 px-3 py-2.5 text-xs font-medium text-white/60 hover:text-white/90 hover:bg-white/[0.04] transition-colors"
+      >
+        <ChevronIcon expanded={expanded} />
+        <span className="flex-1 text-left">{label}</span>
+        {badge}
+      </button>
+      {expanded && <div className="px-3 pb-3">{children}</div>}
+    </div>
+  );
+}
+
+export function DisabledCountBadge({ count }: { count: number }) {
+  return (
+    <span className="px-1.5 py-0.5 rounded-md bg-white/5 text-white/50 text-[10px] font-mono">
+      {count} disabled
+    </span>
+  );
+}
+
+interface ToggleListProps {
+  items: readonly string[];
+  disabledItems: readonly string[];
+  onToggle: (item: string) => void;
+}
+
+export function ToggleList({ items, disabledItems, onToggle }: ToggleListProps) {
+  return (
+    <div className="space-y-1">
+      {items.map((item) => {
+        const isEnabled = !disabledItems.includes(item);
+        return (
+          <div key={item} className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-white/5">
+            <span className="text-xs text-white/70 font-mono">{item}</span>
+            <ToggleSwitch enabled={isEnabled} onToggle={() => onToggle(item)} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/components/oh-my-opencode/toggle-sections.tsx
+++ b/dashboard/src/components/oh-my-opencode/toggle-sections.tsx
@@ -19,6 +19,9 @@ import {
   TMUX_LAYOUTS,
 } from "@/lib/config-generators/oh-my-opencode-types";
 
+import { ChevronIcon, CollapsibleSection, DisabledCountBadge, ToggleList, ToggleSwitch } from "./_components/toggle-ui";
+import { LspSection } from "./_components/lsp-section";
+
 interface ToggleSectionsProps {
   overrides: OhMyOpenCodeFullConfig;
   providerConcurrencyRows: Array<{ key: string; value: number }>;
@@ -84,9 +87,6 @@ export function ToggleSections({
   const [showBrowser, setShowBrowser] = useState(false);
   const [showMcps, setShowMcps] = useState(false);
   const [mcpInput, setMcpInput] = useState("");
-  const [lspLanguage, setLspLanguage] = useState("");
-  const [lspCommand, setLspCommand] = useState("");
-  const [lspExtensions, setLspExtensions] = useState("");
 
   const toggleHookGroup = (group: HookGroupName) => {
     const newExpanded = new Set(expandedHookGroups);
@@ -105,846 +105,279 @@ export function ToggleSections({
     }
   };
 
-  const handleLspAdd = () => {
-    const shouldClear = onLspAdd(lspLanguage, lspCommand, lspExtensions);
-    if (shouldClear) {
-      setLspLanguage("");
-      setLspCommand("");
-      setLspExtensions("");
-    }
-  };
-
   return (
     <>
-      <div className="rounded-xl border border-emerald-400/30 bg-emerald-500/5 p-4 space-y-3">
-        <div className="flex items-start justify-between">
-          <div className="flex-1">
-            <h3 className="text-sm font-semibold text-emerald-300 flex items-center gap-2">
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <polyline points="16 18 22 12 16 6" />
-                <polyline points="8 6 2 12 8 18" />
-              </svg>
-              LSP Servers
-            </h3>
-            <p className="text-xs text-white/50 mt-1">Configure Language Server Protocol for code intelligence</p>
-            <code className="text-[10px] text-emerald-300/60 font-mono block mt-1.5 bg-black/20 px-2 py-1 rounded">
-              {`"lsp": { "typescript": { "command": ["typescript-language-server", "--stdio"] } }`}
-            </code>
-          </div>
-          <span className="px-2 py-1 rounded-lg bg-emerald-500/10 border border-emerald-400/20 text-emerald-300 text-xs font-mono shrink-0">
-            {Object.keys(overrides.lsp ?? {}).length} configured
-          </span>
-        </div>
-
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-          <button
-            type="button"
-            onClick={() => {
-              setLspLanguage("typescript");
-              setLspCommand("typescript-language-server --stdio");
-              setLspExtensions(".ts,.tsx");
-            }}
-            className="px-3 py-2 rounded-lg bg-emerald-500/10 border border-emerald-400/20 text-emerald-300 text-xs font-medium hover:bg-emerald-500/20 hover:border-emerald-400/40 transition-all"
-          >
-            TypeScript
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setLspLanguage("tailwindcss");
-              setLspCommand("tailwindcss-language-server --stdio");
-              setLspExtensions("");
-            }}
-            className="px-3 py-2 rounded-lg bg-cyan-500/10 border border-cyan-400/20 text-cyan-300 text-xs font-medium hover:bg-cyan-500/20 hover:border-cyan-400/40 transition-all"
-          >
-            Tailwind
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setLspLanguage("prisma");
-              setLspCommand("npx -y @prisma/language-server --stdio");
-              setLspExtensions(".prisma");
-            }}
-            className="px-3 py-2 rounded-lg bg-teal-500/10 border border-teal-400/20 text-teal-300 text-xs font-medium hover:bg-teal-500/20 hover:border-teal-400/40 transition-all"
-          >
-            Prisma
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setLspLanguage("markdown");
-              setLspCommand("npx -y remark-language-server --stdio");
-              setLspExtensions(".md");
-            }}
-            className="px-3 py-2 rounded-lg bg-blue-500/10 border border-blue-400/20 text-blue-300 text-xs font-medium hover:bg-blue-500/20 hover:border-blue-400/40 transition-all"
-          >
-            Markdown
-          </button>
-        </div>
-
-        <div className="grid grid-cols-[1fr,2fr,1.5fr,auto] gap-2">
-          <input
-            type="text"
-            placeholder="language"
-            value={lspLanguage}
-            onChange={(e) => setLspLanguage(e.target.value)}
-            className="px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white placeholder:text-white/30 focus:outline-none focus:border-emerald-400/40"
-          />
-          <input
-            type="text"
-            placeholder="command"
-            value={lspCommand}
-            onChange={(e) => setLspCommand(e.target.value)}
-            className="px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white placeholder:text-white/30 focus:outline-none focus:border-emerald-400/40"
-          />
-          <input
-            type="text"
-            placeholder=".ts,.tsx (optional)"
-            value={lspExtensions}
-            onChange={(e) => setLspExtensions(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                handleLspAdd();
-              }
-            }}
-            className="px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white placeholder:text-white/30 focus:outline-none focus:border-emerald-400/40"
-          />
-          <button
-            type="button"
-            onClick={handleLspAdd}
-            className="px-3 py-1.5 text-xs bg-emerald-500/20 text-emerald-300 rounded-lg hover:bg-emerald-500/30"
-          >
-            Add
-          </button>
-        </div>
-
-        {Object.keys(overrides.lsp ?? {}).length > 0 && (
-          <div className="space-y-1.5">
-            {Object.entries(overrides.lsp ?? {}).map(([language, entry]) => (
-              <div
-                key={language}
-                className="flex items-center justify-between px-3 py-2 rounded-lg bg-emerald-500/10 border border-emerald-400/20"
-              >
-                <div className="flex items-center gap-2 text-xs font-mono">
-                  <span className="text-emerald-300">{language}</span>
-                  <span className="text-white/30">→</span>
-                  <span className="text-white/60">{entry.command.join(" ")}</span>
-                  {entry.extensions && entry.extensions.length > 0 && (
-                    <>
-                      <span className="text-white/30">|</span>
-                      <span className="text-white/50">{entry.extensions.join(", ")}</span>
-                    </>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => onLspRemove(language)}
-                  className="text-white/40 hover:text-red-400 transition-colors"
-                >
-                  ×
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
+      <LspSection overrides={overrides} onLspAdd={onLspAdd} onLspRemove={onLspRemove} />
 
       <div className="border-t border-white/5 pt-4">
         <div className="flex flex-col md:flex-row gap-3">
           <div className="flex-1 space-y-3">
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] overflow-hidden transition-all hover:border-white/15">
-              <button
-                type="button"
-                onClick={() => setShowAgents(!showAgents)}
-                className="w-full flex items-center gap-2 px-3 py-2.5 text-xs font-medium text-white/60 hover:text-white/90 hover:bg-white/[0.04] transition-colors"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className={`transition-transform duration-200 ${showAgents ? "rotate-90" : ""}`}
-                  aria-hidden="true"
-                >
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-                <span className="flex-1 text-left">Agents</span>
-                <span className="px-1.5 py-0.5 rounded-md bg-white/5 text-white/50 text-[10px] font-mono">
-                  {(overrides.disabled_agents ?? []).length} disabled
-                </span>
-              </button>
-              {showAgents && (
-                <div className="px-3 pb-3 space-y-1">
-                  {AVAILABLE_AGENTS.map((agent) => {
-                    const isEnabled = !(overrides.disabled_agents ?? []).includes(agent);
-                    return (
-                      <div key={agent} className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-white/5">
-                        <span className="text-xs text-white/70 font-mono">{agent}</span>
-                        <button
-                          type="button"
-                          onClick={() => onDisabledAgentToggle(agent)}
-                          className={`w-9 h-5 rounded-full transition-colors relative ${
-                            isEnabled ? "bg-emerald-500/60" : "bg-white/10"
-                          }`}
-                        >
-                          <span
-                            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform ${
-                              isEnabled ? "translate-x-4 bg-emerald-200" : "bg-white/40"
-                            }`}
-                          />
-                        </button>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
+            {/* Agents */}
+            <CollapsibleSection
+              label="Agents"
+              expanded={showAgents}
+              onToggle={() => setShowAgents(!showAgents)}
+              badge={<DisabledCountBadge count={(overrides.disabled_agents ?? []).length} />}
+            >
+              <ToggleList items={AVAILABLE_AGENTS} disabledItems={overrides.disabled_agents ?? []} onToggle={onDisabledAgentToggle} />
+            </CollapsibleSection>
 
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] overflow-hidden transition-all hover:border-white/15">
-              <button
-                type="button"
-                onClick={() => setShowCommands(!showCommands)}
-                className="w-full flex items-center gap-2 px-3 py-2.5 text-xs font-medium text-white/60 hover:text-white/90 hover:bg-white/[0.04] transition-colors"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className={`transition-transform duration-200 ${showCommands ? "rotate-90" : ""}`}
-                  aria-hidden="true"
-                >
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-                <span className="flex-1 text-left">Commands</span>
-                <span className="px-1.5 py-0.5 rounded-md bg-white/5 text-white/50 text-[10px] font-mono">
-                  {(overrides.disabled_commands ?? []).length} disabled
-                </span>
-              </button>
-              {showCommands && (
-                <div className="px-3 pb-3 space-y-1">
-                  {AVAILABLE_COMMANDS.map((command) => {
-                    const isEnabled = !(overrides.disabled_commands ?? []).includes(command);
-                    return (
-                      <div key={command} className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-white/5">
-                        <span className="text-xs text-white/70 font-mono">{command}</span>
-                        <button
-                          type="button"
-                          onClick={() => onDisabledCommandToggle(command)}
-                          className={`w-9 h-5 rounded-full transition-colors relative ${
-                            isEnabled ? "bg-emerald-500/60" : "bg-white/10"
-                          }`}
-                        >
-                          <span
-                            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform ${
-                              isEnabled ? "translate-x-4 bg-emerald-200" : "bg-white/40"
-                            }`}
-                          />
-                        </button>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
+            {/* Commands */}
+            <CollapsibleSection
+              label="Commands"
+              expanded={showCommands}
+              onToggle={() => setShowCommands(!showCommands)}
+              badge={<DisabledCountBadge count={(overrides.disabled_commands ?? []).length} />}
+            >
+              <ToggleList items={AVAILABLE_COMMANDS} disabledItems={overrides.disabled_commands ?? []} onToggle={onDisabledCommandToggle} />
+            </CollapsibleSection>
 
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] overflow-hidden transition-all hover:border-white/15">
-              <button
-                type="button"
-                onClick={() => setShowTmux(!showTmux)}
-                className="w-full flex items-center gap-2 px-3 py-2.5 text-xs font-medium text-white/60 hover:text-white/90 hover:bg-white/[0.04] transition-colors"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className={`transition-transform duration-200 ${showTmux ? "rotate-90" : ""}`}
-                  aria-hidden="true"
-                >
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-                <span className="flex-1 text-left">Tmux</span>
+            {/* Tmux */}
+            <CollapsibleSection
+              label="Tmux"
+              expanded={showTmux}
+              onToggle={() => setShowTmux(!showTmux)}
+              badge={overrides.tmux?.enabled ? (
+                <span className="px-1.5 py-0.5 rounded-md bg-emerald-500/10 text-emerald-400/80 text-[10px] font-mono">enabled</span>
+              ) : undefined}
+            >
+              <div className="space-y-2">
+                <div className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-white/5">
+                  <span className="text-xs text-white/70 font-mono">Enabled</span>
+                  <ToggleSwitch enabled={!!overrides.tmux?.enabled} onToggle={onTmuxEnabledToggle} />
+                </div>
                 {overrides.tmux?.enabled && (
-                  <span className="px-1.5 py-0.5 rounded-md bg-emerald-500/10 text-emerald-400/80 text-[10px] font-mono">
-                    enabled
-                  </span>
+                  <>
+                    <div className="space-y-1">
+                      <span className="text-xs text-white/50">Layout</span>
+                      <select
+                        value={overrides.tmux.layout ?? "main-vertical"}
+                        onChange={(e) => onTmuxLayoutChange(e.target.value)}
+                        className="w-full px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
+                      >
+                        {TMUX_LAYOUTS.map((layout) => (
+                          <option key={layout} value={layout}>{layout}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <NumberField label="Main Pane Size (20-80)" min={20} max={80} defaultValue={overrides.tmux.main_pane_size ?? 60} onChange={(v) => onTmuxNumberChange("main_pane_size", v)} />
+                    <NumberField label="Main Pane Min Width" min={0} defaultValue={overrides.tmux.main_pane_min_width ?? 120} onChange={(v) => onTmuxNumberChange("main_pane_min_width", v)} />
+                    <NumberField label="Agent Pane Min Width" min={0} defaultValue={overrides.tmux.agent_pane_min_width ?? 40} onChange={(v) => onTmuxNumberChange("agent_pane_min_width", v)} />
+                  </>
                 )}
-              </button>
-              {showTmux && (
-                <div className="px-3 pb-3 space-y-2">
-                  <div className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-white/5">
-                    <span className="text-xs text-white/70 font-mono">Enabled</span>
-                    <button
-                      type="button"
-                      onClick={onTmuxEnabledToggle}
-                      className={`w-9 h-5 rounded-full transition-colors relative ${
-                        overrides.tmux?.enabled ? "bg-emerald-500/60" : "bg-white/10"
-                      }`}
-                    >
-                      <span
-                        className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform ${
-                          overrides.tmux?.enabled ? "translate-x-4 bg-emerald-200" : "bg-white/40"
-                        }`}
-                      />
-                    </button>
+              </div>
+            </CollapsibleSection>
+
+            {/* Sisyphus Agent */}
+            <CollapsibleSection label="Sisyphus Agent" expanded={showSisyphus} onToggle={() => setShowSisyphus(!showSisyphus)}>
+              <div className="space-y-1">
+                {([
+                  { field: "disabled" as const, label: "Disabled", defaultValue: false },
+                  { field: "default_builder_enabled" as const, label: "Default Builder Enabled", defaultValue: false },
+                  { field: "planner_enabled" as const, label: "Planner Enabled", defaultValue: true },
+                  { field: "replace_plan" as const, label: "Replace Plan", defaultValue: true },
+                ] as const).map(({ field, label, defaultValue }) => (
+                  <div key={field} className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-white/5">
+                    <span className="text-xs text-white/70 font-mono">{label}</span>
+                    <ToggleSwitch enabled={overrides.sisyphus_agent?.[field] ?? defaultValue} onToggle={() => onSisyphusToggle(field)} />
                   </div>
-                  {overrides.tmux?.enabled && (
-                    <>
-                      <div className="space-y-1">
-                        <span className="text-xs text-white/50">Layout</span>
-                        <select
-                          value={overrides.tmux.layout ?? "main-vertical"}
-                          onChange={(e) => onTmuxLayoutChange(e.target.value)}
-                          className="w-full px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
-                        >
-                          {TMUX_LAYOUTS.map((layout) => (
-                            <option key={layout} value={layout}>
-                              {layout}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                      <div className="space-y-1">
-                        <span className="text-xs text-white/50">Main Pane Size (20-80)</span>
-                        <input
-                          type="number"
-                          min={20}
-                          max={80}
-                          defaultValue={overrides.tmux.main_pane_size ?? 60}
-                          onChange={(e) => onTmuxNumberChange("main_pane_size", Number(e.target.value))}
-                          className="w-full px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
-                        />
-                      </div>
-                      <div className="space-y-1">
-                        <span className="text-xs text-white/50">Main Pane Min Width</span>
-                        <input
-                          type="number"
-                          min={0}
-                          defaultValue={overrides.tmux.main_pane_min_width ?? 120}
-                          onChange={(e) => onTmuxNumberChange("main_pane_min_width", Number(e.target.value))}
-                          className="w-full px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
-                        />
-                      </div>
-                      <div className="space-y-1">
-                        <span className="text-xs text-white/50">Agent Pane Min Width</span>
-                        <input
-                          type="number"
-                          min={0}
-                          defaultValue={overrides.tmux.agent_pane_min_width ?? 40}
-                          onChange={(e) => onTmuxNumberChange("agent_pane_min_width", Number(e.target.value))}
-                          className="w-full px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
-                        />
-                      </div>
-                    </>
-                  )}
-                </div>
-              )}
-            </div>
+                ))}
+              </div>
+            </CollapsibleSection>
 
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] overflow-hidden transition-all hover:border-white/15">
-              <button
-                type="button"
-                onClick={() => setShowSisyphus(!showSisyphus)}
-                className="w-full flex items-center gap-2 px-3 py-2.5 text-xs font-medium text-white/60 hover:text-white/90 hover:bg-white/[0.04] transition-colors"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className={`transition-transform duration-200 ${showSisyphus ? "rotate-90" : ""}`}
-                  aria-hidden="true"
+            {/* Browser Automation */}
+            <CollapsibleSection label="Browser Automation" expanded={showBrowser} onToggle={() => setShowBrowser(!showBrowser)}>
+              <div className="space-y-1">
+                <span className="text-xs text-white/50">Provider</span>
+                <select
+                  value={overrides.browser_automation_engine?.provider ?? "playwright"}
+                  onChange={(e) => onBrowserProviderChange(e.target.value)}
+                  className="w-full px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
                 >
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-                <span className="flex-1 text-left">Sisyphus Agent</span>
-              </button>
-              {showSisyphus && (
-                <div className="px-3 pb-3 space-y-1">
-                  {[
-                    { field: "disabled" as const, label: "Disabled", defaultValue: false },
-                    { field: "default_builder_enabled" as const, label: "Default Builder Enabled", defaultValue: false },
-                    { field: "planner_enabled" as const, label: "Planner Enabled", defaultValue: true },
-                    { field: "replace_plan" as const, label: "Replace Plan", defaultValue: true },
-                  ].map(({ field, label, defaultValue }) => {
-                    const isEnabled = overrides.sisyphus_agent?.[field] ?? defaultValue;
-                    return (
-                      <div key={field} className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-white/5">
-                        <span className="text-xs text-white/70 font-mono">{label}</span>
-                        <button
-                          type="button"
-                          onClick={() => onSisyphusToggle(field)}
-                          className={`w-9 h-5 rounded-full transition-colors relative ${
-                            isEnabled ? "bg-emerald-500/60" : "bg-white/10"
-                          }`}
-                        >
-                          <span
-                            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform ${
-                              isEnabled ? "translate-x-4 bg-emerald-200" : "bg-white/40"
-                            }`}
-                          />
-                        </button>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] overflow-hidden transition-all hover:border-white/15">
-              <button
-                type="button"
-                onClick={() => setShowBrowser(!showBrowser)}
-                className="w-full flex items-center gap-2 px-3 py-2.5 text-xs font-medium text-white/60 hover:text-white/90 hover:bg-white/[0.04] transition-colors"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className={`transition-transform duration-200 ${showBrowser ? "rotate-90" : ""}`}
-                  aria-hidden="true"
-                >
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-                <span className="flex-1 text-left">Browser Automation</span>
-              </button>
-              {showBrowser && (
-                <div className="px-3 pb-3 space-y-1">
-                  <span className="text-xs text-white/50">Provider</span>
-                  <select
-                    value={overrides.browser_automation_engine?.provider ?? "playwright"}
-                    onChange={(e) => onBrowserProviderChange(e.target.value)}
-                    className="w-full px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
-                  >
-                    {BROWSER_PROVIDERS.map((provider) => (
-                      <option key={provider} value={provider}>
-                        {provider}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              )}
-            </div>
+                  {BROWSER_PROVIDERS.map((provider) => (
+                    <option key={provider} value={provider}>{provider}</option>
+                  ))}
+                </select>
+              </div>
+            </CollapsibleSection>
           </div>
 
           <div className="flex-1 space-y-3">
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] overflow-hidden transition-all hover:border-white/15">
-              <button
-                type="button"
-                onClick={() => setShowSkills(!showSkills)}
-                className="w-full flex items-center gap-2 px-3 py-2.5 text-xs font-medium text-white/60 hover:text-white/90 hover:bg-white/[0.04] transition-colors"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className={`transition-transform duration-200 ${showSkills ? "rotate-90" : ""}`}
-                  aria-hidden="true"
-                >
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-                <span className="flex-1 text-left">Skills</span>
-                <span className="px-1.5 py-0.5 rounded-md bg-white/5 text-white/50 text-[10px] font-mono">
-                  {(overrides.disabled_skills ?? []).length} disabled
-                </span>
-              </button>
-              {showSkills && (
-                <div className="px-3 pb-3 space-y-1">
-                  {AVAILABLE_SKILLS.map((skill) => {
-                    const isEnabled = !(overrides.disabled_skills ?? []).includes(skill);
-                    return (
-                      <div key={skill} className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-white/5">
-                        <span className="text-xs text-white/70 font-mono">{skill}</span>
-                        <button
-                          type="button"
-                          onClick={() => onDisabledSkillToggle(skill)}
-                          className={`w-9 h-5 rounded-full transition-colors relative ${
-                            isEnabled ? "bg-emerald-500/60" : "bg-white/10"
-                          }`}
-                        >
-                          <span
-                            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform ${
-                              isEnabled ? "translate-x-4 bg-emerald-200" : "bg-white/40"
-                            }`}
-                          />
-                        </button>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
+            {/* Skills */}
+            <CollapsibleSection
+              label="Skills"
+              expanded={showSkills}
+              onToggle={() => setShowSkills(!showSkills)}
+              badge={<DisabledCountBadge count={(overrides.disabled_skills ?? []).length} />}
+            >
+              <ToggleList items={AVAILABLE_SKILLS} disabledItems={overrides.disabled_skills ?? []} onToggle={onDisabledSkillToggle} />
+            </CollapsibleSection>
 
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] overflow-hidden transition-all hover:border-white/15">
-              <button
-                type="button"
-                onClick={() => setShowHooks(!showHooks)}
-                className="w-full flex items-center gap-2 px-3 py-2.5 text-xs font-medium text-white/60 hover:text-white/90 hover:bg-white/[0.04] transition-colors"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className={`transition-transform duration-200 ${showHooks ? "rotate-90" : ""}`}
-                  aria-hidden="true"
-                >
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-                <span className="flex-1 text-left">Hooks</span>
-                <span className="px-1.5 py-0.5 rounded-md bg-white/5 text-white/50 text-[10px] font-mono">
-                  {(overrides.disabled_hooks ?? []).length} disabled
-                </span>
-              </button>
-              {showHooks && (
-                <div className="px-3 pb-3 space-y-2">
-                  {(Object.entries(HOOK_GROUPS) as [HookGroupName, readonly string[]][]).map(([groupName, hooks]) => {
-                    const disabledCount = hooks.filter((h) => (overrides.disabled_hooks ?? []).includes(h)).length;
-                    const isGroupExpanded = expandedHookGroups.has(groupName);
-                    return (
-                      <div key={groupName}>
-                        <button
-                          type="button"
-                          onClick={() => toggleHookGroup(groupName)}
-                          className="flex items-center gap-2 text-xs text-white/50 hover:text-white/80 transition-colors"
-                        >
-                          <svg
-                            width="10"
-                            height="10"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            className={`transition-transform duration-200 ${isGroupExpanded ? "rotate-90" : ""}`}
-                            aria-hidden="true"
-                          >
-                            <polyline points="9 18 15 12 9 6" />
-                          </svg>
-                          {groupName} ({disabledCount}/{hooks.length} disabled)
-                        </button>
-                        {isGroupExpanded && (
-                          <div className="space-y-1 pl-4 mt-1">
-                            {hooks.map((hook) => {
-                              const isEnabled = !(overrides.disabled_hooks ?? []).includes(hook);
-                              return (
-                                <div key={hook} className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-white/5">
-                                  <span className="text-xs text-white/70 font-mono">{hook}</span>
-                                  <button
-                                    type="button"
-                                    onClick={() => onDisabledHookToggle(hook)}
-                                    className={`w-9 h-5 rounded-full transition-colors relative ${
-                                      isEnabled ? "bg-emerald-500/60" : "bg-white/10"
-                                    }`}
-                                  >
-                                    <span
-                                      className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform ${
-                                        isEnabled ? "translate-x-4 bg-emerald-200" : "bg-white/40"
-                                      }`}
-                                    />
-                                  </button>
-                                </div>
-                              );
-                            })}
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] overflow-hidden transition-all hover:border-white/15">
-              <button
-                type="button"
-                onClick={() => setShowBgTask(!showBgTask)}
-                className="w-full flex items-center gap-2 px-3 py-2.5 text-xs font-medium text-white/60 hover:text-white/90 hover:bg-white/[0.04] transition-colors"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className={`transition-transform duration-200 ${showBgTask ? "rotate-90" : ""}`}
-                  aria-hidden="true"
-                >
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-                <span className="flex-1 text-left">Background Tasks</span>
-              </button>
-              {showBgTask && (
-                <div className="px-3 pb-3 space-y-2">
-                  <div className="space-y-1">
-                    <span className="text-xs text-white/50">Default Concurrency</span>
-                    <input
-                      type="number"
-                      min={1}
-                      defaultValue={overrides.background_task?.defaultConcurrency ?? 5}
-                      onChange={(e) => onBgTaskNumberChange("defaultConcurrency", Number(e.target.value))}
-                      className="w-full px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <span className="text-xs text-white/50">Stale Timeout (ms)</span>
-                    <input
-                      type="number"
-                      min={60000}
-                      defaultValue={overrides.background_task?.staleTimeoutMs ?? 180000}
-                      onChange={(e) => onBgTaskNumberChange("staleTimeoutMs", Number(e.target.value))}
-                      className="w-full px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs text-white/50">Provider Concurrency</span>
+            {/* Hooks */}
+            <CollapsibleSection
+              label="Hooks"
+              expanded={showHooks}
+              onToggle={() => setShowHooks(!showHooks)}
+              badge={<DisabledCountBadge count={(overrides.disabled_hooks ?? []).length} />}
+            >
+              <div className="space-y-2">
+                {(Object.entries(HOOK_GROUPS) as [HookGroupName, readonly string[]][]).map(([groupName, hooks]) => {
+                  const disabledCount = hooks.filter((h) => (overrides.disabled_hooks ?? []).includes(h)).length;
+                  const isGroupExpanded = expandedHookGroups.has(groupName);
+                  return (
+                    <div key={groupName}>
                       <button
                         type="button"
-                        onClick={onProviderConcurrencyAdd}
-                        className="text-xs text-violet-400 hover:text-violet-300"
+                        onClick={() => toggleHookGroup(groupName)}
+                        className="flex items-center gap-2 text-xs text-white/50 hover:text-white/80 transition-colors"
                       >
-                        + Add
+                        <ChevronIcon expanded={isGroupExpanded} />
+                        {groupName} ({disabledCount}/{hooks.length} disabled)
                       </button>
+                      {isGroupExpanded && (
+                        <div className="space-y-1 pl-4 mt-1">
+                          <ToggleList items={hooks} disabledItems={overrides.disabled_hooks ?? []} onToggle={onDisabledHookToggle} />
+                        </div>
+                      )}
                     </div>
-                    {providerConcurrencyRows.map((row, idx) => (
-                      <div key={`${row.key}-${idx}`} className="flex gap-2">
-                        <input
-                          type="text"
-                          placeholder="Provider"
-                          value={row.key}
-                          onChange={(e) => onProviderConcurrencyChange(idx, "key", e.target.value)}
-                          className="flex-1 px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
-                        />
-                        <input
-                          type="number"
-                          min={1}
-                          value={row.value}
-                          onChange={(e) => onProviderConcurrencyChange(idx, "value", Number(e.target.value))}
-                          className="w-20 px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
-                        />
-                        <button
-                          type="button"
-                          onClick={() => onProviderConcurrencyRemove(idx)}
-                          className="text-xs text-red-400 hover:text-red-300"
-                        >
-                          Remove
-                        </button>
-                      </div>
-                    ))}
+                  );
+                })}
+              </div>
+            </CollapsibleSection>
+
+            {/* Background Tasks */}
+            <CollapsibleSection label="Background Tasks" expanded={showBgTask} onToggle={() => setShowBgTask(!showBgTask)}>
+              <div className="space-y-2">
+                <NumberField label="Default Concurrency" min={1} defaultValue={overrides.background_task?.defaultConcurrency ?? 5} onChange={(v) => onBgTaskNumberChange("defaultConcurrency", v)} />
+                <NumberField label="Stale Timeout (ms)" min={60000} defaultValue={overrides.background_task?.staleTimeoutMs ?? 180000} onChange={(v) => onBgTaskNumberChange("staleTimeoutMs", v)} />
+                <ConcurrencyRows
+                  label="Provider Concurrency"
+                  rows={providerConcurrencyRows}
+                  placeholder="Provider"
+                  onAdd={onProviderConcurrencyAdd}
+                  onChange={onProviderConcurrencyChange}
+                  onRemove={onProviderConcurrencyRemove}
+                />
+                <ConcurrencyRows
+                  label="Model Concurrency"
+                  rows={modelConcurrencyRows}
+                  placeholder="Model"
+                  onAdd={onModelConcurrencyAdd}
+                  onChange={onModelConcurrencyChange}
+                  onRemove={onModelConcurrencyRemove}
+                />
+              </div>
+            </CollapsibleSection>
+
+            {/* Git Master */}
+            <CollapsibleSection label="Git Master" expanded={showGitMaster} onToggle={() => setShowGitMaster(!showGitMaster)}>
+              <div className="space-y-1">
+                {([
+                  { field: "commit_footer" as const, label: "Commit Footer", defaultValue: false },
+                  { field: "include_co_authored_by" as const, label: "Include Co-Authored-By", defaultValue: false },
+                ] as const).map(({ field, label, defaultValue }) => (
+                  <div key={field} className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-white/5">
+                    <span className="text-xs text-white/70 font-mono">{label}</span>
+                    <ToggleSwitch enabled={overrides.git_master?.[field] ?? defaultValue} onToggle={() => onGitMasterToggle(field)} />
                   </div>
-                  <div className="space-y-1">
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs text-white/50">Model Concurrency</span>
-                      <button
-                        type="button"
-                        onClick={onModelConcurrencyAdd}
-                        className="text-xs text-violet-400 hover:text-violet-300"
-                      >
-                        + Add
-                      </button>
+                ))}
+              </div>
+            </CollapsibleSection>
+
+            {/* Disabled MCPs */}
+            <CollapsibleSection
+              label="Disabled MCPs"
+              expanded={showMcps}
+              onToggle={() => setShowMcps(!showMcps)}
+              badge={<span className="px-1.5 py-0.5 rounded-md bg-white/5 text-white/50 text-[10px] font-mono">{(overrides.disabled_mcps ?? []).length}</span>}
+            >
+              <div className="space-y-2">
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    placeholder="MCP name"
+                    value={mcpInput}
+                    onChange={(e) => setMcpInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        handleMcpAdd();
+                      }
+                    }}
+                    className="flex-1 px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white placeholder:text-white/30 focus:outline-none focus:border-violet-400/40"
+                  />
+                  <button type="button" onClick={handleMcpAdd} className="px-3 py-1.5 text-xs bg-violet-500/20 text-violet-300 rounded-lg hover:bg-violet-500/30">
+                    Add
+                  </button>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {(overrides.disabled_mcps ?? []).map((mcp) => (
+                    <div key={mcp} className="inline-flex items-center gap-1.5 px-2 py-1 rounded-lg text-xs bg-red-500/10 border border-red-400/20 text-red-300">
+                      <span className="font-mono">{mcp}</span>
+                      <button type="button" onClick={() => onMcpRemove(mcp)} className="text-red-400 hover:text-red-200">&times;</button>
                     </div>
-                    {modelConcurrencyRows.map((row, idx) => (
-                      <div key={`${row.key}-${idx}`} className="flex gap-2">
-                        <input
-                          type="text"
-                          placeholder="Model"
-                          value={row.key}
-                          onChange={(e) => onModelConcurrencyChange(idx, "key", e.target.value)}
-                          className="flex-1 px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
-                        />
-                        <input
-                          type="number"
-                          min={1}
-                          value={row.value}
-                          onChange={(e) => onModelConcurrencyChange(idx, "value", Number(e.target.value))}
-                          className="w-20 px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
-                        />
-                        <button
-                          type="button"
-                          onClick={() => onModelConcurrencyRemove(idx)}
-                          className="text-xs text-red-400 hover:text-red-300"
-                        >
-                          Remove
-                        </button>
-                      </div>
-                    ))}
-                  </div>
+                  ))}
                 </div>
-              )}
-            </div>
-
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] overflow-hidden transition-all hover:border-white/15">
-              <button
-                type="button"
-                onClick={() => setShowGitMaster(!showGitMaster)}
-                className="w-full flex items-center gap-2 px-3 py-2.5 text-xs font-medium text-white/60 hover:text-white/90 hover:bg-white/[0.04] transition-colors"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className={`transition-transform duration-200 ${showGitMaster ? "rotate-90" : ""}`}
-                  aria-hidden="true"
-                >
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-                <span className="flex-1 text-left">Git Master</span>
-              </button>
-              {showGitMaster && (
-                <div className="px-3 pb-3 space-y-1">
-                  {[
-                    { field: "commit_footer" as const, label: "Commit Footer", defaultValue: false },
-                    { field: "include_co_authored_by" as const, label: "Include Co-Authored-By", defaultValue: false },
-                  ].map(({ field, label, defaultValue }) => {
-                    const isEnabled = overrides.git_master?.[field] ?? defaultValue;
-                    return (
-                      <div key={field} className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-white/5">
-                        <span className="text-xs text-white/70 font-mono">{label}</span>
-                        <button
-                          type="button"
-                          onClick={() => onGitMasterToggle(field)}
-                          className={`w-9 h-5 rounded-full transition-colors relative ${
-                            isEnabled ? "bg-emerald-500/60" : "bg-white/10"
-                          }`}
-                        >
-                          <span
-                            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full transition-transform ${
-                              isEnabled ? "translate-x-4 bg-emerald-200" : "bg-white/40"
-                            }`}
-                          />
-                        </button>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-
-            <div className="rounded-xl border border-white/10 bg-white/[0.02] overflow-hidden transition-all hover:border-white/15">
-              <button
-                type="button"
-                onClick={() => setShowMcps(!showMcps)}
-                className="w-full flex items-center gap-2 px-3 py-2.5 text-xs font-medium text-white/60 hover:text-white/90 hover:bg-white/[0.04] transition-colors"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className={`transition-transform duration-200 ${showMcps ? "rotate-90" : ""}`}
-                  aria-hidden="true"
-                >
-                  <polyline points="9 18 15 12 9 6" />
-                </svg>
-                <span className="flex-1 text-left">Disabled MCPs</span>
-                <span className="px-1.5 py-0.5 rounded-md bg-white/5 text-white/50 text-[10px] font-mono">
-                  {(overrides.disabled_mcps ?? []).length}
-                </span>
-              </button>
-              {showMcps && (
-                <div className="px-3 pb-3 space-y-2">
-                  <div className="flex gap-2">
-                    <input
-                      type="text"
-                      placeholder="MCP name"
-                      value={mcpInput}
-                      onChange={(e) => setMcpInput(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          e.preventDefault();
-                          handleMcpAdd();
-                        }
-                      }}
-                      className="flex-1 px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white placeholder:text-white/30 focus:outline-none focus:border-violet-400/40"
-                    />
-                    <button
-                      type="button"
-                      onClick={handleMcpAdd}
-                      className="px-3 py-1.5 text-xs bg-violet-500/20 text-violet-300 rounded-lg hover:bg-violet-500/30"
-                    >
-                      Add
-                    </button>
-                  </div>
-                  <div className="flex flex-wrap gap-1.5">
-                    {(overrides.disabled_mcps ?? []).map((mcp) => (
-                      <div
-                        key={mcp}
-                        className="inline-flex items-center gap-1.5 px-2 py-1 rounded-lg text-xs bg-red-500/10 border border-red-400/20 text-red-300"
-                      >
-                        <span className="font-mono">{mcp}</span>
-                        <button
-                          type="button"
-                          onClick={() => onMcpRemove(mcp)}
-                          className="text-red-400 hover:text-red-200"
-                        >
-                          ×
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
+              </div>
+            </CollapsibleSection>
           </div>
         </div>
       </div>
     </>
+  );
+}
+
+function NumberField({ label, min, max, defaultValue, onChange }: { label: string; min: number; max?: number; defaultValue: number; onChange: (value: number) => void }) {
+  return (
+    <div className="space-y-1">
+      <span className="text-xs text-white/50">{label}</span>
+      <input
+        type="number"
+        min={min}
+        max={max}
+        defaultValue={defaultValue}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
+      />
+    </div>
+  );
+}
+
+interface ConcurrencyRowsProps {
+  label: string;
+  rows: Array<{ key: string; value: number }>;
+  placeholder: string;
+  onAdd: () => void;
+  onChange: (index: number, field: "key" | "value", newValue: string | number) => void;
+  onRemove: (index: number) => void;
+}
+
+function ConcurrencyRows({ label, rows, placeholder, onAdd, onChange, onRemove }: ConcurrencyRowsProps) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-white/50">{label}</span>
+        <button type="button" onClick={onAdd} className="text-xs text-violet-400 hover:text-violet-300">+ Add</button>
+      </div>
+      {rows.map((row, idx) => (
+        <div key={`${row.key}-${idx}`} className="flex gap-2">
+          <input
+            type="text"
+            placeholder={placeholder}
+            value={row.key}
+            onChange={(e) => onChange(idx, "key", e.target.value)}
+            className="flex-1 px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
+          />
+          <input
+            type="number"
+            min={1}
+            value={row.value}
+            onChange={(e) => onChange(idx, "value", Number(e.target.value))}
+            className="w-20 px-2.5 py-1.5 text-xs bg-white/5 border border-white/10 rounded-lg text-white focus:outline-none focus:border-violet-400/40"
+          />
+          <button type="button" onClick={() => onRemove(idx)} className="text-xs text-red-400 hover:text-red-300">Remove</button>
+        </div>
+      ))}
+    </div>
   );
 }

--- a/dashboard/src/components/providers/oauth-import-modal.tsx
+++ b/dashboard/src/components/providers/oauth-import-modal.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import React, { useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Modal, ModalContent, ModalFooter, ModalHeader, ModalTitle } from "@/components/ui/modal";
+import type { OAuthProviderId, ShowToast } from "./oauth-types";
+import { getOAuthProviderById, MAX_IMPORT_FILE_SIZE } from "./oauth-types";
+
+type ImportStatus = "idle" | "validating" | "uploading" | "success" | "error";
+
+interface OAuthImportModalProps {
+  isOpen: boolean;
+  providerId: OAuthProviderId | null;
+  showToast: ShowToast;
+  refreshProviders: () => Promise<void>;
+  loadAccounts: () => Promise<void>;
+  onClose: () => void;
+}
+
+function validateImportJson(content: string): { valid: boolean; error: string | null } {
+  try {
+    const parsed = JSON.parse(content);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { valid: false, error: "File must contain a JSON object, not an array." };
+    }
+    return { valid: true, error: null };
+  } catch {
+    return { valid: false, error: "Invalid JSON content." };
+  }
+}
+
+export function OAuthImportModal({ isOpen, providerId, showToast, refreshProviders, loadAccounts, onClose }: OAuthImportModalProps) {
+  const [jsonContent, setJsonContent] = useState("");
+  const [fileName, setFileName] = useState("");
+  const [status, setStatus] = useState<ImportStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleClose = () => {
+    setJsonContent("");
+    setFileName("");
+    setStatus("idle");
+    setErrorMessage(null);
+    onClose();
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!file.name.endsWith(".json")) {
+      setFileName("");
+      setJsonContent("");
+      setErrorMessage("Please select a JSON file.");
+      setStatus("error");
+      return;
+    }
+
+    if (file.size > MAX_IMPORT_FILE_SIZE) {
+      setFileName("");
+      setJsonContent("");
+      setErrorMessage("File is too large (max 1MB).");
+      setStatus("error");
+      return;
+    }
+
+    setFileName(file.name);
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const content = event.target?.result;
+      if (typeof content === "string") {
+        setJsonContent(content);
+        const result = validateImportJson(content);
+        if (!result.valid) {
+          setErrorMessage(result.error);
+          setStatus("error");
+        } else {
+          setErrorMessage(null);
+          setStatus("idle");
+        }
+      }
+    };
+    reader.onerror = () => {
+      setErrorMessage("Failed to read file.");
+      setStatus("error");
+    };
+    reader.readAsText(file);
+  };
+
+  const handleJsonChange = (value: string) => {
+    setJsonContent(value);
+    if (value.trim()) {
+      const result = validateImportJson(value);
+      setErrorMessage(result.error);
+      setStatus(result.valid ? "idle" : "error");
+    } else {
+      setErrorMessage(null);
+      setStatus("idle");
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!providerId || !jsonContent.trim()) return;
+
+    const result = validateImportJson(jsonContent);
+    if (!result.valid) {
+      setErrorMessage(result.error);
+      setStatus("error");
+      return;
+    }
+
+    setStatus("uploading");
+    setErrorMessage(null);
+
+    try {
+      const res = await fetch("/api/providers/oauth/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider: providerId,
+          fileName: fileName || `${providerId}-credential.json`,
+          fileContent: jsonContent.trim(),
+        }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        setStatus("error");
+        setErrorMessage(data.error || "Failed to import credential.");
+        return;
+      }
+
+      setStatus("success");
+      showToast("OAuth credential imported successfully", "success");
+      await refreshProviders();
+      void loadAccounts();
+    } catch {
+      setStatus("error");
+      setErrorMessage("Network error while importing credential.");
+    }
+  };
+
+  const providerName = providerId ? getOAuthProviderById(providerId)?.name || providerId : "";
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <ModalHeader>
+        <ModalTitle>Import {providerName} Credential</ModalTitle>
+      </ModalHeader>
+      <ModalContent>
+        <div className="space-y-4">
+          <div className="rounded-xl border-l-4 border-blue-400/60 bg-blue-500/10 p-4 text-sm backdrop-blur-xl">
+            <div className="font-medium text-white">Import a local OAuth credential</div>
+            <p className="mt-2 text-white/80">
+              Upload a JSON credential file or paste the raw JSON content below.
+              The credential will be imported and connected to your account.
+            </p>
+          </div>
+
+          <div>
+            <div className="mb-2 text-xs font-medium text-white/90">Upload JSON file</div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              onChange={handleFileSelect}
+              className="block w-full text-xs text-slate-400 file:mr-3 file:rounded-md file:border-0 file:bg-slate-700 file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-slate-200 hover:file:bg-slate-600 file:cursor-pointer file:transition-colors"
+              disabled={status === "uploading"}
+            />
+          </div>
+
+          <div className="relative">
+            <div className="absolute inset-x-0 top-0 flex items-center justify-center">
+              <span className="bg-slate-900 px-2 text-[10px] font-medium uppercase tracking-wider text-slate-500">or paste JSON</span>
+            </div>
+            <div className="border-t border-slate-700/50 pt-4 mt-2">
+              <textarea
+                value={jsonContent}
+                onChange={(e) => handleJsonChange(e.target.value)}
+                placeholder='{&#10;  "access_token": "...",&#10;  "refresh_token": "...",&#10;  ...&#10;}'
+                rows={8}
+                disabled={status === "uploading"}
+                className="w-full rounded-md border border-slate-700/70 bg-slate-800/50 px-3 py-2 font-mono text-xs text-slate-200 placeholder:text-slate-600 focus:border-blue-500/50 focus:outline-none focus:ring-1 focus:ring-blue-500/30 disabled:opacity-50 resize-y"
+              />
+            </div>
+          </div>
+
+          {status === "error" && errorMessage && (
+            <div className="rounded-xl border-l-4 border-red-400/60 bg-red-500/20 p-3 text-xs text-white backdrop-blur-xl">{errorMessage}</div>
+          )}
+
+          {status === "success" && (
+            <div className="rounded-xl border-l-4 border-green-400/60 bg-green-500/20 p-3 text-xs text-white backdrop-blur-xl">Credential imported successfully.</div>
+          )}
+
+          {jsonContent.trim() && status !== "error" && status !== "success" && (
+            <div className="rounded-xl border-l-4 border-green-400/60 bg-green-500/10 p-2 text-xs text-white/70 backdrop-blur-xl">
+              JSON content loaded ({jsonContent.length.toLocaleString()} characters). Ready to import.
+            </div>
+          )}
+        </div>
+      </ModalContent>
+      <ModalFooter>
+        <Button variant="ghost" onClick={handleClose}>{status === "success" ? "Done" : "Cancel"}</Button>
+        {status !== "success" && (
+          <Button variant="secondary" onClick={handleSubmit} disabled={!jsonContent.trim() || status === "uploading"}>
+            {status === "uploading" ? "Importing..." : "Import Credential"}
+          </Button>
+        )}
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/dashboard/src/components/providers/oauth-section.tsx
+++ b/dashboard/src/components/providers/oauth-section.tsx
@@ -5,242 +5,31 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Modal, ModalContent, ModalFooter, ModalHeader, ModalTitle } from "@/components/ui/modal";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
-import { useToast } from "@/components/ui/toast";
 import { cn } from "@/lib/utils";
-import { OwnerBadge, type CurrentUserLike } from "@/components/providers/api-key-section";
-
-type ShowToast = ReturnType<typeof useToast>["showToast"];
-
-interface OAuthSectionProps {
-  showToast: ShowToast;
-  currentUser: CurrentUserLike | null;
-  refreshProviders: () => Promise<void>;
-  onAccountCountChange: (count: number) => void;
-}
-
-const OAUTH_PROVIDERS = [
-  {
-    id: "claude" as const,
-    name: "Claude Code",
-    description: "Anthropic Claude (Pro/Max subscription)",
-    authEndpoint: "/api/management/anthropic-auth-url?is_webui=true",
-    requiresCallback: true,
-  },
-  {
-    id: "gemini-cli" as const,
-    name: "Gemini CLI",
-    description: "Google Gemini (via Google OAuth)",
-    authEndpoint: "/api/management/gemini-cli-auth-url?project_id=ALL&is_webui=true",
-    requiresCallback: true,
-  },
-  {
-    id: "codex" as const,
-    name: "Codex",
-    description: "OpenAI Codex (Plus/Pro subscription)",
-    authEndpoint: "/api/management/codex-auth-url?is_webui=true",
-    requiresCallback: true,
-  },
-  {
-    id: "antigravity" as const,
-    name: "Antigravity",
-    description: "Google Antigravity (via Google OAuth)",
-    authEndpoint: "/api/management/antigravity-auth-url?is_webui=true",
-    requiresCallback: true,
-  },
-  {
-    id: "iflow" as const,
-    name: "iFlow",
-    description: "iFlytek iFlow (via OAuth)",
-    authEndpoint: "/api/management/iflow-auth-url?is_webui=true",
-    requiresCallback: true,
-  },
-  {
-    id: "kimi" as const,
-    name: "Kimi",
-    description: "Moonshot AI Kimi (device OAuth)",
-    authEndpoint: "/api/management/kimi-auth-url?is_webui=true",
-    requiresCallback: false,
-  },
-  {
-    id: "qwen" as const,
-    name: "Qwen Code",
-    description: "Alibaba Qwen Code (device OAuth)",
-    authEndpoint: "/api/management/qwen-auth-url?is_webui=true",
-    requiresCallback: false,
-  },
-  {
-    id: "copilot" as const,
-    name: "GitHub Copilot",
-    description: "GitHub Copilot (via GitHub device OAuth)",
-    authEndpoint: "/api/management/github-auth-url?is_webui=true",
-    requiresCallback: false,
-  },
-  {
-    id: "kiro" as const,
-    name: "Kiro",
-    description: "AWS CodeWhisperer / Kiro (device OAuth)",
-    authEndpoint: "/api/management/kiro-auth-url?is_webui=true",
-    requiresCallback: false,
-  },
-] as const;
-
-type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
-type OAuthProviderId = OAuthProvider["id"];
-const OAUTH_STATUS_POLL_INTERVAL_MS = 5000;
-const OAUTH_STATUS_POLL_INTERVAL_HIDDEN_MS = 10000;
-
-const MODAL_STATUS = {
-  IDLE: "idle",
-  LOADING: "loading",
-  WAITING: "waiting",
-  SUBMITTING: "submitting",
-  POLLING: "polling",
-  SUCCESS: "success",
-  ERROR: "error",
-} as const;
-
-type ModalStatus = (typeof MODAL_STATUS)[keyof typeof MODAL_STATUS];
-
-const CALLBACK_VALIDATION = {
-  EMPTY: "empty",
-  INVALID: "invalid",
-  VALID: "valid",
-} as const;
-
-type CallbackValidation =
-  (typeof CALLBACK_VALIDATION)[keyof typeof CALLBACK_VALIDATION];
-
-interface OAuthAccountWithOwnership {
-  id: string;
-  accountName: string;
-  accountEmail: string | null;
-  provider: string;
-  ownerUsername: string | null;
-  ownerUserId: string | null;
-  isOwn: boolean;
-  status: "active" | "error" | "disabled" | string;
-  statusMessage: string | null;
-  unavailable: boolean;
-}
-
-interface AuthUrlResponse {
-  status?: string;
-  url?: string;
-  state?: string;
-  user_code?: string;
-  method?: string;
-  verification_uri?: string;
-}
-interface AuthStatusResponse {
-  status?: string;
-  error?: string;
-  verification_url?: string;
-  user_code?: string;
-  url?: string;
-}
-
-interface OAuthCallbackResponse {
-  status?: number;
-  error?: string;
-}
-
-const getOAuthProviderById = (id: OAuthProviderId | null) =>
-  OAUTH_PROVIDERS.find((provider) => provider.id === id) || null;
-
-function isTabVisible(): boolean {
-  if (typeof document === "undefined") return true;
-  return document.visibilityState === "visible";
-}
-
-const validateCallbackUrl = (value: string) => {
-  if (!value.trim()) {
-    return { status: CALLBACK_VALIDATION.EMPTY, message: "Paste the full URL." };
-  }
-
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(value.trim());
-  } catch {
-    return {
-      status: CALLBACK_VALIDATION.INVALID,
-      message: "That doesn't look like a valid URL.",
-    };
-  }
-
-  const code = parsedUrl.searchParams.get("code");
-  const state = parsedUrl.searchParams.get("state");
-
-  if (!code || !state) {
-    return {
-      status: CALLBACK_VALIDATION.INVALID,
-      message: "URL must include both code and state parameters.",
-    };
-  }
-
-  return {
-    status: CALLBACK_VALIDATION.VALID,
-    message: "Callback URL looks good. Ready to submit.",
-  };
-};
-
-function parseStatusMessage(raw: string | null): string | null {
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed?.error?.message) return parsed.error.message;
-    if (typeof parsed?.message === "string") return parsed.message;
-    return raw;
-  } catch {
-    return raw;
-  }
-}
-
-function OAuthStatusBadge({
-  status,
-  statusMessage,
-  unavailable,
-}: {
-  status: string;
-  statusMessage: string | null;
-  unavailable: boolean;
-}) {
-  const message = parseStatusMessage(statusMessage);
-
-  if (status === "active" && !unavailable) {
-    return (
-      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-400" title="Token is valid and working">
-        <span className="size-1.5 rounded-full bg-emerald-400" />
-        Active
-      </span>
-    );
-  }
-
-  if (status === "error" || unavailable) {
-    return (
-      <span
-        className="inline-flex items-center gap-1 rounded-full bg-red-500/15 px-2 py-0.5 text-[10px] font-medium text-red-400"
-        title={message || "Account has an error"}
-      >
-        <span className="size-1.5 rounded-full bg-red-400" />
-        {message
-          ? message.length > 40 ? `${message.slice(0, 40)}…` : message
-          : "Error"}
-      </span>
-    );
-  }
-
-  if (status === "disabled") {
-    return (
-      <span className="inline-flex items-center gap-1 rounded-full bg-slate-500/15 px-2 py-0.5 text-[10px] font-medium text-slate-400" title="Account is disabled">
-        <span className="size-1.5 rounded-full bg-slate-400" />
-        Disabled
-      </span>
-    );
-  }
-
-  return null;
-}
-
+import { OwnerBadge } from "@/components/providers/api-key-section";
+import { OAuthStatusBadge } from "./oauth-status-badge";
+import { OAuthImportModal } from "./oauth-import-modal";
+import {
+  OAUTH_PROVIDERS,
+  OAUTH_STATUS_POLL_INTERVAL_MS,
+  OAUTH_STATUS_POLL_INTERVAL_HIDDEN_MS,
+  MAX_POLL_ATTEMPTS,
+  MAX_NO_CALLBACK_ATTEMPTS,
+  NO_CALLBACK_RETRY_DELAY_MS,
+  MODAL_STATUS,
+  CALLBACK_VALIDATION,
+  getOAuthProviderById,
+  isTabVisible,
+  validateCallbackUrl,
+  type OAuthSectionProps,
+  type OAuthProviderId,
+  type ModalStatus,
+  type CallbackValidation,
+  type OAuthAccountWithOwnership,
+  type AuthUrlResponse,
+  type AuthStatusResponse,
+  type OAuthCallbackResponse,
+} from "./oauth-types";
 
 export function OAuthSection({
   showToast,
@@ -271,11 +60,6 @@ export function OAuthSection({
   const [togglingAccountId, setTogglingAccountId] = useState<string | null>(null);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [importProviderId, setImportProviderId] = useState<OAuthProviderId | null>(null);
-  const [importJsonContent, setImportJsonContent] = useState("");
-  const [importFileName, setImportFileName] = useState("");
-  const [importStatus, setImportStatus] = useState<"idle" | "validating" | "uploading" | "success" | "error">("idle");
-  const [importErrorMessage, setImportErrorMessage] = useState<string | null>(null);
-  const importFileInputRef = useRef<HTMLInputElement>(null);
 
   const selectedOAuthProvider = getOAuthProviderById(selectedOAuthProviderId);
   const selectedOAuthProviderRequiresCallback = selectedOAuthProvider?.requiresCallback ?? true;
@@ -305,7 +89,6 @@ export function OAuthSection({
         setOauthAccountsLoading(false);
         return;
       }
-
       const data = await res.json();
       const nextAccounts = Array.isArray(data.accounts) ? data.accounts : [];
       setAccounts(nextAccounts);
@@ -341,23 +124,14 @@ export function OAuthSection({
     }
   };
 
-  const openAuthPopup = (url: string) => {
-    const popup = window.open(url, "oauth", "width=600,height=800");
-    return popup !== null;
-  };
-
   const pollAuthStatus = (state: string) => {
-    if (pollingIntervalRef.current !== null) {
-      return;
-    }
+    if (pollingIntervalRef.current !== null) return;
 
     pollingIntervalRef.current = window.setInterval(async () => {
-      if (!isTabVisible()) {
-        return;
-      }
+      if (!isTabVisible()) return;
 
       pollingAttemptsRef.current += 1;
-      if (pollingAttemptsRef.current > 60) {
+      if (pollingAttemptsRef.current > MAX_POLL_ATTEMPTS) {
         stopPolling();
         setOauthModalStatus(MODAL_STATUS.ERROR);
         setOauthErrorMessage("Timed out waiting for authorization.");
@@ -365,9 +139,7 @@ export function OAuthSection({
       }
 
       try {
-        const res = await fetch(
-          `/api/management/get-auth-status?state=${encodeURIComponent(state)}`
-        );
+        const res = await fetch(`/api/management/get-auth-status?state=${encodeURIComponent(state)}`);
         if (!res.ok) {
           stopPolling();
           setOauthModalStatus(MODAL_STATUS.ERROR);
@@ -376,15 +148,10 @@ export function OAuthSection({
         }
 
         const data: AuthStatusResponse = await res.json();
-        if (data.status === "wait") {
-          return;
-        }
+        if (data.status === "wait") return;
 
         if (data.status === "device_code" && data.verification_url && data.user_code) {
-          setDeviceCodeInfo({
-            verificationUrl: data.verification_url,
-            userCode: data.user_code,
-          });
+          setDeviceCodeInfo({ verificationUrl: data.verification_url, userCode: data.user_code });
           if (!deviceCodePopupOpenedRef.current) {
             deviceCodePopupOpenedRef.current = true;
             window.open(data.verification_url, "oauth", "width=600,height=800");
@@ -447,18 +214,17 @@ export function OAuthSection({
       const data: OAuthCallbackResponse = await res.json().catch(() => ({}));
 
       if (res.status === 202 || data.status === 202) {
-        if (noCallbackClaimAttemptsRef.current >= 25) {
+        if (noCallbackClaimAttemptsRef.current >= MAX_NO_CALLBACK_ATTEMPTS) {
           stopNoCallbackClaimPolling();
           return;
         }
-
         noCallbackClaimAttemptsRef.current += 1;
         if (noCallbackClaimTimeoutRef.current !== null) {
           window.clearTimeout(noCallbackClaimTimeoutRef.current);
         }
         noCallbackClaimTimeoutRef.current = window.setTimeout(() => {
           void claimOAuthWithoutCallback(providerId, state);
-        }, 3000);
+        }, NO_CALLBACK_RETRY_DELAY_MS);
         return;
       }
 
@@ -473,7 +239,7 @@ export function OAuthSection({
       stopNoCallbackClaimPolling();
       void loadAccounts();
     } catch {
-      if (noCallbackClaimAttemptsRef.current >= 25) {
+      if (noCallbackClaimAttemptsRef.current >= MAX_NO_CALLBACK_ATTEMPTS) {
         stopNoCallbackClaimPolling();
         return;
       }
@@ -483,7 +249,7 @@ export function OAuthSection({
       }
       noCallbackClaimTimeoutRef.current = window.setTimeout(() => {
         void claimOAuthWithoutCallback(providerId, state);
-      }, 3000);
+      }, NO_CALLBACK_RETRY_DELAY_MS);
     }
   }
 
@@ -533,12 +299,14 @@ export function OAuthSection({
         setOauthErrorMessage("OAuth response missing URL.");
         return;
       }
-      const popupOpened = openAuthPopup(data.url);
-      if (!popupOpened) {
+
+      const popup = window.open(data.url, "oauth", "width=600,height=800");
+      if (!popup) {
         setOauthModalStatus(MODAL_STATUS.ERROR);
         setOauthErrorMessage("Popup blocked. Allow pop-ups and try again.");
         return;
       }
+
       authStateRef.current = data.state;
       setAuthState(data.state);
       if (provider.requiresCallback) {
@@ -552,10 +320,7 @@ export function OAuthSection({
         setCallbackMessage("No callback URL needed. Complete sign-in in the popup window.");
         showToast("OAuth window opened. Complete sign-in in the popup.", "info");
         if (data.user_code && data.url) {
-          setDeviceCodeInfo({
-            verificationUrl: data.url,
-            userCode: data.user_code,
-          });
+          setDeviceCodeInfo({ verificationUrl: data.url, userCode: data.user_code });
           deviceCodePopupOpenedRef.current = true;
         }
         stopNoCallbackClaimPolling();
@@ -580,8 +345,7 @@ export function OAuthSection({
     const currentProvider = selectedOAuthProviderIdRef.current;
     const currentState = authStateRef.current;
     if (!currentProvider || !currentState) {
-      console.warn("[OAuth] Submit failed - provider:", currentProvider, "state:", currentState,
-                   "stateFromState:", selectedOAuthProviderId, "providerFromState:", authState);
+      // Missing provider or state — likely a stale ref
       setOauthModalStatus(MODAL_STATUS.ERROR);
       setOauthErrorMessage("Missing provider or state. Please restart the flow.");
       return;
@@ -601,18 +365,13 @@ export function OAuthSection({
       const res = await fetch("/api/management/oauth-callback", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          provider: currentProvider,
-          callbackUrl: callbackUrl.trim(),
-        }),
+        body: JSON.stringify({ provider: currentProvider, callbackUrl: callbackUrl.trim() }),
       });
 
       const data: OAuthCallbackResponse = await res.json().catch(() => ({}));
       if (!res.ok) {
         setOauthModalStatus(MODAL_STATUS.ERROR);
-        setOauthErrorMessage(
-          data.error || "Failed to relay the OAuth callback URL."
-        );
+        setOauthErrorMessage(data.error || "Failed to relay the OAuth callback URL.");
         return;
       }
 
@@ -634,12 +393,8 @@ export function OAuthSection({
 
   const handleOAuthDelete = async () => {
     if (!pendingOAuthDelete) return;
-    const { accountId } = pendingOAuthDelete;
-
     try {
-      const res = await fetch(`/api/providers/oauth/${accountId}`, {
-        method: "DELETE",
-      });
+      const res = await fetch(`/api/providers/oauth/${pendingOAuthDelete.accountId}`, { method: "DELETE" });
       if (!res.ok) {
         const data = await res.json();
         showToast(data.error || "Failed to remove OAuth account", "error");
@@ -653,132 +408,8 @@ export function OAuthSection({
     }
   };
 
-  const openImportModal = (providerId: OAuthProviderId) => {
-    setImportProviderId(providerId);
-    setImportJsonContent("");
-    setImportFileName("");
-    setImportStatus("idle");
-    setImportErrorMessage(null);
-    setIsImportModalOpen(true);
-  };
-
-  const closeImportModal = () => {
-    setIsImportModalOpen(false);
-    setImportProviderId(null);
-    setImportJsonContent("");
-    setImportFileName("");
-    setImportStatus("idle");
-    setImportErrorMessage(null);
-  };
-
-  const handleImportFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    if (!file.name.endsWith(".json")) {
-      setImportFileName("");
-      setImportJsonContent("");
-      setImportErrorMessage("Please select a JSON file.");
-      setImportStatus("error");
-      return;
-    }
-
-    if (file.size > 1024 * 1024) {
-      setImportFileName("");
-      setImportJsonContent("");
-      setImportErrorMessage("File is too large (max 1MB).");
-      setImportStatus("error");
-      return;
-    }
-
-    setImportFileName(file.name);
-    const reader = new FileReader();
-    reader.onload = (event) => {
-      const content = event.target?.result;
-      if (typeof content === "string") {
-        setImportJsonContent(content);
-        validateImportJson(content);
-      }
-    };
-    reader.onerror = () => {
-      setImportErrorMessage("Failed to read file.");
-      setImportStatus("error");
-    };
-    reader.readAsText(file);
-  };
-
-  const validateImportJson = (content: string) => {
-    try {
-      const parsed = JSON.parse(content);
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        setImportErrorMessage("File must contain a JSON object, not an array.");
-        setImportStatus("error");
-        return false;
-      }
-      setImportErrorMessage(null);
-      setImportStatus("idle");
-      return true;
-    } catch {
-      setImportErrorMessage("Invalid JSON content.");
-      setImportStatus("error");
-      return false;
-    }
-  };
-
-  const handleImportJsonChange = (value: string) => {
-    setImportJsonContent(value);
-    if (value.trim()) {
-      validateImportJson(value);
-    } else {
-      setImportErrorMessage(null);
-      setImportStatus("idle");
-    }
-  };
-
-  const handleImportSubmit = async () => {
-    if (!importProviderId || !importJsonContent.trim()) return;
-
-    if (!validateImportJson(importJsonContent)) return;
-
-    const fileName = importFileName || `${importProviderId}-credential.json`;
-
-    setImportStatus("uploading");
-    setImportErrorMessage(null);
-
-    try {
-      const res = await fetch("/api/providers/oauth/import", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          provider: importProviderId,
-          fileName,
-          fileContent: importJsonContent.trim(),
-        }),
-      });
-
-      const data = await res.json().catch(() => ({}));
-
-      if (!res.ok) {
-        setImportStatus("error");
-        setImportErrorMessage(data.error || "Failed to import credential.");
-        return;
-      }
-
-      setImportStatus("success");
-      showToast("OAuth credential imported successfully", "success");
-      await refreshProviders();
-      void loadAccounts();
-    } catch {
-      setImportStatus("error");
-      setImportErrorMessage("Network error while importing credential.");
-    }
-  };
-
   useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      void loadAccounts();
-    }, 0);
-
+    const timeoutId = window.setTimeout(() => { void loadAccounts(); }, 0);
     return () => {
       window.clearTimeout(timeoutId);
       stopPolling();
@@ -828,33 +459,18 @@ export function OAuthSection({
                     <div className="min-w-0 flex-1 space-y-2">
                       <div className="flex flex-wrap items-center gap-2">
                         <span className="text-sm font-semibold text-slate-100">{account.provider}</span>
-                        {currentUser && (
-                          <OwnerBadge ownerUsername={account.ownerUsername} isOwn={account.isOwn} />
-                        )}
+                        {currentUser && <OwnerBadge ownerUsername={account.ownerUsername} isOwn={account.isOwn} />}
                         <OAuthStatusBadge status={account.status} statusMessage={account.statusMessage} unavailable={account.unavailable} />
                       </div>
-                      {account.accountEmail && (
-                        <p className="truncate text-xs text-slate-300">{account.accountEmail}</p>
-                      )}
+                      {account.accountEmail && <p className="truncate text-xs text-slate-300">{account.accountEmail}</p>}
                       <p className="truncate text-xs font-mono text-slate-500">{account.accountName}</p>
                     </div>
                     {currentUser && (account.isOwn || currentUser.isAdmin) && (
                       <div className="flex shrink-0 items-center gap-2">
-                        <Button
-                          variant="secondary"
-                          className="px-2.5 py-1 text-xs"
-                          disabled={togglingAccountId === account.id}
-                          onClick={() => toggleOAuthAccount(account.id, account.status === "disabled")}
-                        >
+                        <Button variant="secondary" className="px-2.5 py-1 text-xs" disabled={togglingAccountId === account.id} onClick={() => toggleOAuthAccount(account.id, account.status === "disabled")}>
                           {togglingAccountId === account.id ? "..." : account.status === "disabled" ? "Enable" : "Disable"}
                         </Button>
-                        <Button
-                          variant="danger"
-                          className="px-2.5 py-1 text-xs"
-                          onClick={() => confirmDeleteOAuth(account.id)}
-                        >
-                          Disconnect
-                        </Button>
+                        <Button variant="danger" className="px-2.5 py-1 text-xs" onClick={() => confirmDeleteOAuth(account.id)}>Disconnect</Button>
                       </div>
                     )}
                   </div>
@@ -872,32 +488,14 @@ export function OAuthSection({
           </div>
           <div className="overflow-hidden rounded-md border border-slate-700/70 bg-slate-900/25">
             {OAUTH_PROVIDERS.map((provider, index) => (
-              <div
-                key={provider.id}
-                className={cn(
-                  "flex items-center justify-between gap-3 px-3 py-2.5",
-                  index !== OAUTH_PROVIDERS.length - 1 && "border-b border-slate-700/70"
-                )}
-              >
+              <div key={provider.id} className={cn("flex items-center justify-between gap-3 px-3 py-2.5", index !== OAUTH_PROVIDERS.length - 1 && "border-b border-slate-700/70")}>
                 <div className="space-y-1">
                   <div className="text-sm font-medium text-slate-100">{provider.name}</div>
                   <p className="text-xs leading-relaxed text-slate-400">{provider.description}</p>
                 </div>
                 <div className="flex shrink-0 items-center gap-1.5">
-                  <Button
-                    variant="secondary"
-                    onClick={() => handleOAuthConnect(provider.id)}
-                    className="shrink-0 px-2.5 py-1 text-xs"
-                  >
-                    Connect
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    onClick={() => openImportModal(provider.id)}
-                    className="shrink-0 px-2.5 py-1 text-xs"
-                  >
-                    Import JSON
-                  </Button>
+                  <Button variant="secondary" onClick={() => handleOAuthConnect(provider.id)} className="shrink-0 px-2.5 py-1 text-xs">Connect</Button>
+                  <Button variant="secondary" onClick={() => { setImportProviderId(provider.id); setIsImportModalOpen(true); }} className="shrink-0 px-2.5 py-1 text-xs">Import JSON</Button>
                 </div>
               </div>
             ))}
@@ -907,80 +505,37 @@ export function OAuthSection({
 
       <Modal isOpen={isOAuthModalOpen} onClose={handleOAuthModalClose}>
         <ModalHeader>
-          <ModalTitle>
-            {selectedOAuthProvider ? `Connect ${selectedOAuthProvider.name}` : "Connect"}
-          </ModalTitle>
+          <ModalTitle>{selectedOAuthProvider ? `Connect ${selectedOAuthProvider.name}` : "Connect"}</ModalTitle>
         </ModalHeader>
         <ModalContent>
           {oauthModalStatus === MODAL_STATUS.LOADING && (
-            <div className="rounded-xl border-l-4 border-white/30 bg-white/5 p-4 text-sm text-white/80 backdrop-blur-xl">
-              Fetching authorization link...
-            </div>
+            <div className="rounded-xl border-l-4 border-white/30 bg-white/5 p-4 text-sm text-white/80 backdrop-blur-xl">Fetching authorization link...</div>
           )}
 
-          {(oauthModalStatus === MODAL_STATUS.WAITING ||
-            oauthModalStatus === MODAL_STATUS.SUBMITTING ||
-            oauthModalStatus === MODAL_STATUS.POLLING ||
-            oauthModalStatus === MODAL_STATUS.ERROR) &&
-            selectedOAuthProviderRequiresCallback && (
+          {(oauthModalStatus === MODAL_STATUS.WAITING || oauthModalStatus === MODAL_STATUS.SUBMITTING || oauthModalStatus === MODAL_STATUS.POLLING || oauthModalStatus === MODAL_STATUS.ERROR) && selectedOAuthProviderRequiresCallback && (
             <div className="space-y-4">
               <div className="rounded-xl border-l-4 border-purple-400/60 bg-white/10 p-4 text-sm backdrop-blur-xl">
-                <div className="font-medium text-white">
-                  Step-by-step
-                </div>
+                <div className="font-medium text-white">Step-by-step</div>
                 <ol className="mt-3 list-decimal space-y-2 pl-4 text-white/90">
                   <li>Log in and authorize in the popup window.</li>
-                  <li>
-                    After authorizing, the page will fail to load (this is
-                    expected).
-                  </li>
-                  <li>
-                    Our server runs remotely, so the OAuth redirect can&apos;t reach
-                    it directly. Copy the FULL URL from the address bar.
-                  </li>
+                  <li>After authorizing, the page will fail to load (this is expected).</li>
+                  <li>Our server runs remotely, so the OAuth redirect can&apos;t reach it directly. Copy the FULL URL from the address bar.</li>
                   <li>Paste the URL below and submit.</li>
                 </ol>
               </div>
-
               <div>
-                <div className="mb-2 text-xs font-medium text-white/90">
-                  Paste callback URL
-                </div>
-                <Input
-                  type="text"
-                  name="callbackUrl"
-                  value={callbackUrl}
-                  onChange={handleCallbackChange}
-                  placeholder="https://localhost/callback?code=...&state=..."
-                  disabled={
-                    oauthModalStatus === MODAL_STATUS.SUBMITTING ||
-                    oauthModalStatus === MODAL_STATUS.POLLING
-                  }
-                  className="font-mono"
-                />
-                <div
-                  className={`mt-2 rounded-xl border-l-4 p-2 text-xs ${
-                    callbackValidation === CALLBACK_VALIDATION.VALID
-                      ? "border-green-400/60 bg-green-500/20 text-white backdrop-blur-xl"
-                      : callbackValidation === CALLBACK_VALIDATION.INVALID
-                        ? "border-red-400/60 bg-red-500/20 text-white backdrop-blur-xl"
-                        : "border-white/30 bg-white/5 text-white/70 backdrop-blur-xl"
-                  }`}
-                >
+                <div className="mb-2 text-xs font-medium text-white/90">Paste callback URL</div>
+                <Input type="text" name="callbackUrl" value={callbackUrl} onChange={handleCallbackChange} placeholder="https://localhost/callback?code=...&state=..." disabled={oauthModalStatus === MODAL_STATUS.SUBMITTING || oauthModalStatus === MODAL_STATUS.POLLING} className="font-mono" />
+                <div className={`mt-2 rounded-xl border-l-4 p-2 text-xs ${callbackValidation === CALLBACK_VALIDATION.VALID ? "border-green-400/60 bg-green-500/20 text-white backdrop-blur-xl" : callbackValidation === CALLBACK_VALIDATION.INVALID ? "border-red-400/60 bg-red-500/20 text-white backdrop-blur-xl" : "border-white/30 bg-white/5 text-white/70 backdrop-blur-xl"}`}>
                   {callbackMessage}
                 </div>
               </div>
             </div>
           )}
 
-          {(oauthModalStatus === MODAL_STATUS.WAITING ||
-            oauthModalStatus === MODAL_STATUS.POLLING ||
-            oauthModalStatus === MODAL_STATUS.ERROR) &&
-            !selectedOAuthProviderRequiresCallback && (
+          {(oauthModalStatus === MODAL_STATUS.WAITING || oauthModalStatus === MODAL_STATUS.POLLING || oauthModalStatus === MODAL_STATUS.ERROR) && !selectedOAuthProviderRequiresCallback && (
             <div className="rounded-xl border-l-4 border-purple-400/60 bg-white/10 p-4 text-sm backdrop-blur-xl">
-              <div className="font-medium text-white">
-                Device Authorization
-              </div>
+              <div className="font-medium text-white">Device Authorization</div>
               <ol className="mt-3 list-decimal space-y-2 pl-4 text-white/90">
                 <li>A browser window has opened with the authorization page.</li>
                 <li>Log in and approve the access request.</li>
@@ -994,9 +549,7 @@ export function OAuthSection({
                   </div>
                   <p className="text-xs text-slate-400">
                     Enter this code at{" "}
-                    <a href={deviceCodeInfo.verificationUrl} target="_blank" rel="noopener noreferrer" className="text-blue-400 underline">
-                      {deviceCodeInfo.verificationUrl}
-                    </a>
+                    <a href={deviceCodeInfo.verificationUrl} target="_blank" rel="noopener noreferrer" className="text-blue-400 underline">{deviceCodeInfo.verificationUrl}</a>
                   </p>
                 </div>
               )}
@@ -1005,55 +558,32 @@ export function OAuthSection({
 
           {oauthModalStatus === MODAL_STATUS.POLLING && (
             <div className="mt-4 rounded-xl border-l-4 border-blue-400/60 bg-blue-500/20 p-4 text-sm text-white backdrop-blur-xl">
-              {selectedOAuthProviderRequiresCallback
-                ? "Callback submitted. Waiting for CLIProxyAPI to finish token exchange..."
-                : "Waiting for CLIProxyAPI to finish OAuth authorization..."}
+              {selectedOAuthProviderRequiresCallback ? "Callback submitted. Waiting for CLIProxyAPI to finish token exchange..." : "Waiting for CLIProxyAPI to finish OAuth authorization..."}
             </div>
           )}
 
           {oauthModalStatus === MODAL_STATUS.SUCCESS && (
-            <div className="rounded-xl border-l-4 border-green-400/60 bg-green-500/20 p-4 text-sm text-white backdrop-blur-xl">
-              OAuth account connected successfully.
-            </div>
+            <div className="rounded-xl border-l-4 border-green-400/60 bg-green-500/20 p-4 text-sm text-white backdrop-blur-xl">OAuth account connected successfully.</div>
           )}
 
           {oauthModalStatus === MODAL_STATUS.ERROR && oauthErrorMessage && (
-            <div className="rounded-xl border-l-4 border-red-400/60 bg-red-500/20 p-4 text-sm text-white backdrop-blur-xl">
-              {oauthErrorMessage}
-            </div>
+            <div className="rounded-xl border-l-4 border-red-400/60 bg-red-500/20 p-4 text-sm text-white backdrop-blur-xl">{oauthErrorMessage}</div>
           )}
         </ModalContent>
         <ModalFooter>
-          <Button variant="ghost" onClick={handleOAuthModalClose}>
-            Close
-          </Button>
+          <Button variant="ghost" onClick={handleOAuthModalClose}>Close</Button>
           {oauthModalStatus !== MODAL_STATUS.SUCCESS && selectedOAuthProviderRequiresCallback && (
-            <Button
-              variant="secondary"
-              onClick={handleSubmitCallback}
-              disabled={isOAuthSubmitDisabled}
-            >
-              {oauthModalStatus === MODAL_STATUS.SUBMITTING
-                ? "Submitting..."
-                : oauthModalStatus === MODAL_STATUS.POLLING
-                  ? "Waiting..."
-                  : "Submit URL"}
+            <Button variant="secondary" onClick={handleSubmitCallback} disabled={isOAuthSubmitDisabled}>
+              {oauthModalStatus === MODAL_STATUS.SUBMITTING ? "Submitting..." : oauthModalStatus === MODAL_STATUS.POLLING ? "Waiting..." : "Submit URL"}
             </Button>
           )}
-          {oauthModalStatus === MODAL_STATUS.SUCCESS && (
-            <Button variant="secondary" onClick={handleOAuthModalClose}>
-              Done
-            </Button>
-          )}
+          {oauthModalStatus === MODAL_STATUS.SUCCESS && <Button variant="secondary" onClick={handleOAuthModalClose}>Done</Button>}
         </ModalFooter>
       </Modal>
 
       <ConfirmDialog
         isOpen={showConfirmOAuthDelete}
-        onClose={() => {
-          setShowConfirmOAuthDelete(false);
-          setPendingOAuthDelete(null);
-        }}
+        onClose={() => { setShowConfirmOAuthDelete(false); setPendingOAuthDelete(null); }}
         onConfirm={handleOAuthDelete}
         title="Remove OAuth Account"
         message={`Remove OAuth account ${pendingOAuthDelete?.accountName}?`}
@@ -1062,84 +592,14 @@ export function OAuthSection({
         variant="danger"
       />
 
-      <Modal isOpen={isImportModalOpen} onClose={closeImportModal}>
-        <ModalHeader>
-          <ModalTitle>
-            Import {importProviderId ? getOAuthProviderById(importProviderId)?.name || importProviderId : ""} Credential
-          </ModalTitle>
-        </ModalHeader>
-        <ModalContent>
-          <div className="space-y-4">
-            <div className="rounded-xl border-l-4 border-blue-400/60 bg-blue-500/10 p-4 text-sm backdrop-blur-xl">
-              <div className="font-medium text-white">Import a local OAuth credential</div>
-              <p className="mt-2 text-white/80">
-                Upload a JSON credential file or paste the raw JSON content below.
-                The credential will be imported and connected to your account.
-              </p>
-            </div>
-
-            <div>
-              <div className="mb-2 text-xs font-medium text-white/90">Upload JSON file</div>
-              <input
-                ref={importFileInputRef}
-                type="file"
-                accept=".json,application/json"
-                onChange={handleImportFileSelect}
-                className="block w-full text-xs text-slate-400 file:mr-3 file:rounded-md file:border-0 file:bg-slate-700 file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-slate-200 hover:file:bg-slate-600 file:cursor-pointer file:transition-colors"
-                disabled={importStatus === "uploading"}
-              />
-            </div>
-
-            <div className="relative">
-              <div className="absolute inset-x-0 top-0 flex items-center justify-center">
-                <span className="bg-slate-900 px-2 text-[10px] font-medium uppercase tracking-wider text-slate-500">or paste JSON</span>
-              </div>
-              <div className="border-t border-slate-700/50 pt-4 mt-2">
-                <textarea
-                  value={importJsonContent}
-                  onChange={(e) => handleImportJsonChange(e.target.value)}
-                  placeholder='{&#10;  "access_token": "...",&#10;  "refresh_token": "...",&#10;  ...&#10;}'
-                  rows={8}
-                  disabled={importStatus === "uploading"}
-                  className="w-full rounded-md border border-slate-700/70 bg-slate-800/50 px-3 py-2 font-mono text-xs text-slate-200 placeholder:text-slate-600 focus:border-blue-500/50 focus:outline-none focus:ring-1 focus:ring-blue-500/30 disabled:opacity-50 resize-y"
-                />
-              </div>
-            </div>
-
-            {importStatus === "error" && importErrorMessage && (
-              <div className="rounded-xl border-l-4 border-red-400/60 bg-red-500/20 p-3 text-xs text-white backdrop-blur-xl">
-                {importErrorMessage}
-              </div>
-            )}
-
-            {importStatus === "success" && (
-              <div className="rounded-xl border-l-4 border-green-400/60 bg-green-500/20 p-3 text-xs text-white backdrop-blur-xl">
-                Credential imported successfully.
-              </div>
-            )}
-
-            {importJsonContent.trim() && importStatus !== "error" && importStatus !== "success" && (
-              <div className="rounded-xl border-l-4 border-green-400/60 bg-green-500/10 p-2 text-xs text-white/70 backdrop-blur-xl">
-                JSON content loaded ({importJsonContent.length.toLocaleString()} characters). Ready to import.
-              </div>
-            )}
-          </div>
-        </ModalContent>
-        <ModalFooter>
-          <Button variant="ghost" onClick={closeImportModal}>
-            {importStatus === "success" ? "Done" : "Cancel"}
-          </Button>
-          {importStatus !== "success" && (
-            <Button
-              variant="secondary"
-              onClick={handleImportSubmit}
-              disabled={!importJsonContent.trim() || importStatus === "uploading"}
-            >
-              {importStatus === "uploading" ? "Importing..." : "Import Credential"}
-            </Button>
-          )}
-        </ModalFooter>
-      </Modal>
+      <OAuthImportModal
+        isOpen={isImportModalOpen}
+        providerId={importProviderId}
+        showToast={showToast}
+        refreshProviders={refreshProviders}
+        loadAccounts={loadAccounts}
+        onClose={() => { setIsImportModalOpen(false); setImportProviderId(null); }}
+      />
     </>
   );
 }

--- a/dashboard/src/components/providers/oauth-status-badge.tsx
+++ b/dashboard/src/components/providers/oauth-status-badge.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { parseStatusMessage, STATUS_MESSAGE_MAX_LENGTH } from "./oauth-types";
+
+interface OAuthStatusBadgeProps {
+  status: string;
+  statusMessage: string | null;
+  unavailable: boolean;
+}
+
+export function OAuthStatusBadge({ status, statusMessage, unavailable }: OAuthStatusBadgeProps) {
+  const message = parseStatusMessage(statusMessage);
+
+  if (status === "active" && !unavailable) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-400" title="Token is valid and working">
+        <span className="size-1.5 rounded-full bg-emerald-400" />
+        Active
+      </span>
+    );
+  }
+
+  if (status === "error" || unavailable) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-red-500/15 px-2 py-0.5 text-[10px] font-medium text-red-400"
+        title={message || "Account has an error"}
+      >
+        <span className="size-1.5 rounded-full bg-red-400" />
+        {message
+          ? message.length > STATUS_MESSAGE_MAX_LENGTH ? `${message.slice(0, STATUS_MESSAGE_MAX_LENGTH)}…` : message
+          : "Error"}
+      </span>
+    );
+  }
+
+  if (status === "disabled") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-slate-500/15 px-2 py-0.5 text-[10px] font-medium text-slate-400" title="Account is disabled">
+        <span className="size-1.5 rounded-full bg-slate-400" />
+        Disabled
+      </span>
+    );
+  }
+
+  return null;
+}

--- a/dashboard/src/components/providers/oauth-types.ts
+++ b/dashboard/src/components/providers/oauth-types.ts
@@ -1,0 +1,185 @@
+import { useToast } from "@/components/ui/toast";
+import type { CurrentUserLike } from "@/components/providers/api-key-section";
+
+export type ShowToast = ReturnType<typeof useToast>["showToast"];
+
+export interface OAuthSectionProps {
+  showToast: ShowToast;
+  currentUser: CurrentUserLike | null;
+  refreshProviders: () => Promise<void>;
+  onAccountCountChange: (count: number) => void;
+}
+
+export const OAUTH_PROVIDERS = [
+  {
+    id: "claude" as const,
+    name: "Claude Code",
+    description: "Anthropic Claude (Pro/Max subscription)",
+    authEndpoint: "/api/management/anthropic-auth-url?is_webui=true",
+    requiresCallback: true,
+  },
+  {
+    id: "gemini-cli" as const,
+    name: "Gemini CLI",
+    description: "Google Gemini (via Google OAuth)",
+    authEndpoint: "/api/management/gemini-cli-auth-url?project_id=ALL&is_webui=true",
+    requiresCallback: true,
+  },
+  {
+    id: "codex" as const,
+    name: "Codex",
+    description: "OpenAI Codex (Plus/Pro subscription)",
+    authEndpoint: "/api/management/codex-auth-url?is_webui=true",
+    requiresCallback: true,
+  },
+  {
+    id: "antigravity" as const,
+    name: "Antigravity",
+    description: "Google Antigravity (via Google OAuth)",
+    authEndpoint: "/api/management/antigravity-auth-url?is_webui=true",
+    requiresCallback: true,
+  },
+  {
+    id: "iflow" as const,
+    name: "iFlow",
+    description: "iFlytek iFlow (via OAuth)",
+    authEndpoint: "/api/management/iflow-auth-url?is_webui=true",
+    requiresCallback: true,
+  },
+  {
+    id: "kimi" as const,
+    name: "Kimi",
+    description: "Moonshot AI Kimi (device OAuth)",
+    authEndpoint: "/api/management/kimi-auth-url?is_webui=true",
+    requiresCallback: false,
+  },
+  {
+    id: "qwen" as const,
+    name: "Qwen Code",
+    description: "Alibaba Qwen Code (device OAuth)",
+    authEndpoint: "/api/management/qwen-auth-url?is_webui=true",
+    requiresCallback: false,
+  },
+  {
+    id: "copilot" as const,
+    name: "GitHub Copilot",
+    description: "GitHub Copilot (via GitHub device OAuth)",
+    authEndpoint: "/api/management/github-auth-url?is_webui=true",
+    requiresCallback: false,
+  },
+  {
+    id: "kiro" as const,
+    name: "Kiro",
+    description: "AWS CodeWhisperer / Kiro (device OAuth)",
+    authEndpoint: "/api/management/kiro-auth-url?is_webui=true",
+    requiresCallback: false,
+  },
+] as const;
+
+export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
+export type OAuthProviderId = OAuthProvider["id"];
+
+export const OAUTH_STATUS_POLL_INTERVAL_MS = 5000;
+export const OAUTH_STATUS_POLL_INTERVAL_HIDDEN_MS = 10000;
+export const MAX_POLL_ATTEMPTS = 60;
+export const MAX_NO_CALLBACK_ATTEMPTS = 25;
+export const NO_CALLBACK_RETRY_DELAY_MS = 3000;
+export const MAX_IMPORT_FILE_SIZE = 1024 * 1024;
+export const STATUS_MESSAGE_MAX_LENGTH = 40;
+
+export const MODAL_STATUS = {
+  IDLE: "idle",
+  LOADING: "loading",
+  WAITING: "waiting",
+  SUBMITTING: "submitting",
+  POLLING: "polling",
+  SUCCESS: "success",
+  ERROR: "error",
+} as const;
+
+export type ModalStatus = (typeof MODAL_STATUS)[keyof typeof MODAL_STATUS];
+
+export const CALLBACK_VALIDATION = {
+  EMPTY: "empty",
+  INVALID: "invalid",
+  VALID: "valid",
+} as const;
+
+export type CallbackValidation = (typeof CALLBACK_VALIDATION)[keyof typeof CALLBACK_VALIDATION];
+
+export interface OAuthAccountWithOwnership {
+  id: string;
+  accountName: string;
+  accountEmail: string | null;
+  provider: string;
+  ownerUsername: string | null;
+  ownerUserId: string | null;
+  isOwn: boolean;
+  status: "active" | "error" | "disabled" | string;
+  statusMessage: string | null;
+  unavailable: boolean;
+}
+
+export interface AuthUrlResponse {
+  status?: string;
+  url?: string;
+  state?: string;
+  user_code?: string;
+  method?: string;
+  verification_uri?: string;
+}
+
+export interface AuthStatusResponse {
+  status?: string;
+  error?: string;
+  verification_url?: string;
+  user_code?: string;
+  url?: string;
+}
+
+export interface OAuthCallbackResponse {
+  status?: number;
+  error?: string;
+}
+
+export const getOAuthProviderById = (id: OAuthProviderId | null) =>
+  OAUTH_PROVIDERS.find((provider) => provider.id === id) || null;
+
+export function isTabVisible(): boolean {
+  if (typeof document === "undefined") return true;
+  return document.visibilityState === "visible";
+}
+
+export const validateCallbackUrl = (value: string) => {
+  if (!value.trim()) {
+    return { status: CALLBACK_VALIDATION.EMPTY, message: "Paste the full URL." };
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(value.trim());
+  } catch {
+    return { status: CALLBACK_VALIDATION.INVALID, message: "That doesn't look like a valid URL." };
+  }
+
+  const code = parsedUrl.searchParams.get("code");
+  const state = parsedUrl.searchParams.get("state");
+
+  if (!code || !state) {
+    return { status: CALLBACK_VALIDATION.INVALID, message: "URL must include both code and state parameters." };
+  }
+
+  return { status: CALLBACK_VALIDATION.VALID, message: "Callback URL looks good. Ready to submit." };
+};
+
+export function parseStatusMessage(raw: string | null): string | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed?.error?.message) return parsed.error.message;
+    if (typeof parsed?.message === "string") return parsed.message;
+    return raw;
+  } catch {
+    return raw;
+  }
+}

--- a/dashboard/src/lib/api-response.ts
+++ b/dashboard/src/lib/api-response.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+
+interface ApiResponseMeta {
+  total?: number
+  page?: number
+  limit?: number
+}
+
+export function apiSuccess<T>(data: T, meta?: ApiResponseMeta, status = 200) {
+  const body: { success: true; data: T; meta?: ApiResponseMeta } = { success: true, data }
+  if (meta) {
+    body.meta = meta
+  }
+  return NextResponse.json(body, { status })
+}
+
+export function apiError(error: string, status = 400, details?: unknown) {
+  const body: { success: false; error: string; details?: unknown } = { success: false, error }
+  if (details !== undefined) {
+    body.details = details
+  }
+  return NextResponse.json(body, { status })
+}

--- a/dashboard/src/lib/errors.ts
+++ b/dashboard/src/lib/errors.ts
@@ -2,139 +2,33 @@ import { NextResponse } from "next/server";
 import type { ZodIssue } from "zod";
 import { logger } from "@/lib/logger";
 
-/**
- * Standard Error Codes
- *
- * Categorized by type for consistent API error responses.
- *
- * @example
- * // Usage in API routes:
- * return apiError(ERROR_CODE.VALIDATION_ERROR, "Invalid input", 400, zodIssues);
- * return apiError(ERROR_CODE.AUTH_FAILED, "Invalid credentials", 401);
- */
 export const ERROR_CODE = {
-  // ============================================
-  // AUTH_* - Authentication & Authorization
-  // ============================================
-
-  /** User credentials are invalid (wrong username/password) */
   AUTH_FAILED: "AUTH_FAILED",
-
-  /** JWT or session token has expired */
   AUTH_TOKEN_EXPIRED: "AUTH_TOKEN_EXPIRED",
-
-  /** User is authenticated but lacks required permissions */
   AUTH_INSUFFICIENT_PERMISSIONS: "AUTH_INSUFFICIENT_PERMISSIONS",
-
-  /** No valid session or token provided */
   AUTH_UNAUTHORIZED: "AUTH_UNAUTHORIZED",
-
-  // ============================================
-  // VALIDATION_* - Input Validation
-  // ============================================
-
-  /** Generic validation error (use details for specifics) */
   VALIDATION_ERROR: "VALIDATION_ERROR",
-
-  /** Zod schema validation failed (details contains ZodIssue[]) */
   VALIDATION_SCHEMA_ERROR: "VALIDATION_SCHEMA_ERROR",
-
-  /** Required fields are missing */
   VALIDATION_MISSING_FIELDS: "VALIDATION_MISSING_FIELDS",
-
-  /** Field value is outside allowed range or format */
   VALIDATION_INVALID_FORMAT: "VALIDATION_INVALID_FORMAT",
-
-  // ============================================
-  // RATE_LIMIT_* - Rate Limiting
-  // ============================================
-
-  /** Request rate limit exceeded */
   RATE_LIMIT_EXCEEDED: "RATE_LIMIT_EXCEEDED",
-
-  // ============================================
-  // NOT_FOUND_* - Resource Not Found
-  // ============================================
-
-  /** Generic resource not found */
   RESOURCE_NOT_FOUND: "RESOURCE_NOT_FOUND",
-
-  /** Specific user not found */
   USER_NOT_FOUND: "USER_NOT_FOUND",
-
-  /** API key or token not found */
   KEY_NOT_FOUND: "KEY_NOT_FOUND",
-
-  /** Provider configuration not found */
   PROVIDER_NOT_FOUND: "PROVIDER_NOT_FOUND",
-
-  // ============================================
-  // CONFLICT_* - Resource Conflicts
-  // ============================================
-
-  /** Generic resource already exists */
   RESOURCE_ALREADY_EXISTS: "RESOURCE_ALREADY_EXISTS",
-
-  /** Initial setup has already been completed */
   SETUP_ALREADY_COMPLETED: "SETUP_ALREADY_COMPLETED",
-
-  /** API key already contributed by this user */
   KEY_ALREADY_EXISTS: "KEY_ALREADY_EXISTS",
-
-  /** User has reached limit for this resource */
   LIMIT_REACHED: "LIMIT_REACHED",
-
-  // ============================================
-  // PROVIDER_* - Provider-specific
-  // ============================================
-
-  /** Invalid provider specified */
   PROVIDER_INVALID: "PROVIDER_INVALID",
-
-  /** Provider operation failed */
   PROVIDER_ERROR: "PROVIDER_ERROR",
-
-  // ============================================
-  // INTERNAL_* - Server Errors
-  // ============================================
-
-  /** Generic internal server error */
   INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
-
-  /** Database operation failed */
   DATABASE_ERROR: "DATABASE_ERROR",
-
-  /** Configuration error */
   CONFIG_ERROR: "CONFIG_ERROR",
 } as const;
 
 export type ErrorCode = (typeof ERROR_CODE)[keyof typeof ERROR_CODE];
 
-/**
- * Standard API error response format
- */
-export interface APIErrorResponse {
-  error: {
-    code: ErrorCode;
-    message: string;
-    details?: unknown;
-  };
-}
-
-/**
- * Transform Zod issues to a structured format
- *
- * @example
- * const result = schema.safeParse(data);
- * if (!result.success) {
- *   return apiError(
- *     ERROR_CODE.VALIDATION_SCHEMA_ERROR,
- *     "Validation failed",
- *     400,
- *     transformZodErrors(result.error.issues)
- *   );
- * }
- */
 export interface TransformedZodError {
   field: string;
   message: string;
@@ -150,146 +44,83 @@ export function transformZodErrors(issues: ZodIssue[]): TransformedZodError[] {
 }
 
 /**
- * Create a standard error response
+ * Create a standard error response.
  *
- * @example
- * // Simple error
- * return apiError(ERROR_CODE.AUTH_FAILED, "Invalid credentials", 401);
+ * Produces the same envelope as api-response.ts::apiError:
+ *   { success: false, error: "message", code?: "ERROR_CODE", details?: ... }
  *
- * // With details
- * return apiError(ERROR_CODE.VALIDATION_ERROR, "Invalid input", 400, { field: "email" });
- *
- * // With Zod errors
- * return apiError(
- *   ERROR_CODE.VALIDATION_SCHEMA_ERROR,
- *   "Validation failed",
- *   400,
- *   transformZodErrors(result.error.issues)
- * );
+ * This ensures client code reading `data.error` always gets a string.
  */
 export function apiError(
   code: ErrorCode,
   message: string,
   status: number,
   details?: unknown
-): NextResponse<APIErrorResponse> {
-  return NextResponse.json(
-    {
-      error: {
-        code,
-        message,
-        ...(details !== undefined && { details }),
-      },
-    },
-    { status }
-  );
+): NextResponse {
+  const body: { success: false; error: string; code: ErrorCode; details?: unknown } = {
+    success: false,
+    error: message,
+    code,
+  };
+  if (details !== undefined) {
+    body.details = details;
+  }
+  return NextResponse.json(body, { status });
 }
 
-/**
- * Create a standard error response with additional headers
- *
- * @example
- * return apiErrorWithHeaders(
- *   ERROR_CODE.RATE_LIMIT_EXCEEDED,
- *   "Too many requests",
- *   429,
- *   undefined,
- *   { "Retry-After": "60" }
- * );
- */
 export function apiErrorWithHeaders(
   code: ErrorCode,
   message: string,
   status: number,
   details: unknown | undefined,
   headers: Record<string, string>
-): NextResponse<APIErrorResponse> {
-  return NextResponse.json(
-    {
-      error: {
-        code,
-        message,
-        ...(details !== undefined && { details }),
-      },
-    },
-    { status, headers }
-  );
+): NextResponse {
+  const body: { success: false; error: string; code: ErrorCode; details?: unknown } = {
+    success: false,
+    error: message,
+    code,
+  };
+  if (details !== undefined) {
+    body.details = details;
+  }
+  return NextResponse.json(body, { status, headers });
 }
 
-// ============================================
-// Convenience factories for common errors
-// ============================================
-
 export const Errors = {
-  /** 401 - No valid session */
   unauthorized: () =>
     apiError(ERROR_CODE.AUTH_UNAUTHORIZED, "Unauthorized", 401),
 
-  /** 401 - Invalid credentials */
   invalidCredentials: () =>
     apiError(ERROR_CODE.AUTH_FAILED, "Invalid credentials", 401),
 
-  /** 403 - Lacks permissions */
   forbidden: () =>
-    apiError(
-      ERROR_CODE.AUTH_INSUFFICIENT_PERMISSIONS,
-      "Insufficient permissions",
-      403
-    ),
+    apiError(ERROR_CODE.AUTH_INSUFFICIENT_PERMISSIONS, "Insufficient permissions", 403),
 
-  /** 404 - Resource not found */
   notFound: (resource = "Resource") =>
     apiError(ERROR_CODE.RESOURCE_NOT_FOUND, `${resource} not found`, 404),
 
-  /** 400 - Validation error */
   validation: (message: string, details?: unknown) =>
     apiError(ERROR_CODE.VALIDATION_ERROR, message, 400, details),
 
-  /** 400 - Missing required fields */
   missingFields: (fields: string[]) =>
-    apiError(
-      ERROR_CODE.VALIDATION_MISSING_FIELDS,
-      `Missing required fields: ${fields.join(", ")}`,
-      400,
-      { fields }
-    ),
+    apiError(ERROR_CODE.VALIDATION_MISSING_FIELDS, `Missing required fields: ${fields.join(", ")}`, 400, { fields }),
 
-  /** 400 - Zod schema validation failed */
   zodValidation: (issues: ZodIssue[]) =>
-    apiError(
-      ERROR_CODE.VALIDATION_SCHEMA_ERROR,
-      "Validation failed",
-      400,
-      transformZodErrors(issues)
-    ),
+    apiError(ERROR_CODE.VALIDATION_SCHEMA_ERROR, "Validation failed", 400, transformZodErrors(issues)),
 
-  /** 409 - Resource already exists */
   conflict: (message: string) =>
     apiError(ERROR_CODE.RESOURCE_ALREADY_EXISTS, message, 409),
 
-  /** 429 - Rate limit exceeded */
   rateLimited: (retryAfterSeconds: number) =>
-    apiErrorWithHeaders(
-      ERROR_CODE.RATE_LIMIT_EXCEEDED,
-      "Too many requests. Try again later.",
-      429,
-      undefined,
-      { "Retry-After": String(retryAfterSeconds) }
-    ),
+    apiErrorWithHeaders(ERROR_CODE.RATE_LIMIT_EXCEEDED, "Too many requests. Try again later.", 429, undefined, { "Retry-After": String(retryAfterSeconds) }),
 
-  /** 500 - Internal server error */
   internal: (context: string, error?: unknown) => {
     if (error) {
       logger.error({ err: error, context }, context);
     }
-    return apiError(
-      ERROR_CODE.INTERNAL_SERVER_ERROR,
-      "Internal server error",
-      500
-    );
+    return apiError(ERROR_CODE.INTERNAL_SERVER_ERROR, "Internal server error", 500);
   },
 
-  /** 500 - Database error */
   database: (context: string, error?: unknown) => {
     if (error) {
       logger.error({ err: error, context }, `Database error in ${context}`);

--- a/dashboard/src/lib/validation/schemas.ts
+++ b/dashboard/src/lib/validation/schemas.ts
@@ -153,9 +153,12 @@ export const LoginSchema = z.object({
   password: z.string().min(1)
 });
 
+const PASSWORD_MIN_LENGTH = 8;
+const PASSWORD_MAX_LENGTH = 72;
+
 export const ChangePasswordSchema = z.object({
   currentPassword: z.string().min(1),
-  newPassword: z.string().min(1)
+  newPassword: z.string().min(PASSWORD_MIN_LENGTH, `Password must be at least ${PASSWORD_MIN_LENGTH} characters`).max(PASSWORD_MAX_LENGTH, `Password must be at most ${PASSWORD_MAX_LENGTH} characters`),
 });
 
 // ============================================================================
@@ -206,3 +209,199 @@ export const ImportOAuthCredentialSchema = z.object({
 });
 
 export type ImportOAuthCredentialInput = z.infer<typeof ImportOAuthCredentialSchema>;
+
+// ============================================================================
+// ADMIN SETTINGS
+// ============================================================================
+
+const ALLOWED_SETTING_KEYS = [
+  "max_provider_keys_per_user",
+  "telegram_bot_token",
+  "telegram_chat_id",
+  "telegram_quota_threshold",
+  "telegram_alerts_enabled",
+  "telegram_last_alert_time",
+  "telegram_alert_providers",
+  "telegram_check_interval",
+  "telegram_cooldown",
+] as const;
+
+export const UpdateSystemSettingSchema = z.object({
+  key: z.enum(ALLOWED_SETTING_KEYS, { message: "Unknown setting key" }),
+  value: z.string().min(1).max(1000),
+});
+
+// ============================================================================
+// ADMIN DEPLOY
+// ============================================================================
+
+export const DeploySchema = z.object({
+  noCache: z.boolean().optional(),
+});
+
+// ============================================================================
+// ADMIN TELEGRAM
+// ============================================================================
+
+export const UpdateTelegramSettingsSchema = z.object({
+  botToken: z.string().optional(),
+  chatId: z.string().optional(),
+  threshold: z.union([z.number().int().min(1).max(100), z.string()]).optional(),
+  enabled: z.boolean().optional(),
+  providers: z.array(z.string()).optional(),
+  checkInterval: z.number().int().min(1).max(1440).optional(),
+  cooldown: z.number().int().min(1).max(1440).optional(),
+});
+
+// ============================================================================
+// CONFIG SYNC TOKEN UPDATE
+// ============================================================================
+
+export const UpdateSyncTokenSchema = z.object({
+  syncApiKey: z.string().optional().nullable(),
+});
+
+// ============================================================================
+// RESTART / CONFIRM ACTIONS
+// ============================================================================
+
+export const ConfirmActionSchema = z.object({
+  confirm: z.literal(true, {
+    message: "Confirmation required: set confirm to true",
+  }),
+});
+
+// ============================================================================
+// UPDATE PROXY
+// ============================================================================
+
+export const UpdateProxySchema = z.object({
+  version: z.string().default("latest"),
+  confirm: z.literal(true, {
+    message: "Confirmation required: set confirm to true",
+  }),
+});
+
+// ============================================================================
+// UPDATE DASHBOARD
+// ============================================================================
+
+export const UpdateDashboardSchema = z.object({
+  confirm: z.literal(true, {
+    message: "Confirmation required: set confirm to true",
+  }),
+});
+
+// ============================================================================
+// USER API KEYS
+// ============================================================================
+
+export const CreateApiKeySchema = z.object({
+  name: z.string().optional(),
+});
+
+// ============================================================================
+// PROVIDER KEYS
+// ============================================================================
+
+export const ContributeKeySchema = z.object({
+  provider: z.string().min(1),
+  apiKey: z.string().min(1),
+});
+
+// ============================================================================
+// OAUTH ACCOUNTS
+// ============================================================================
+
+export const ContributeOAuthSchema = z.object({
+  provider: z.string().min(1),
+  accountName: z.string().min(1),
+  accountEmail: z.string().optional(),
+});
+
+export const ToggleOAuthSchema = z.object({
+  disabled: z.boolean(),
+});
+
+// ============================================================================
+// PERPLEXITY COOKIE
+// ============================================================================
+
+export const CreatePerplexityCookieSchema = z.object({
+  cookieData: z.string().min(1),
+  label: z.string().optional(),
+});
+
+export const DeletePerplexityCookieSchema = z.object({
+  id: z.string().min(1),
+});
+
+// ============================================================================
+// CONFIG SHARING - PUBLISH
+// ============================================================================
+
+export const CreatePublishSchema = z.object({
+  name: z.string().optional(),
+});
+
+export const UpdatePublishSchema = z.object({
+  name: z.string().optional(),
+  isActive: z.boolean().optional(),
+});
+
+// ============================================================================
+// CONFIG SHARING - SUBSCRIBE
+// ============================================================================
+
+export const SubscribeSchema = z.object({
+  shareCode: z.string().min(1),
+});
+
+export const UpdateSubscriptionSchema = z.object({
+  isActive: z.boolean(),
+});
+
+// ============================================================================
+// OAUTH CALLBACK
+// ============================================================================
+
+export const OAuthCallbackSchema = z.object({
+  provider: z.string().min(1),
+  callbackUrl: z.string().optional(),
+  state: z.string().optional(),
+});
+
+// ============================================================================
+// ADMIN USERS
+// ============================================================================
+
+export const CreateUserSchema = z.object({
+  username: z.string().min(1),
+  password: z.string().min(1),
+  isAdmin: z.boolean().optional(),
+});
+
+// ============================================================================
+// USER CONFIG
+// ============================================================================
+
+const UserConfigMcpLocalSchema = z.object({
+  name: z.string().min(1),
+  type: z.literal("local"),
+  command: z.array(z.string()).min(1),
+  enabled: z.boolean().optional(),
+  environment: z.record(z.string(), z.string()).optional(),
+});
+
+const UserConfigMcpRemoteSchema = z.object({
+  name: z.string().min(1),
+  type: z.literal("remote"),
+  url: z.string().min(1),
+  enabled: z.boolean().optional(),
+  environment: z.record(z.string(), z.string()).optional(),
+});
+
+export const UserConfigSchema = z.object({
+  mcpServers: z.array(z.union([UserConfigMcpLocalSchema, UserConfigMcpRemoteSchema])).optional(),
+  customPlugins: z.array(z.string().min(1)).optional(),
+});


### PR DESCRIPTION
## Summary

- **Split 4 oversized files** into focused modules using `_components/` convention:
  - `config/page.tsx` 1118 → 253 lines (5 sub-files extracted)
  - `quota/page.tsx` 1029 → 312 lines (types, utils, telegram section extracted)
  - `oauth-section.tsx` 1145 → 606 lines (types, badge, import modal extracted)
  - `toggle-sections.tsx` 950 → 383 lines (toggle-ui primitives, LSP section extracted)
- **Standardized all 55+ API routes** to use `apiSuccess()`/`apiError()` envelope + `Errors.*` convenience factories
- **Added 30+ Zod validation schemas** for all API inputs (`lib/validation/schemas.ts`)
- **Fixed dual `apiError` envelope mismatch** — `errors.ts` now produces same `{ success, error }` shape as `api-response.ts`, preventing `[object Object]` in UI toasts
- **Security hardening:**
  - Admin settings key allowlist (prevents arbitrary DB writes)
  - Deploy route error message sanitization (no more raw `error.message` leaks)
  - `validateOrigin` added to deploy GET handler
  - Removed `console.warn` leaking OAuth state tokens
  - Password schema enforces min 8 / max 72 at Zod level
- **Zod schema validation** for restart (`ConfirmActionSchema`) and update (`UpdateProxySchema`) routes
- **Added `zod` dependency** to `package.json`
- **Net: -1,106 lines** (3,112 added / 4,218 removed across 76 files)

## Test plan

- [ ] Full `npm run build` passes (verified locally)
- [ ] `npx tsc --noEmit` passes with 0 errors (verified locally)
- [ ] Verify OAuth add/remove/import flows still work (envelope fix)
- [ ] Verify admin settings update still works (key allowlist)
- [ ] Verify deploy trigger and status check work
- [ ] Verify restart and update proxy flows work (Zod validation)
- [ ] Verify login/change-password error messages display correctly
- [ ] Smoke test config page, quota page, providers page render correctly