### PR TITLE
fix: improve PostgreSQL password auth error handling and documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,10 @@ API_SUBDOMAIN=api
 # =============================================================================
 # Full connection string used by the dashboard (Prisma)
 DATABASE_URL=postgresql://cliproxyapi:CHANGE_ME_POSTGRES_PASSWORD@postgres:5432/cliproxyapi
-# Password for the Postgres container
+# Password for the Postgres container (generate with: openssl rand -hex 32)
+# WARNING: Only used during first-time DB initialization. Changing this after
+# the database volume exists will NOT update the password, causing auth failures.
+# To reset: docker compose down -v (destroys all data)
 POSTGRES_PASSWORD=CHANGE_ME_POSTGRES_PASSWORD
 
 # =============================================================================

--- a/dashboard/entrypoint.sh
+++ b/dashboard/entrypoint.sh
@@ -7,7 +7,25 @@ const { Client } = require('pg');
 const client = new Client({ connectionString: process.env.DATABASE_URL });
 
 async function migrate() {
-  await client.connect();
+  try {
+    await client.connect();
+  } catch (e) {
+    if (e.code === '28P01') {
+      console.error('[dashboard] FATAL: Password authentication failed for PostgreSQL user.');
+      console.error('[dashboard] This usually means POSTGRES_PASSWORD in your .env was changed after the database was first created.');
+      console.error('[dashboard] PostgreSQL only reads POSTGRES_PASSWORD during initial volume creation.');
+      console.error('[dashboard]');
+      console.error('[dashboard] To fix, choose one of:');
+      console.error('[dashboard]   1. Reset the volume (destroys data): docker compose down -v && docker compose up -d');
+      console.error('[dashboard]   2. Update the DB password to match your .env:');
+      console.error('[dashboard]      docker compose exec postgres psql -U cliproxyapi -c "ALTER USER cliproxyapi PASSWORD \'<POSTGRES_PASSWORD from .env>\';"');
+      console.error('[dashboard]   3. Revert POSTGRES_PASSWORD in .env to the original value');
+    } else {
+      console.error('[dashboard] FATAL: Cannot connect to database:', e.message);
+    }
+    process.exitCode = 1;
+    return;
+  }
   let failed = false;
 
   try {

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -12,6 +12,8 @@ services:
     environment:
       POSTGRES_DB: cliproxyapi
       POSTGRES_USER: cliproxyapi
+      # NOTE: Only used on first run (volume creation). Changing this later won't update the DB password.
+      # To reset: docker compose -f docker-compose.local.yml down -v
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -22,6 +22,48 @@ docker compose logs -f
 
 ## Database Connection Errors
 
+### Password Authentication Failed (error code 28P01)
+
+If you see an error like:
+```
+error: password authentication failed for user "cliproxyapi"
+  severity: 'FATAL',
+  code: '28P01',
+```
+
+This is almost always caused by a **password mismatch** between your `.env` file and what PostgreSQL was initialized with.
+
+> **Important**: PostgreSQL only reads `POSTGRES_PASSWORD` during **first-time initialization** (when the data volume is empty). If you change the password in `.env` after the database has already been created, PostgreSQL will still use the old password — but the dashboard will try to connect with the new one.
+
+**Fix — Option 1: Reset the volume** (easiest, destroys all data):
+```bash
+# Local setup
+docker compose -f docker-compose.local.yml down -v
+./setup-local.sh          # macOS/Linux
+.\setup-local.ps1         # Windows
+
+# Server setup
+cd infrastructure
+docker compose down -v
+sudo systemctl start cliproxyapi-stack
+```
+
+**Fix — Option 2: Update PostgreSQL password** (preserves data):
+```bash
+# 1. Find the current password in your .env
+grep POSTGRES_PASSWORD .env
+
+# 2. Connect to PostgreSQL with the OLD password and change it
+docker compose exec postgres psql -U cliproxyapi -d cliproxyapi -c \
+  "ALTER USER cliproxyapi PASSWORD 'YOUR_NEW_PASSWORD_FROM_ENV';"
+```
+If you don't know the old password, use option 1.
+
+**Fix — Option 3: Revert `.env` to the original password**:
+If you accidentally changed `POSTGRES_PASSWORD` in `.env`, revert it to the value that was originally generated, then restart the stack.
+
+### General Database Connectivity
+
 **Verify PostgreSQL is healthy:**
 ```bash
 docker compose ps postgres
@@ -33,6 +75,8 @@ docker compose exec postgres pg_isready -U cliproxyapi
 grep -E 'POSTGRES_PASSWORD|DATABASE_URL' infrastructure/.env
 ```
 
+**Verify the password in `DATABASE_URL` matches `POSTGRES_PASSWORD`:**
+The `DATABASE_URL` contains the password inline: `postgresql://cliproxyapi:<password>@postgres:5432/cliproxyapi`. If you set these manually, ensure both values use the same password.
 ## OAuth Callbacks Failing
 
 **Verify firewall rules:**

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     environment:
       POSTGRES_DB: cliproxyapi
       POSTGRES_USER: cliproxyapi
+      # NOTE: Only used on first run (volume creation). Changing this later won't update the DB password.
+      # To reset: docker compose down -v (destroys all data)
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       TZ: ${TZ}
     env_file:


### PR DESCRIPTION
## Summary

Fixes #134 — "Unable to start dashboard" caused by PostgreSQL password authentication failure (error code `28P01`).

**Root cause**: PostgreSQL only reads `POSTGRES_PASSWORD` during first-time volume initialization. If a user changes the password in `.env` after the database volume already exists, the dashboard tries to connect with the new password while PostgreSQL still expects the old one.

## Changes

- **`dashboard/entrypoint.sh`**: Catch `28P01` errors during DB connection and surface clear, actionable fix instructions instead of a raw Node.js stack trace
- **`docs/TROUBLESHOOTING.md`**: Add comprehensive "Password Authentication Failed" section with 3 resolution options (volume reset, ALTER USER, revert .env)
- **`docker-compose.local.yml`** / **`infrastructure/docker-compose.yml`**: Add inline warning comments next to `POSTGRES_PASSWORD` about volume persistence behavior
- **`.env.example`**: Add warning about password only being used during initial DB creation

## What users will see (before → after)

**Before**: Raw `pg-protocol` stack trace with `code: '28P01'`

**After**:
```
[dashboard] FATAL: Password authentication failed for PostgreSQL user.
[dashboard] This usually means POSTGRES_PASSWORD in your .env was changed after the database was first created.
[dashboard] PostgreSQL only reads POSTGRES_PASSWORD during initial volume creation.
[dashboard]
[dashboard] To fix, choose one of:
[dashboard]   1. Reset the volume (destroys data): docker compose down -v && docker compose up -d
[dashboard]   2. Update the DB password to match your .env: ...
[dashboard]   3. Revert POSTGRES_PASSWORD in .env to the original value
```