### PR TITLE
feat(quota): add model-first Antigravity snapshots

### DIFF
--- a/dashboard/src/app/api/quota/route.test.ts
+++ b/dashboard/src/app/api/quota/route.test.ts
@@ -1,7 +1,5 @@
-import { NextRequest } from "next/server";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Mock external dependencies before importing route
 vi.mock("@/lib/auth/session", () => ({
   verifySession: vi.fn(() => ({ userId: "test-user" })),
 }));
@@ -19,27 +17,18 @@ vi.mock("@/lib/db", () => ({
   prisma: {},
 }));
 
-// Set required env vars
-process.env.MANAGEMENT_API_KEY = "test-key";
-process.env.CLIPROXYAPI_MANAGEMENT_URL = "http://test:8317/v0/management";
-
-// Track all fetch calls
 const fetchMock = vi.fn();
-Object.defineProperty(global, "fetch", { value: fetchMock, writable: true, configurable: true });
+vi.stubGlobal("fetch", fetchMock);
 
-function createQuotaRequest(): NextRequest {
-  return new NextRequest("http://localhost/api/quota", {
-    headers: { cookie: "session=test" },
-  });
-}
+vi.stubEnv("MANAGEMENT_API_KEY", "test-key");
+vi.stubEnv("CLIPROXYAPI_MANAGEMENT_URL", "http://test:8317/v0/management");
 
-describe("GET /api/quota — Gemini CLI support (issue #125)", () => {
+describe("GET /api/quota - Gemini CLI support (issue #125)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should return supported: true for gemini-cli accounts", async () => {
-    // Mock auth-files response with a gemini-cli account
+  it("returns supported: true for gemini-cli accounts", async () => {
     const authFilesResponse = {
       files: [
         {
@@ -52,7 +41,6 @@ describe("GET /api/quota — Gemini CLI support (issue #125)", () => {
       ],
     };
 
-    // Mock Google fetchAvailableModels response (same format as Antigravity)
     const googleModelsResponse = {
       models: {
         "gemini-2.5-pro": {
@@ -73,13 +61,22 @@ describe("GET /api/quota — Gemini CLI support (issue #125)", () => {
     };
 
     fetchMock
-      // First call: auth-files
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(authFilesResponse),
         body: { cancel: vi.fn() },
       })
-      // Second call: api-call for gemini-cli quota
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            status_code: 200,
+            body: {
+              cloudaicompanionProject: "test-project",
+            },
+          }),
+        body: { cancel: vi.fn() },
+      })
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(googleModelsResponse),
@@ -88,22 +85,22 @@ describe("GET /api/quota — Gemini CLI support (issue #125)", () => {
 
     const { GET } = await import("./route");
 
-    const response = await GET(createQuotaRequest());
+    const request = new Request("http://localhost/api/quota", {
+      headers: { cookie: "session=test" },
+    });
+    const response = await GET(request as any);
     const data = await response.json();
 
-    // Route returns { accounts: [...] } directly (no success wrapper)
-    expect(data.accounts).toBeDefined();
     expect(data.accounts).toHaveLength(1);
 
     const account = data.accounts[0];
     expect(account.provider).toBe("gemini-cli");
     expect(account.supported).toBe(true);
-    // Should have quota groups, not be unsupported
     expect(account.groups).toBeDefined();
     expect(account.groups.length).toBeGreaterThan(0);
   });
 
-  it("should return supported: true with error for gemini-cli auth failures", async () => {
+  it("returns supported: true with error for gemini-cli auth failures", async () => {
     const authFilesResponse = {
       files: [
         {
@@ -123,6 +120,17 @@ describe("GET /api/quota — Gemini CLI support (issue #125)", () => {
         body: { cancel: vi.fn() },
       })
       .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            status_code: 200,
+            body: {
+              cloudaicompanionProject: "test-project",
+            },
+          }),
+        body: { cancel: vi.fn() },
+      })
+      .mockResolvedValueOnce({
         ok: false,
         status: 401,
         json: () => Promise.resolve({}),
@@ -131,18 +139,19 @@ describe("GET /api/quota — Gemini CLI support (issue #125)", () => {
 
     const { GET } = await import("./route");
 
-    const response = await GET(createQuotaRequest());
+    const request = new Request("http://localhost/api/quota", {
+      headers: { cookie: "session=test" },
+    });
+    const response = await GET(request as any);
     const data = await response.json();
 
-    // Route returns { accounts: [...] } directly (no success wrapper)
-    expect(data.accounts).toBeDefined();
     const account = data.accounts[0];
     expect(account.provider).toBe("gemini-cli");
     expect(account.supported).toBe(true);
     expect(account.error).toBeDefined();
   });
 
-  it("should handle 'gemini' provider the same as 'gemini-cli'", async () => {
+  it("handles the gemini provider the same as gemini-cli", async () => {
     const authFilesResponse = {
       files: [
         {
@@ -175,33 +184,211 @@ describe("GET /api/quota — Gemini CLI support (issue #125)", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: () =>
+          Promise.resolve({
+            status_code: 200,
+            body: {
+              cloudaicompanionProject: "test-project",
+            },
+          }),
+        body: { cancel: vi.fn() },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve(googleModelsResponse),
         body: { cancel: vi.fn() },
       });
 
     const { GET } = await import("./route");
 
-    const response = await GET(createQuotaRequest());
+    const request = new Request("http://localhost/api/quota", {
+      headers: { cookie: "session=test" },
+    });
+    const response = await GET(request as any);
     const data = await response.json();
 
-    // Route returns { accounts: [...] } directly (no success wrapper)
-    expect(data.accounts).toBeDefined();
     const account = data.accounts[0];
     expect(account.supported).toBe(true);
     expect(account.groups).toBeDefined();
   });
+
+  it("falls back to the next Antigravity quota endpoint and returns model-first metadata", async () => {
+    const authFilesResponse = {
+      files: [
+        {
+          auth_index: 0,
+          provider: "antigravity",
+          email: "test@gmail.com",
+          disabled: false,
+          status: "active",
+        },
+      ],
+    };
+
+    const googleModelsResponse = {
+      status_code: 200,
+      body: {
+        models: {
+          "gemini-2.5-flash": {
+            quotaInfo: {
+              remainingFraction: 0.8,
+              resetTime: "2026-03-08T05:00:00Z",
+            },
+          },
+          "gemini-3-pro-high": {
+            displayName: "Gemini 3 Pro High",
+            quotaInfo: {
+              remainingFraction: 0.4,
+              resetTime: "2026-03-12T00:00:00Z",
+            },
+          },
+        },
+      },
+    };
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(authFilesResponse),
+        body: { cancel: vi.fn() },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            status_code: 200,
+            body: {
+              cloudaicompanionProject: "test-project",
+            },
+          }),
+        body: { cancel: vi.fn() },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            status_code: 429,
+            body: {},
+          }),
+        body: { cancel: vi.fn() },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(googleModelsResponse),
+        body: { cancel: vi.fn() },
+      });
+
+    const { GET } = await import("./route");
+
+    const request = new Request("http://localhost/api/quota", {
+      headers: { cookie: "session=test" },
+    });
+    const response = await GET(request as any);
+    const data = await response.json();
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(data.accounts).toHaveLength(1);
+    expect(data.generatedAt).toBeDefined();
+
+    const account = data.accounts[0];
+    expect(account.provider).toBe("antigravity");
+    expect(account.monitorMode).toBe("model-first");
+    expect(account.snapshotFetchedAt).toBeDefined();
+    expect(account.snapshotSource).toContain("daily-cloudcode-pa.googleapis.com");
+    expect(account.groups[0].monitorMode).toBe("model-first");
+    expect(account.groups[0].nextWindowResetAt).toBeDefined();
+    expect(account.groups[0].p50RemainingFraction).toBeDefined();
+    expect(account.groups[0].models[0].displayName).toBe("Gemini 3 Pro High");
+    expect(account.groups[1].models[0].displayName).toBe("gemini-2.5-flash");
+  });
+
+  it("passes project_id to fetchAvailableModels and treats missing remainingFraction as depleted", async () => {
+    const authFilesResponse = {
+      files: [
+        {
+          auth_index: 0,
+          provider: "antigravity",
+          email: "test@gmail.com",
+          disabled: false,
+          status: "active",
+        },
+      ],
+    };
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(authFilesResponse),
+        body: { cancel: vi.fn() },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            status_code: 200,
+            body: {
+              cloudaicompanionProject: "confident-arc-98xjk",
+            },
+          }),
+        body: { cancel: vi.fn() },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            status_code: 200,
+            body: {
+              models: {
+                "claude-opus-4-6-thinking": {
+                  displayName: "Claude Opus 4.6 (Thinking)",
+                  quotaInfo: {
+                    resetTime: "2026-04-07T20:18:24Z",
+                  },
+                },
+                "gemini-3-flash": {
+                  displayName: "Gemini 3 Flash",
+                  quotaInfo: {
+                    remainingFraction: 0.8,
+                    resetTime: "2026-04-07T12:10:05Z",
+                  },
+                },
+              },
+            },
+          }),
+        body: { cancel: vi.fn() },
+      });
+
+    const { GET } = await import("./route");
+
+    const request = new Request("http://localhost/api/quota", {
+      headers: { cookie: "session=test" },
+    });
+    const response = await GET(request as any);
+    const data = await response.json();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[2]?.[1]).toMatchObject({
+      method: "POST",
+    });
+    const fetchQuotaCallBody = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body));
+    expect(fetchQuotaCallBody.data).toBe("{\"project\":\"confident-arc-98xjk\"}");
+
+    const account = data.accounts[0];
+    const models = account.groups.flatMap((group: any) => group.models);
+    const claudeModel = models.find((model: any) => model.id === "claude-opus-4-6-thinking");
+    const flashModel = models.find((model: any) => model.id === "gemini-3-flash");
+
+    expect(claudeModel?.remainingFraction).toBe(0);
+    expect(flashModel?.remainingFraction).toBe(0.8);
+  });
 });
 
-// RED: These tests fail until quota/route.ts normalizes provider strings
-describe("GET /api/quota — imported provider normalization (issue #provider-fix)", () => {
+describe("GET /api/quota - imported provider normalization", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("copilot provider should return supported: true (RED: route checks 'github'/'github-copilot' but not 'copilot')", async () => {
-    // RED: This test fails until quota/route.ts normalizes provider strings
-    // Fix needed: add || account.provider === "copilot" to the github branch in route.ts
-
+  it("copilot provider returns supported: true", async () => {
     const authFilesResponse = {
       files: [
         {
@@ -214,7 +401,6 @@ describe("GET /api/quota — imported provider normalization (issue #provider-fi
       ],
     };
 
-    // fetchCopilotQuota calls /api-call and expects ApiCallResponse shape
     const copilotApiCallResponse = {
       status_code: 200,
       body: {
@@ -228,13 +414,11 @@ describe("GET /api/quota — imported provider normalization (issue #provider-fi
     };
 
     fetchMock
-      // First call: auth-files
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(authFilesResponse),
         body: { cancel: vi.fn() },
       })
-      // Second call: api-call for copilot quota
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(copilotApiCallResponse),
@@ -243,25 +427,21 @@ describe("GET /api/quota — imported provider normalization (issue #provider-fi
 
     const { GET } = await import("./route");
 
-    const response = await GET(createQuotaRequest());
+    const request = new Request("http://localhost/api/quota", {
+      headers: { cookie: "session=test" },
+    });
+    const response = await GET(request as any);
     const data = await response.json();
 
-    // Route returns { accounts: [...] } directly (no success wrapper)
-    expect(data.accounts).toBeDefined();
     expect(data.accounts).toHaveLength(1);
 
     const account = data.accounts[0];
     expect(account.provider).toBe("copilot");
-    // RED: currently returns supported: false because route only checks "github"/"github-copilot"
     expect(account.supported).toBe(true);
     expect(account.groups).toBeDefined();
   });
 
-  it("CLAUDE (uppercase) provider should return supported: true (RED: route uses strict equality, no toLowerCase)", async () => {
-    // RED: This test fails until quota/route.ts normalizes provider strings
-    // Fix needed: normalize provider to lowercase before the if-chain, e.g.:
-    //   const normalizedProvider = account.provider.toLowerCase();
-
+  it("CLAUDE uppercase provider returns supported: true", async () => {
     const authFilesResponse = {
       files: [
         {
@@ -274,33 +454,28 @@ describe("GET /api/quota — imported provider normalization (issue #provider-fi
       ],
     };
 
-    fetchMock
-      // First call: auth-files — no second call needed, route falls through before fetching
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(authFilesResponse),
-        body: { cancel: vi.fn() },
-      });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(authFilesResponse),
+      body: { cancel: vi.fn() },
+    });
 
     const { GET } = await import("./route");
 
-    const response = await GET(createQuotaRequest());
+    const request = new Request("http://localhost/api/quota", {
+      headers: { cookie: "session=test" },
+    });
+    const response = await GET(request as any);
     const data = await response.json();
 
-    // Route returns { accounts: [...] } directly (no success wrapper)
-    expect(data.accounts).toBeDefined();
     expect(data.accounts).toHaveLength(1);
 
     const account = data.accounts[0];
     expect(account.provider).toBe("CLAUDE");
-    // RED: currently returns supported: false because route checks === "claude" (lowercase only)
     expect(account.supported).toBe(true);
   });
 
-  it("unknown-xyz provider should return supported: false (regression guard — must always pass)", async () => {
-    // GREEN: This test should always pass — regression guard to ensure unknown providers
-    // are never accidentally marked as supported after normalization changes.
-
+  it("unknown providers remain unsupported", async () => {
     const authFilesResponse = {
       files: [
         {
@@ -313,26 +488,24 @@ describe("GET /api/quota — imported provider normalization (issue #provider-fi
       ],
     };
 
-    fetchMock
-      // First call: auth-files — no second call, route falls through
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(authFilesResponse),
-        body: { cancel: vi.fn() },
-      });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(authFilesResponse),
+      body: { cancel: vi.fn() },
+    });
 
     const { GET } = await import("./route");
 
-    const response = await GET(createQuotaRequest());
+    const request = new Request("http://localhost/api/quota", {
+      headers: { cookie: "session=test" },
+    });
+    const response = await GET(request as any);
     const data = await response.json();
 
-    // Route returns { accounts: [...] } directly (no success wrapper)
-    expect(data.accounts).toBeDefined();
     expect(data.accounts).toHaveLength(1);
 
     const account = data.accounts[0];
     expect(account.provider).toBe("unknown-xyz");
-    // GREEN: unknown providers must always return supported: false
     expect(account.supported).toBe(false);
   });
 
@@ -371,10 +544,12 @@ describe("GET /api/quota — imported provider normalization (issue #provider-fi
 
     const { GET } = await import("./route");
 
-    const response = await GET(createQuotaRequest());
+    const request = new Request("http://localhost/api/quota", {
+      headers: { cookie: "session=test" },
+    });
+    const response = await GET(request as any);
     const data = await response.json();
 
-    expect(data.accounts).toBeDefined();
     expect(data.accounts).toHaveLength(1);
 
     const account = data.accounts[0];

--- a/dashboard/src/app/api/quota/route.ts
+++ b/dashboard/src/app/api/quota/route.ts
@@ -4,6 +4,14 @@ import { verifySession } from "@/lib/auth/session";
 import { logger } from "@/lib/logger";
 import { quotaCache, CACHE_TTL } from "@/lib/cache";
 import { Errors } from "@/lib/errors";
+import {
+  ANTIGRAVITY_QUOTA_ENDPOINTS,
+  enrichModelFirstGroup,
+  isStaleSnapshot,
+  type QuotaAccount,
+  type QuotaGroup,
+  type QuotaResponse,
+} from "@/lib/model-first-monitoring";
 
 const CLIPROXYAPI_MANAGEMENT_URL =
   process.env.CLIPROXYAPI_MANAGEMENT_URL ||
@@ -28,42 +36,15 @@ interface AuthFilesResponse {
 }
 
 interface AntigravityModel {
-  displayName: string;
+  displayName?: string;
   quotaInfo?: {
-    remainingFraction: number;
+    remainingFraction?: number | null;
     resetTime: string | null;
   };
 }
 
 interface AntigravityResponse {
   models: Record<string, AntigravityModel>;
-}
-
-interface QuotaGroup {
-  id: string;
-  label: string;
-  remainingFraction: number;
-  resetTime: string | null;
-  models: Array<{
-    id: string;
-    displayName: string;
-    remainingFraction: number;
-    resetTime: string | null;
-  }>;
-}
-
-interface QuotaAccount {
-  auth_index: string;
-  provider: string;
-  email: string;
-  supported: boolean;
-  error?: string;
-  groups?: QuotaGroup[];
-  raw?: unknown;
-}
-
-interface QuotaResponse {
-  accounts: QuotaAccount[];
 }
 
 function isMeaningfulDisplayValue(value: string | undefined): value is string {
@@ -165,6 +146,12 @@ function groupAntigravityModels(
   for (const [modelId, modelData] of Object.entries(models)) {
     if (!modelData.quotaInfo) continue;
 
+    const remainingFraction =
+      typeof modelData.quotaInfo.remainingFraction === "number" &&
+      Number.isFinite(modelData.quotaInfo.remainingFraction)
+        ? modelData.quotaInfo.remainingFraction
+        : 0;
+
     const groupName = categorizeModel(modelId);
     
     if (!groups[groupName]) {
@@ -177,35 +164,59 @@ function groupAntigravityModels(
 
     groups[groupName].models.push({
       id: modelId,
-      displayName: modelData.displayName,
-      remainingFraction: modelData.quotaInfo.remainingFraction,
+      displayName: modelData.displayName?.trim() || modelId,
+      remainingFraction,
       resetTime: modelData.quotaInfo.resetTime,
     });
   }
 
-  return Object.values(groups).map((group) => {
-    const remainingFraction = Math.min(
-      ...group.models.map((m) => m.remainingFraction)
-    );
-    
-    const resetTimes = group.models
-      .map((m) => m.resetTime)
-      .filter((rt): rt is string => rt !== null);
-    const resetTime = resetTimes.length > 0
-      ? resetTimes.sort()[0]
-      : null;
+  const groupOrder = Object.keys(MODEL_GROUPS);
 
-    return {
-      ...group,
-      remainingFraction,
-      resetTime,
-    };
-  });
+  return Object.values(groups)
+    .map((group) => {
+      const sortedModels = [...group.models].sort((left, right) => {
+        const resetLeft = left.resetTime ? Date.parse(left.resetTime) : Number.POSITIVE_INFINITY;
+        const resetRight = right.resetTime ? Date.parse(right.resetTime) : Number.POSITIVE_INFINITY;
+        if (resetLeft !== resetRight) return resetLeft - resetRight;
+        return left.displayName.localeCompare(right.displayName);
+      });
+
+      return enrichModelFirstGroup({
+        ...group,
+        remainingFraction: 1,
+        resetTime: null,
+        models: sortedModels,
+      });
+    })
+    .sort((left, right) => {
+      const orderLeft = groupOrder.indexOf(left.label);
+      const orderRight = groupOrder.indexOf(right.label);
+      const normalizedLeft = orderLeft === -1 ? Number.MAX_SAFE_INTEGER : orderLeft;
+      const normalizedRight = orderRight === -1 ? Number.MAX_SAFE_INTEGER : orderRight;
+      if (normalizedLeft !== normalizedRight) return normalizedLeft - normalizedRight;
+      return left.label.localeCompare(right.label);
+    });
 }
 
-async function fetchAntigravityQuota(
-  authIndex: string
-): Promise<QuotaGroup[] | { error: string }> {
+function parseAntigravityPayload(payload: unknown): Record<string, AntigravityModel> | null {
+  if (!payload || typeof payload !== "object") return null;
+  const typed = payload as AntigravityResponse;
+  if (!typed.models || typeof typed.models !== "object") return null;
+  return typed.models;
+}
+
+interface AntigravityLoadCodeAssistResponse {
+  cloudaicompanionProject?: string;
+}
+
+interface AntigravityQuotaSnapshot {
+  groups: QuotaGroup[];
+  snapshotFetchedAt: string;
+  snapshotSource: string;
+  snapshotStale: boolean;
+}
+
+async function fetchAntigravityProjectId(authIndex: string): Promise<string | null> {
   try {
     const response = await fetch(`${CLIPROXYAPI_MANAGEMENT_URL}/api-call`, {
       method: "POST",
@@ -217,57 +228,135 @@ async function fetchAntigravityQuota(
       body: JSON.stringify({
         auth_index: authIndex,
         method: "POST",
-        url: "https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+        url: "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:loadCodeAssist",
         header: {
           Authorization: "Bearer $TOKEN$",
           "Content-Type": "application/json",
           "User-Agent": "antigravity/1.11.5 windows/amd64",
         },
-        data: "{}",
+        data: JSON.stringify({
+          metadata: {
+            ideType: "ANTIGRAVITY",
+          },
+        }),
       }),
     });
 
     if (!response.ok) {
       await response.body?.cancel();
-      return { error: `API call failed: ${response.status}` };
+      return null;
     }
 
-    const apiCallResult = (await response.json()) as ApiCallResponse | AntigravityResponse;
+    const apiCallResult = (await response.json()) as ApiCallResponse | AntigravityLoadCodeAssistResponse;
+    let parsedBody: unknown = apiCallResult;
 
     if ("status_code" in apiCallResult || "statusCode" in apiCallResult) {
       const statusCode = Number(apiCallResult.status_code ?? apiCallResult.statusCode ?? 0);
       if (statusCode < 200 || statusCode >= 300) {
-        return { error: `Provider API failed: ${statusCode}` };
+        return null;
       }
 
-      let parsedBody: unknown = apiCallResult.body;
+      parsedBody = apiCallResult.body;
       if (typeof parsedBody === "string") {
         try {
           parsedBody = JSON.parse(parsedBody);
         } catch {
-          return { error: "Invalid provider response body" };
+          return null;
+        }
+      }
+    }
+
+    if (!parsedBody || typeof parsedBody !== "object") {
+      return null;
+    }
+
+    const payload = parsedBody as AntigravityLoadCodeAssistResponse;
+    return typeof payload.cloudaicompanionProject === "string" && payload.cloudaicompanionProject.trim().length > 0
+      ? payload.cloudaicompanionProject.trim()
+      : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+async function fetchAntigravityQuota(
+  authIndex: string
+): Promise<AntigravityQuotaSnapshot | { error: string }> {
+  const projectId = await fetchAntigravityProjectId(authIndex);
+  const payload = JSON.stringify(projectId ? { project: projectId } : {});
+  let lastError = "No Antigravity quota endpoints responded";
+
+  for (const endpoint of ANTIGRAVITY_QUOTA_ENDPOINTS) {
+    try {
+      const response = await fetch(`${CLIPROXYAPI_MANAGEMENT_URL}/api-call`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${MANAGEMENT_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        signal: AbortSignal.timeout(30_000),
+        body: JSON.stringify({
+          auth_index: authIndex,
+          method: "POST",
+          url: endpoint,
+          header: {
+            Authorization: "Bearer $TOKEN$",
+            "Content-Type": "application/json",
+            "User-Agent": "antigravity/1.11.5 windows/amd64",
+          },
+          data: payload,
+        }),
+      });
+
+      if (!response.ok) {
+        await response.body?.cancel();
+        lastError = `API call failed: ${response.status}`;
+        continue;
+      }
+
+      const apiCallResult = (await response.json()) as ApiCallResponse | AntigravityResponse;
+      let parsedPayload: unknown = apiCallResult;
+
+      if ("status_code" in apiCallResult || "statusCode" in apiCallResult) {
+        const statusCode = Number(apiCallResult.status_code ?? apiCallResult.statusCode ?? 0);
+        if (statusCode < 200 || statusCode >= 300) {
+          lastError = `Provider API failed: ${statusCode}`;
+          if (statusCode === 429 || statusCode >= 500) {
+            continue;
+          }
+          return { error: lastError };
+        }
+
+        parsedPayload = apiCallResult.body;
+        if (typeof parsedPayload === "string") {
+          try {
+            parsedPayload = JSON.parse(parsedPayload);
+          } catch {
+            lastError = "Invalid provider response body";
+            continue;
+          }
         }
       }
 
-      const data = parsedBody as AntigravityResponse;
-      if (!data.models || typeof data.models !== "object") {
-        return { error: "Invalid Antigravity quota payload" };
+      const models = parseAntigravityPayload(parsedPayload);
+      if (!models) {
+        lastError = "Invalid Antigravity quota payload";
+        continue;
       }
 
-      return groupAntigravityModels(data.models);
+      const snapshotFetchedAt = new Date().toISOString();
+      return {
+        groups: groupAntigravityModels(models),
+        snapshotFetchedAt,
+        snapshotSource: endpoint,
+        snapshotStale: isStaleSnapshot(snapshotFetchedAt),
+      };
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : "Unknown error";
     }
-
-    const directData = apiCallResult as AntigravityResponse;
-    if (!directData.models || typeof directData.models !== "object") {
-      return { error: "Invalid Antigravity quota payload" };
-    }
-
-    return groupAntigravityModels(directData.models);
-  } catch (error) {
-    return {
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
   }
+
+  return { error: lastError };
 }
 
 interface CodexRateWindow {
@@ -1068,7 +1157,7 @@ export async function GET(request: NextRequest) {
       (file) => !file.disabled && file.status !== "disabled"
     );
 
-    const quotaPromises = activeAccounts.map(async (account) => {
+    const quotaPromises: Promise<QuotaAccount>[] = activeAccounts.map(async (account): Promise<QuotaAccount> => {
       const authIndex = String(account.auth_index);
       const displayEmail =
         isMeaningfulDisplayValue(account.email)
@@ -1143,7 +1232,11 @@ export async function GET(request: NextRequest) {
           provider: providerForResponse,
           email: displayEmail,
           supported: true,
-          groups: result,
+          monitorMode: "model-first",
+          snapshotFetchedAt: result.snapshotFetchedAt,
+          snapshotSource: result.snapshotSource,
+          snapshotStale: result.snapshotStale,
+          groups: result.groups,
         };
       }
 
@@ -1240,7 +1333,10 @@ export async function GET(request: NextRequest) {
       };
     });
 
-    const response: QuotaResponse = { accounts };
+    const response: QuotaResponse = {
+      accounts,
+      generatedAt: new Date().toISOString(),
+    };
 
     quotaCache.set(CACHE_KEY, response, CACHE_TTL.QUOTA);
 

--- a/dashboard/src/app/dashboard/quota/page.tsx
+++ b/dashboard/src/app/dashboard/quota/page.tsx
@@ -1,45 +1,29 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
+
+import { Button } from "@/components/ui/button";
 import { HelpTooltip } from "@/components/ui/tooltip";
 import { API_ENDPOINTS } from "@/lib/api-endpoints";
+import { isShortTermQuotaWindow } from "@/lib/quota-window-classification";
+import {
+  isModelFirstAccount,
+  isModelFirstProviderQuotaUnverified,
+  normalizeFraction,
+  summarizeModelFirstProvider,
+  type ModelFirstProviderSummary,
+  type QuotaAccount,
+  type QuotaMonitorMode,
+  type QuotaResponse,
+} from "@/lib/model-first-monitoring";
+
 const QuotaChart = dynamic(
-  () => import("@/components/quota/quota-chart").then(mod => ({ default: mod.QuotaChart })),
+  () => import("@/components/quota/quota-chart").then((mod) => ({ default: mod.QuotaChart })),
   { ssr: false, loading: () => <div className="h-64 animate-pulse rounded-lg bg-[var(--surface-muted)]" /> }
 );
 import { QuotaDetails } from "@/components/quota/quota-details";
 import { QuotaAlerts } from "@/components/quota/quota-alerts";
-
-interface QuotaModel {
-  id: string;
-  displayName: string;
-  remainingFraction?: number | null;
-  resetTime: string | null;
-}
-
-interface QuotaGroup {
-  id: string;
-  label: string;
-  remainingFraction?: number | null;
-  resetTime: string | null;
-  models: QuotaModel[];
-}
-
-interface QuotaAccount {
-  auth_index: string;
-  provider: string;
-  email?: string | null;
-  supported: boolean;
-  error?: string;
-  groups?: QuotaGroup[];
-  raw?: unknown;
-}
-
-interface QuotaResponse {
-  accounts: QuotaAccount[];
-}
 
 const PROVIDERS = {
   ALL: "all",
@@ -52,30 +36,6 @@ const PROVIDERS = {
 
 type ProviderType = (typeof PROVIDERS)[keyof typeof PROVIDERS];
 
-function normalizeFraction(value: unknown): number | null {
-  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
-    return null;
-  }
-  if (value < 0) return 0;
-  if (value > 1) return 1;
-  return value;
-}
-
-function isShortTermGroup(group: QuotaGroup): boolean {
-  const id = group.id.toLowerCase();
-  const label = group.label.toLowerCase();
-  return (
-    id.includes("five-hour") ||
-    id.includes("primary") ||
-    id.includes("request") ||
-    id.includes("token") ||
-    label.includes("5h") ||
-    label.includes("5m") ||
-    label.includes("request") ||
-    label.includes("token")
-  );
-}
-
 interface WindowCapacity {
   id: string;
   label: string;
@@ -86,44 +46,79 @@ interface WindowCapacity {
 
 interface ProviderSummary {
   provider: string;
+  monitorMode: QuotaMonitorMode;
   totalAccounts: number;
   healthyAccounts: number;
   errorAccounts: number;
   windowCapacities: WindowCapacity[];
+  modelFirstSummary?: ModelFirstProviderSummary;
+}
+
+function formatRelativeTime(isoDate: string | null | undefined): string {
+  if (!isoDate) return "Unknown";
+
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+
+  const diffMs = date.getTime() - Date.now();
+  if (diffMs <= 0) return "Resetting...";
+
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
 }
 
 function calcProviderSummary(accounts: QuotaAccount[]): ProviderSummary {
   const totalAccounts = accounts.length;
   const healthy = accounts.filter(
-    (a) => a.supported && !a.error && a.groups && a.groups.length > 0
+    (account) => account.supported && !account.error && account.groups && account.groups.length > 0
   );
   const errorAccounts = totalAccounts - healthy.length;
+  const modelFirst = healthy.length > 0 && healthy.every((account) => isModelFirstAccount(account));
+
+  if (modelFirst) {
+    return {
+      provider: accounts[0]?.provider ?? "unknown",
+      monitorMode: "model-first",
+      totalAccounts,
+      healthyAccounts: healthy.length,
+      errorAccounts,
+      windowCapacities: [],
+      modelFirstSummary: summarizeModelFirstProvider(accounts),
+    };
+  }
 
   const allWindowIds = new Set<string>();
-  for (const a of healthy) {
-    for (const g of a.groups ?? []) {
-      if (g.id !== "extra-usage") allWindowIds.add(g.id);
+  for (const account of healthy) {
+    for (const group of account.groups ?? []) {
+      if (group.id !== "extra-usage") allWindowIds.add(group.id);
     }
   }
 
   const windowCapacities: WindowCapacity[] = [];
 
   for (const windowId of allWindowIds) {
-    const relevantAccounts = healthy.filter((a) =>
-      a.groups?.some((g) => g.id === windowId)
+    const relevantAccounts = healthy.filter((account) =>
+      account.groups?.some((group) => group.id === windowId)
     );
     if (relevantAccounts.length === 0) continue;
 
-    const scores = relevantAccounts.map((a) => {
-      const group = a.groups?.find((g) => g.id === windowId);
-      return normalizeFraction(group?.remainingFraction);
-    }).filter((score): score is number => score !== null);
+    const scores = relevantAccounts
+      .map((account) => {
+        const group = account.groups?.find((candidate) => candidate.id === windowId);
+        return normalizeFraction(group?.remainingFraction);
+      })
+      .filter((score): score is number => score !== null);
 
     if (scores.length === 0) {
       continue;
     }
 
-    const exhaustedProduct = scores.reduce((prod, score) => prod * (1 - score), 1);
+    const exhaustedProduct = scores.reduce((product, score) => product * (1 - score), 1);
     const capacity = 1 - exhaustedProduct;
 
     let earliestReset: string | null = null;
@@ -131,18 +126,18 @@ function calcProviderSummary(accounts: QuotaAccount[]): ProviderSummary {
     let label = "";
     let isShortTerm = false;
 
-    for (const a of relevantAccounts) {
-      const g = a.groups?.find((g) => g.id === windowId);
-      if (g) {
+    for (const account of relevantAccounts) {
+      const group = account.groups?.find((candidate) => candidate.id === windowId);
+      if (group) {
         if (!label) {
-          label = g.label;
-          isShortTerm = isShortTermGroup(g);
+          label = group.label;
+          isShortTerm = isShortTermQuotaWindow(group, account.groups ?? []);
         }
-        if (g.resetTime) {
-          const t = new Date(g.resetTime).getTime();
-          if (t < minResetTime) {
-            minResetTime = t;
-            earliestReset = g.resetTime;
+        if (group.resetTime) {
+          const timestamp = new Date(group.resetTime).getTime();
+          if (timestamp < minResetTime) {
+            minResetTime = timestamp;
+            earliestReset = group.resetTime;
           }
         }
       }
@@ -157,13 +152,14 @@ function calcProviderSummary(accounts: QuotaAccount[]): ProviderSummary {
     });
   }
 
-  windowCapacities.sort((a, b) => {
-    if (a.isShortTerm !== b.isShortTerm) return a.isShortTerm ? 1 : -1;
-    return a.label.localeCompare(b.label);
+  windowCapacities.sort((left, right) => {
+    if (left.isShortTerm !== right.isShortTerm) return left.isShortTerm ? 1 : -1;
+    return left.label.localeCompare(right.label);
   });
 
   return {
     provider: accounts[0]?.provider ?? "unknown",
+    monitorMode: "window-based",
     totalAccounts,
     healthyAccounts: healthy.length,
     errorAccounts,
@@ -182,15 +178,29 @@ function calcOverallCapacity(summaries: ProviderSummary[]): { value: number; lab
       continue;
     }
 
-    const longTerm = summary.windowCapacities.filter((w) => !w.isShortTerm);
-    const shortTerm = summary.windowCapacities.filter((w) => w.isShortTerm);
+    if (summary.monitorMode === "model-first" && summary.modelFirstSummary) {
+      if (isModelFirstProviderQuotaUnverified(summary.modelFirstSummary)) {
+        continue;
+      }
+
+      const providerCapacity =
+        summary.modelFirstSummary.totalAccounts > 0
+          ? summary.modelFirstSummary.readyAccounts / summary.modelFirstSummary.totalAccounts
+          : 0;
+      weightedCapacity += providerCapacity * summary.healthyAccounts;
+      weightedAccounts += summary.healthyAccounts;
+      continue;
+    }
+
+    const longTerm = summary.windowCapacities.filter((window) => !window.isShortTerm);
+    const shortTerm = summary.windowCapacities.filter((window) => window.isShortTerm);
     const relevantWindows = longTerm.length > 0 ? longTerm : shortTerm;
 
     if (relevantWindows.length === 0) {
       continue;
     }
 
-    const providerCapacity = Math.min(...relevantWindows.map((w) => w.capacity));
+    const providerCapacity = Math.min(...relevantWindows.map((window) => window.capacity));
     weightedCapacity += providerCapacity * summary.healthyAccounts;
     weightedAccounts += summary.healthyAccounts;
   }
@@ -212,12 +222,13 @@ export default function QuotaPage() {
   const [selectedProvider, setSelectedProvider] = useState<ProviderType>(PROVIDERS.ALL);
   const [expandedCards, setExpandedCards] = useState<Record<string, boolean>>({});
 
-  const fetchQuota = async (signal?: AbortSignal) => {
+  const fetchQuota = async (signal?: AbortSignal, bust = false) => {
     setLoading(true);
     try {
-      const res = await fetch(API_ENDPOINTS.QUOTA.BASE, { signal });
-      if (res.ok) {
-        const data = await res.json();
+      const url = bust ? `${API_ENDPOINTS.QUOTA.BASE}?bust=${Date.now()}` : API_ENDPOINTS.QUOTA.BASE;
+      const response = await fetch(url, { signal });
+      if (response.ok) {
+        const data = (await response.json()) as QuotaResponse;
         setQuotaData(data);
       }
     } catch {
@@ -237,13 +248,14 @@ export default function QuotaPage() {
     };
   }, []);
 
-  const filteredAccounts = quotaData?.accounts.filter((account) => {
-    if (selectedProvider === PROVIDERS.ALL) return true;
-    if (selectedProvider === PROVIDERS.COPILOT) {
-      return account.provider === "github" || account.provider === "github-copilot";
-    }
-    return account.provider === selectedProvider;
-  }) || [];
+  const filteredAccounts =
+    quotaData?.accounts.filter((account) => {
+      if (selectedProvider === PROVIDERS.ALL) return true;
+      if (selectedProvider === PROVIDERS.COPILOT) {
+        return account.provider === "github" || account.provider === "github-copilot";
+      }
+      return account.provider === selectedProvider;
+    }) ?? [];
 
   const activeAccounts = filteredAccounts.filter((account) => account.supported && !account.error).length;
 
@@ -256,13 +268,27 @@ export default function QuotaPage() {
 
   const providerSummaries = Array.from(providerGroups.entries())
     .map(([, accounts]) => calcProviderSummary(accounts))
-    .sort((a, b) => b.healthyAccounts - a.healthyAccounts);
+    .sort((left, right) => right.healthyAccounts - left.healthyAccounts);
 
   const overallCapacity = calcOverallCapacity(providerSummaries);
+  const isModelFirstOnlyView =
+    filteredAccounts.length > 0 && filteredAccounts.every((account) => isModelFirstAccount(account));
+  const modelFirstSummary = isModelFirstOnlyView ? summarizeModelFirstProvider(filteredAccounts) : null;
+  const modelFirstQuotaUnverified = isModelFirstProviderQuotaUnverified(modelFirstSummary);
+  const modelFirstWarnings = providerSummaries
+    .filter((summary) => summary.monitorMode === "model-first" && summary.modelFirstSummary)
+    .map((summary) => ({
+      provider: summary.provider,
+      summary: summary.modelFirstSummary!,
+    }))
+    .filter(({ summary }) => isModelFirstProviderQuotaUnverified(summary));
 
-  const lowCapacityCount = providerSummaries.filter(
-    (s) => s.windowCapacities.some((w) => w.capacity < 0.2) && s.totalAccounts > 0
-  ).length;
+  const lowCapacityCount = providerSummaries.filter((summary) => {
+    if (summary.monitorMode === "model-first") {
+      return (summary.modelFirstSummary?.minRemainingFraction ?? 1) < 0.2 && summary.totalAccounts > 0;
+    }
+    return summary.windowCapacities.some((window) => window.capacity < 0.2) && summary.totalAccounts > 0;
+  }).length;
 
   const providerFilters = [
     { key: PROVIDERS.ALL, label: "All" },
@@ -274,8 +300,12 @@ export default function QuotaPage() {
   ] as const;
 
   const toggleCard = (accountId: string) => {
-    setExpandedCards((prev) => ({ ...prev, [accountId]: !prev[accountId] }));
+    setExpandedCards((previous) => ({ ...previous, [accountId]: !previous[accountId] }));
   };
+
+  const freshSnapshotCount = modelFirstSummary
+    ? Math.max(0, modelFirstSummary.totalAccounts - modelFirstSummary.staleAccounts)
+    : 0;
 
   return (
     <div className="space-y-4">
@@ -283,7 +313,11 @@ export default function QuotaPage() {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h1 className="text-xl font-semibold tracking-tight text-[var(--text-primary)]">Quota</h1>
-            <p className="mt-1 text-sm text-[var(--text-muted)]">Monitor OAuth account quotas and usage windows.</p>
+            <p className="mt-1 text-sm text-[var(--text-muted)]">
+              {isModelFirstOnlyView
+                ? "Model-first monitoring for Antigravity quota snapshots, grouped by model family."
+                : "Monitor OAuth account quotas and usage windows."}
+            </p>
           </div>
           <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
             <div className="flex flex-wrap gap-1">
@@ -295,7 +329,9 @@ export default function QuotaPage() {
                     setSelectedProvider(filter.key);
                     if (filter.key !== PROVIDERS.ALL) {
                       setTimeout(() => {
-                        document.getElementById("quota-accounts")?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+                        document
+                          .getElementById("quota-accounts")
+                          ?.scrollIntoView({ behavior: "smooth", block: "nearest" });
                       }, 50);
                     }
                   }}
@@ -305,7 +341,7 @@ export default function QuotaPage() {
                 </Button>
               ))}
             </div>
-            <Button onClick={fetchQuota} disabled={loading} className="px-2.5 py-1 text-xs">
+            <Button onClick={() => fetchQuota(undefined, true)} disabled={loading} className="px-2.5 py-1 text-xs">
               {loading ? "Loading..." : "Refresh"}
             </Button>
           </div>
@@ -318,32 +354,101 @@ export default function QuotaPage() {
         </div>
       ) : (
         <>
-          <section className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+          {modelFirstWarnings.length > 0 && (
+            <section className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-900">
+              {modelFirstWarnings.map(({ provider, summary }) => (
+                <p key={provider}>
+                  {provider.charAt(0).toUpperCase() + provider.slice(1)} snapshot API currently returns full quota for
+                  all {summary.totalAccounts} active accounts. Snapshot freshness is tracked, but current remaining quota
+                  is not fully verifiable from provider data alone.
+                </p>
+              ))}
+            </section>
+          )}
+
+          <section className={`grid grid-cols-2 gap-2 ${isModelFirstOnlyView ? "lg:grid-cols-5" : "lg:grid-cols-4"}`}>
             <div className="rounded-lg border border-[var(--surface-border)] bg-[var(--surface-base)] px-2.5 py-2">
               <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Active Accounts</p>
               <p className="mt-0.5 text-xs font-semibold text-[var(--text-primary)]">{activeAccounts}</p>
             </div>
-            <div className="rounded-lg border border-[var(--surface-border)] bg-[var(--surface-base)] px-2.5 py-2">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Overall Capacity <HelpTooltip content="Weighted average of remaining quota across all active provider accounts" /></p>
-              <p className="mt-0.5 text-xs font-semibold text-[var(--text-primary)]">{Math.round(overallCapacity.value * 100)}%</p>
-            </div>
-            <div className="rounded-lg border border-[var(--surface-border)] bg-[var(--surface-base)] px-2.5 py-2">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Low Capacity <HelpTooltip content="Number of accounts with remaining quota below 20%" /></p>
-              <p className="mt-0.5 text-xs font-semibold text-[var(--text-primary)]">{lowCapacityCount}</p>
-            </div>
-            <div className="rounded-lg border border-[var(--surface-border)] bg-[var(--surface-base)] px-2.5 py-2">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Providers</p>
-              <p className="mt-0.5 text-xs font-semibold text-[var(--text-primary)]">{providerSummaries.length}</p>
-            </div>
+            {isModelFirstOnlyView && modelFirstSummary ? (
+              <>
+                <div className="rounded-lg border border-[var(--surface-border)] bg-[var(--surface-base)] px-2.5 py-2">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                    {modelFirstQuotaUnverified ? "Fresh Snapshots" : "Ready Accounts"}{" "}
+                    <HelpTooltip
+                      content={
+                        modelFirstQuotaUnverified
+                          ? "Fresh Antigravity snapshots are available, but the provider currently reports full quota on every grouped family."
+                          : "Accounts with a fresh grouped snapshot and at least one ready model family."
+                      }
+                    />
+                  </p>
+                  <p className="mt-0.5 text-xs font-semibold text-[var(--text-primary)]">
+                    {modelFirstQuotaUnverified ? freshSnapshotCount : modelFirstSummary.readyAccounts}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-[var(--surface-border)] bg-[var(--surface-base)] px-2.5 py-2">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                    Stale Snapshots{" "}
+                    <HelpTooltip content="Accounts whose latest grouped model snapshot is older than the freshness threshold." />
+                  </p>
+                  <p className="mt-0.5 text-xs font-semibold text-[var(--text-primary)]">{modelFirstSummary.staleAccounts}</p>
+                </div>
+                <div className="rounded-lg border border-[var(--surface-border)] bg-[var(--surface-base)] px-2.5 py-2">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                    Closest Reset{" "}
+                    <HelpTooltip content="Earliest grouped model reset time visible in the latest Antigravity snapshot." />
+                  </p>
+                  <p className="mt-0.5 text-xs font-semibold text-[var(--text-primary)]">
+                    {formatRelativeTime(modelFirstSummary.nextWindowResetAt)}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-[var(--surface-border)] bg-[var(--surface-base)] px-2.5 py-2">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                    Model Families{" "}
+                    <HelpTooltip content="Grouped quota families inferred from Antigravity model IDs." />
+                  </p>
+                  <p className="mt-0.5 text-xs font-semibold text-[var(--text-primary)]">{modelFirstSummary.groups.length}</p>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="rounded-lg border border-[var(--surface-border)] bg-[var(--surface-base)] px-2.5 py-2">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                    Overall Capacity{" "}
+                    <HelpTooltip content="Weighted average of remaining quota across all active provider accounts." />
+                  </p>
+                  <p className="mt-0.5 text-xs font-semibold text-[var(--text-primary)]">{Math.round(overallCapacity.value * 100)}%</p>
+                </div>
+                <div className="rounded-lg border border-[var(--surface-border)] bg-[var(--surface-base)] px-2.5 py-2">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                    Low Capacity{" "}
+                    <HelpTooltip content="Number of providers or grouped snapshots with remaining quota below 20%." />
+                  </p>
+                  <p className="mt-0.5 text-xs font-semibold text-[var(--text-primary)]">{lowCapacityCount}</p>
+                </div>
+                <div className="rounded-lg border border-[var(--surface-border)] bg-[var(--surface-base)] px-2.5 py-2">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Providers</p>
+                  <p className="mt-0.5 text-xs font-semibold text-[var(--text-primary)]">{providerSummaries.length}</p>
+                </div>
+              </>
+            )}
           </section>
 
-          <QuotaChart overallCapacity={overallCapacity} providerSummaries={providerSummaries} />
+          <QuotaChart
+            overallCapacity={overallCapacity}
+            providerSummaries={providerSummaries}
+            modelFirstSummary={modelFirstSummary}
+            modelFirstOnlyView={isModelFirstOnlyView}
+          />
 
           <QuotaDetails
             filteredAccounts={filteredAccounts}
             expandedCards={expandedCards}
             onToggleCard={toggleCard}
             loading={loading}
+            modelFirstOnlyView={isModelFirstOnlyView}
           />
         </>
       )}

--- a/dashboard/src/components/quota/quota-chart.tsx
+++ b/dashboard/src/components/quota/quota-chart.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { RadialBarChart, RadialBar, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from "recharts";
-import { ChartContainer, ChartEmpty, CHART_COLORS, useChartTheme } from "@/components/ui/chart-theme";
+import { Bar, BarChart, Legend, RadialBar, RadialBarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+
+import { CHART_COLORS, ChartContainer, ChartEmpty, useChartTheme } from "@/components/ui/chart-theme";
+import { isModelFirstProviderQuotaUnverified, type ModelFirstProviderSummary } from "@/lib/model-first-monitoring";
 
 interface WindowCapacity {
   id: string;
@@ -13,20 +15,166 @@ interface WindowCapacity {
 
 interface ProviderSummary {
   provider: string;
+  monitorMode: "window-based" | "model-first";
   totalAccounts: number;
   healthyAccounts: number;
   errorAccounts: number;
   windowCapacities: WindowCapacity[];
+  modelFirstSummary?: ModelFirstProviderSummary;
 }
 
 interface QuotaChartProps {
   overallCapacity: { value: number; label: string; provider: string };
   providerSummaries: ProviderSummary[];
+  modelFirstSummary: ModelFirstProviderSummary | null;
+  modelFirstOnlyView: boolean;
 }
 
-export function QuotaChart({ overallCapacity, providerSummaries }: QuotaChartProps) {
-   const { axisTickStyle, tooltipStyle, tokens } = useChartTheme();
-   return (
+function formatRelativeTime(isoDate: string | null | undefined): string {
+  if (!isoDate) return "Unknown";
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  const diffMs = date.getTime() - Date.now();
+  if (diffMs <= 0) return "Resetting...";
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+export function QuotaChart({
+  overallCapacity,
+  providerSummaries,
+  modelFirstSummary,
+  modelFirstOnlyView,
+}: QuotaChartProps) {
+  const { axisTickStyle, tooltipStyle, tokens } = useChartTheme();
+  if (modelFirstOnlyView && modelFirstSummary) {
+    const quotaUnverified = isModelFirstProviderQuotaUnverified(modelFirstSummary);
+    const readyPct =
+      modelFirstSummary.totalAccounts > 0
+        ? Math.round((modelFirstSummary.readyAccounts / modelFirstSummary.totalAccounts) * 100)
+        : 0;
+    const gaugeColor = quotaUnverified
+      ? CHART_COLORS.text.dimmed
+      : readyPct > 60
+        ? CHART_COLORS.success
+        : readyPct > 20
+          ? CHART_COLORS.warning
+          : CHART_COLORS.danger;
+    const gaugeData = [{ value: quotaUnverified ? 100 : readyPct, fill: gaugeColor }];
+    const groupData = modelFirstSummary.groups.map((group) => ({
+      group: group.label,
+      minRemaining: group.minRemainingFraction === null ? null : Math.round(group.minRemainingFraction * 100),
+      p50Remaining: group.p50RemainingFraction === null ? null : Math.round(group.p50RemainingFraction * 100),
+      readyAccounts: group.readyAccounts,
+      totalAccounts: group.totalAccounts,
+      nextReset: group.nextWindowResetAt,
+      fullReset: group.fullWindowResetAt,
+      nextRecovery: group.nextRecoveryAt,
+      bottleneckModel: group.bottleneckModel,
+    }));
+
+    return (
+      <section className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <ChartContainer title="Effective Snapshot Readiness" subtitle="Fresh grouped Antigravity snapshots with at least one ready family">
+          {modelFirstSummary.totalAccounts === 0 ? (
+            <ChartEmpty message="No Antigravity snapshots" />
+          ) : (
+            <div className="relative flex h-48 items-center justify-center">
+              <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 320, height: 200 }}>
+                <RadialBarChart
+                  cx="50%"
+                  cy="60%"
+                  innerRadius="55%"
+                  outerRadius="80%"
+                  startAngle={210}
+                  endAngle={-30}
+                  data={[{ value: 100, fill: "rgba(148,163,184,0.1)" }, ...gaugeData]}
+                  barSize={14}
+                >
+                  <RadialBar dataKey="value" background={false} cornerRadius={4} />
+                </RadialBarChart>
+              </ResponsiveContainer>
+              <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+                <span className="text-3xl font-bold" style={{ color: gaugeColor }}>
+                  {quotaUnverified ? "N/A" : `${readyPct}%`}
+                </span>
+                <span className="mt-0.5 text-[10px] uppercase tracking-widest" style={{ color: CHART_COLORS.text.dimmed }}>
+                  {quotaUnverified ? "Snapshot" : "Ready"}
+                </span>
+                <span className="mt-2 text-[11px]" style={{ color: CHART_COLORS.text.dimmed }}>
+                  {quotaUnverified
+                    ? `${Math.max(0, modelFirstSummary.totalAccounts - modelFirstSummary.staleAccounts)}/${modelFirstSummary.totalAccounts} fresh snapshots`
+                    : `${modelFirstSummary.readyAccounts}/${modelFirstSummary.totalAccounts} accounts`}
+                </span>
+                <span className="mt-1 text-[10px]" style={{ color: CHART_COLORS.text.muted }}>
+                  Next reset: {formatRelativeTime(modelFirstSummary.nextWindowResetAt)}
+                </span>
+              </div>
+            </div>
+          )}
+        </ChartContainer>
+
+        <ChartContainer title="Grouped Snapshot" subtitle="Grouped family quota view with minimum and median remaining percentages">
+          {groupData.length === 0 ? (
+            <ChartEmpty message="No grouped model data" />
+          ) : (
+            <div className="h-48">
+              <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 320, height: 200 }}>
+                <BarChart data={groupData} layout="vertical" margin={{ top: 4, right: 12, bottom: 4, left: 4 }} barSize={8} barGap={2}>
+                  <XAxis
+                    type="number"
+                    domain={[0, 100]}
+                    tick={axisTickStyle}
+                    tickLine={false}
+                    axisLine={{ stroke: tokens.border }}
+                    tickFormatter={(value) => `${value}%`}
+                  />
+                  <YAxis
+                    type="category"
+                    dataKey="group"
+                    tick={{ ...axisTickStyle, fontSize: 10 }}
+                    tickLine={false}
+                    axisLine={false}
+                    width={96}
+                  />
+                  <Tooltip
+                    {...tooltipStyle}
+                    formatter={(value, name, props) => {
+                      if (value === null) return ["-", name];
+                      const label = name === "p50Remaining" ? "Median Remaining" : "Minimum Remaining";
+                      const extra = ` | ${props.payload.readyAccounts}/${props.payload.totalAccounts} ready`;
+                      return [`${value}%${extra}`, label];
+                    }}
+                    labelFormatter={(label, payload) => {
+                      const item = payload?.[0]?.payload as
+                        | { nextReset?: string | null; fullReset?: string | null; nextRecovery?: string | null; bottleneckModel?: string | null }
+                        | undefined;
+                      if (!item) return label;
+                      return `${label} | reset ${formatRelativeTime(item.nextReset)} | recovery ${formatRelativeTime(item.nextRecovery)} | bottleneck ${item.bottleneckModel ?? "-"}`;
+                    }}
+                  />
+                  <Legend
+                    verticalAlign="top"
+                    height={24}
+                    formatter={(value: string) => (value === "p50Remaining" ? "Median Remaining" : "Minimum Remaining")}
+                    wrapperStyle={{ fontSize: 10, color: tokens.text.dimmed }}
+                  />
+                  <Bar dataKey="p50Remaining" radius={[0, 3, 3, 0]} fill={CHART_COLORS.cyan} />
+                  <Bar dataKey="minRemaining" radius={[0, 3, 3, 0]} fill={CHART_COLORS.success} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </ChartContainer>
+      </section>
+    );
+  }
+
+  return (
     <section className="grid grid-cols-1 gap-3 lg:grid-cols-2">
       <ChartContainer title="Overall Capacity" subtitle="Weighted across all providers">
         {providerSummaries.length === 0 ? (
@@ -37,8 +185,8 @@ export function QuotaChart({ overallCapacity, providerSummaries }: QuotaChartPro
             overallCapacity.value > 0.6
               ? CHART_COLORS.success
               : overallCapacity.value > 0.2
-              ? CHART_COLORS.warning
-              : CHART_COLORS.danger;
+                ? CHART_COLORS.warning
+                : CHART_COLORS.danger;
           const gaugeData = [{ value: pct, fill: gaugeColor }];
           return (
             <div className="relative flex h-48 items-center justify-center">
@@ -57,71 +205,97 @@ export function QuotaChart({ overallCapacity, providerSummaries }: QuotaChartPro
                 </RadialBarChart>
               </ResponsiveContainer>
               <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
-                <span className="text-3xl font-bold" style={{ color: gaugeColor }}>{pct}%</span>
-                <span className="mt-0.5 text-[10px] uppercase tracking-widest" style={{ color: tokens.text.dimmed }}>Capacity</span>
+                <span className="text-3xl font-bold" style={{ color: gaugeColor }}>
+                  {pct}%
+                </span>
+                <span className="mt-0.5 text-[10px] uppercase tracking-widest" style={{ color: CHART_COLORS.text.dimmed }}>
+                  Capacity
+                </span>
               </div>
             </div>
           );
         })()}
       </ChartContainer>
 
-      <ChartContainer title="Provider Capacity" subtitle="Long-term & short-term window minimum per provider">
+      <ChartContainer title="Provider Capacity" subtitle="Window minimums or grouped snapshot minimums per provider">
         {providerSummaries.length === 0 ? (
           <ChartEmpty message="No provider data" />
         ) : (() => {
-          const barData = providerSummaries.map((s) => {
-            const longTerm = s.windowCapacities.filter((w) => !w.isShortTerm);
-            const shortTerm = s.windowCapacities.filter((w) => w.isShortTerm);
-            const longMin = longTerm.length > 0 ? Math.round(Math.min(...longTerm.map((w) => w.capacity)) * 100) : null;
-            const shortMin = shortTerm.length > 0 ? Math.round(Math.min(...shortTerm.map((w) => w.capacity)) * 100) : null;
+          const barData = providerSummaries.map((summary) => {
+            if (summary.monitorMode === "model-first" && summary.modelFirstSummary) {
+              return {
+                provider: summary.provider,
+                longTerm:
+                  summary.modelFirstSummary.minRemainingFraction === null
+                    ? null
+                    : Math.round(summary.modelFirstSummary.minRemainingFraction * 100),
+                shortTerm: null,
+                healthy: summary.healthyAccounts,
+                total: summary.totalAccounts,
+                issues: summary.errorAccounts,
+                monitorMode: summary.monitorMode,
+              };
+            }
+
+            const longTerm = summary.windowCapacities.filter((window) => !window.isShortTerm);
+            const shortTerm = summary.windowCapacities.filter((window) => window.isShortTerm);
+            const longMin =
+              longTerm.length > 0 ? Math.round(Math.min(...longTerm.map((window) => window.capacity)) * 100) : null;
+            const shortMin =
+              shortTerm.length > 0 ? Math.round(Math.min(...shortTerm.map((window) => window.capacity)) * 100) : null;
+
             return {
-              provider: s.provider,
+              provider: summary.provider,
               longTerm: longMin,
               shortTerm: shortMin,
-              healthy: s.healthyAccounts,
-              total: s.totalAccounts,
-              issues: s.errorAccounts,
+              healthy: summary.healthyAccounts,
+              total: summary.totalAccounts,
+              issues: summary.errorAccounts,
+              monitorMode: summary.monitorMode,
             };
           });
+
           return (
             <div className="h-48">
               <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0} initialDimension={{ width: 320, height: 200 }}>
-                <BarChart
-                  data={barData}
-                  layout="vertical"
-                  margin={{ top: 4, right: 12, bottom: 4, left: 4 }}
-                  barSize={8}
-                  barGap={2}
-                >
-                   <XAxis
-                     type="number"
-                     domain={[0, 100]}
-                     tick={axisTickStyle}
-                     tickLine={false}
-                     axisLine={{ stroke: tokens.border }}
-                     tickFormatter={(v) => `${v}%`}
-                   />
-                   <YAxis
-                     type="category"
-                     dataKey="provider"
-                     tick={{ ...axisTickStyle, fontSize: 10 }}
-                     tickLine={false}
-                     axisLine={false}
-                     width={72}
-                   />
-                   <Tooltip
-                     {...tooltipStyle}
-                     formatter={(value, name, props) => {
-                       if (value === null) return ["-", name];
-                       const label = name === "longTerm" ? "Long-Term" : "Short-Term";
-                       const extra = name === "longTerm" ? ` (${props.payload.healthy}/${props.payload.total} healthy${props.payload.issues > 0 ? `, ${props.payload.issues} issues` : ""})` : "";
-                       return [`${value}%${extra}`, label];
-                     }}
-                   />
+                <BarChart data={barData} layout="vertical" margin={{ top: 4, right: 12, bottom: 4, left: 4 }} barSize={8} barGap={2}>
+                  <XAxis
+                    type="number"
+                    domain={[0, 100]}
+                    tick={axisTickStyle}
+                    tickLine={false}
+                    axisLine={{ stroke: tokens.border }}
+                    tickFormatter={(value) => `${value}%`}
+                  />
+                  <YAxis
+                    type="category"
+                    dataKey="provider"
+                    tick={{ ...axisTickStyle, fontSize: 10 }}
+                    tickLine={false}
+                    axisLine={false}
+                    width={72}
+                  />
+                  <Tooltip
+                    {...tooltipStyle}
+                    formatter={(value, name, props) => {
+                      if (value === null) return ["-", name];
+
+                      if (props.payload.monitorMode === "model-first") {
+                        return [`${value}% (${props.payload.healthy}/${props.payload.total} healthy)`, "Grouped Snapshot Minimum"];
+                      }
+
+                      const label = name === "longTerm" ? "Long-Term" : "Short-Term";
+                      const extra =
+                        name === "longTerm"
+                          ? ` (${props.payload.healthy}/${props.payload.total} healthy${props.payload.issues > 0 ? `, ${props.payload.issues} issues` : ""})`
+                          : "";
+                      return [`${value}%${extra}`, label];
+                    }}
+                  />
                   <Legend
                     verticalAlign="top"
                     height={24}
-                    formatter={(value: string) => value === "longTerm" ? "Long-Term" : "Short-Term"}
+                    formatter={(value: string) => (value === "longTerm" ? "Primary Metric" : "Short-Term")}
                     wrapperStyle={{ fontSize: 10, color: tokens.text.dimmed }}
                   />
                   <Bar dataKey="longTerm" radius={[0, 3, 3, 0]} fill={CHART_COLORS.success} />

--- a/dashboard/src/components/quota/quota-details.tsx
+++ b/dashboard/src/components/quota/quota-details.tsx
@@ -1,40 +1,16 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-
-interface QuotaModel {
-  id: string;
-  displayName: string;
-  remainingFraction?: number | null;
-  resetTime: string | null;
-}
-
-interface QuotaGroup {
-  id: string;
-  label: string;
-  remainingFraction?: number | null;
-  resetTime: string | null;
-  models: QuotaModel[];
-}
-
-interface QuotaAccount {
-  auth_index: string;
-  provider: string;
-  email?: string | null;
-  supported: boolean;
-  error?: string;
-  groups?: QuotaGroup[];
-  raw?: unknown;
-}
-
-function normalizeFraction(value: unknown): number | null {
-  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
-    return null;
-  }
-  if (value < 0) return 0;
-  if (value > 1) return 1;
-  return value;
-}
+import { isShortTermQuotaWindow } from "@/lib/quota-window-classification";
+import {
+  enrichModelFirstGroup,
+  isModelFirstAccount,
+  isModelFirstAccountQuotaUnverified,
+  normalizeFraction,
+  summarizeModelFirstAccount,
+  type QuotaAccount,
+  type QuotaGroup,
+} from "@/lib/model-first-monitoring";
 
 function maskEmail(email: unknown): string {
   if (typeof email !== "string") return "unknown";
@@ -52,46 +28,22 @@ function maskEmail(email: unknown): string {
   return `${maskedLocal}@${domain}`;
 }
 
-function formatRelativeTime(isoDate: string | null): string {
+function formatRelativeTime(isoDate: string | null | undefined): string {
   if (!isoDate) return "Unknown";
 
-  try {
-    const resetDate = new Date(isoDate);
-    if (Number.isNaN(resetDate.getTime())) return "Unknown";
-    const now = new Date();
-    const diffMs = resetDate.getTime() - now.getTime();
+  const resetDate = new Date(isoDate);
+  if (Number.isNaN(resetDate.getTime())) return "Unknown";
+  const diffMs = resetDate.getTime() - Date.now();
 
-    if (diffMs <= 0) return "Resetting...";
+  if (diffMs <= 0) return "Resetting...";
 
-    const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-    const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-    const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
 
-    if (days > 0) {
-      return `Resets in ${days}d ${hours}h`;
-    }
-    if (hours > 0) {
-      return `Resets in ${hours}h ${minutes}m`;
-    }
-    return `Resets in ${minutes}m`;
-  } catch {
-    return "Unknown";
-  }
-}
-
-function isShortTermGroup(group: QuotaGroup): boolean {
-  const id = group.id.toLowerCase();
-  const label = group.label.toLowerCase();
-  return (
-    id.includes("five-hour") ||
-    id.includes("primary") ||
-    id.includes("request") ||
-    id.includes("token") ||
-    label.includes("5h") ||
-    label.includes("5m") ||
-    label.includes("request") ||
-    label.includes("token")
-  );
+  if (days > 0) return `Resets in ${days}d ${hours}h`;
+  if (hours > 0) return `Resets in ${hours}h ${minutes}m`;
+  return `Resets in ${minutes}m`;
 }
 
 function calcAccountWindowScores(groups: QuotaGroup[]): Record<string, { score: number; label: string; isShortTerm: boolean }> {
@@ -103,16 +55,16 @@ function calcAccountWindowScores(groups: QuotaGroup[]): Record<string, { score: 
     result[group.id] = {
       score,
       label: group.label,
-      isShortTerm: isShortTermGroup(group),
+      isShortTerm: isShortTermQuotaWindow(group, groups),
     };
   }
   return result;
 }
 
 function getCapacityBarClass(value: number): string {
-  if (value > 0.6) return "bg-emerald-500/100/80";
-  if (value > 0.2) return "bg-amber-500/100";
-  return "bg-rose-500/100/80";
+  if (value > 0.6) return "bg-emerald-500/80";
+  if (value > 0.2) return "bg-amber-500";
+  return "bg-rose-500/80";
 }
 
 interface QuotaDetailsProps {
@@ -120,102 +72,271 @@ interface QuotaDetailsProps {
   expandedCards: Record<string, boolean>;
   onToggleCard: (accountId: string) => void;
   loading: boolean;
+  modelFirstOnlyView: boolean;
 }
 
-export function QuotaDetails({ filteredAccounts, expandedCards, onToggleCard, loading }: QuotaDetailsProps) {
+export function QuotaDetails({
+  filteredAccounts,
+  expandedCards,
+  onToggleCard,
+  loading,
+  modelFirstOnlyView,
+}: QuotaDetailsProps) {
+  const sections = (() => {
+    if (filteredAccounts.length === 0) {
+      return [];
+    }
+
+    const hasModelFirstAccounts = filteredAccounts.some((account) => isModelFirstAccount(account));
+    const hasWindowAccounts = filteredAccounts.some((account) => !isModelFirstAccount(account));
+
+    if (!hasModelFirstAccounts || !hasWindowAccounts) {
+      return [
+        {
+          key: "all",
+          title: null as string | null,
+          accounts: filteredAccounts,
+          modelFirstView: modelFirstOnlyView || hasModelFirstAccounts,
+        },
+      ];
+    }
+
+    const buckets = new Map<string, { key: string; title: string; accounts: QuotaAccount[]; modelFirstView: boolean }>();
+    for (const account of filteredAccounts) {
+      const sectionModelFirstView = isModelFirstAccount(account);
+      const providerTitle =
+        account.provider === "github-copilot"
+          ? "Copilot"
+          : account.provider.charAt(0).toUpperCase() + account.provider.slice(1);
+      const key = `${sectionModelFirstView ? "model-first" : "window-based"}:${account.provider}`;
+      const bucket = buckets.get(key) ?? {
+        key,
+        title: providerTitle,
+        accounts: [],
+        modelFirstView: sectionModelFirstView,
+      };
+      bucket.accounts.push(account);
+      buckets.set(key, bucket);
+    }
+
+    return Array.from(buckets.values()).sort((left, right) => {
+      if (left.modelFirstView !== right.modelFirstView) {
+        return left.modelFirstView ? -1 : 1;
+      }
+      return left.title.localeCompare(right.title);
+    });
+  })();
+
   return (
     <section id="quota-accounts" className="scroll-mt-24 space-y-2">
       <h2 className="text-xs font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Accounts</h2>
-      <div className="overflow-x-auto rounded-md border border-[var(--surface-border)] bg-[var(--surface-base)]">
-        <div className="min-w-[650px]">
-        <div className="grid grid-cols-[24px_minmax(0,1fr)_120px_120px_140px_140px] border-b border-[var(--surface-border)] bg-[var(--surface-base)]/60 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
-          <span></span>
-          <span>Account</span>
-          <span>Provider</span>
-          <span>Status</span>
-          <span>Long-Term</span>
-          <span>Short-Term</span>
-        </div>
-
-        {filteredAccounts.map((account) => {
-          const isRowExpanded = expandedCards[account.auth_index];
-          const scores = account.groups ? Object.values(calcAccountWindowScores(account.groups)) : [];
-          const longScores = scores.filter((s) => !s.isShortTerm);
-          const shortScores = scores.filter((s) => s.isShortTerm);
-          const longMin = longScores.length > 0 ? Math.min(...longScores.map((s) => s.score)) : null;
-          const shortMin = shortScores.length > 0 ? Math.min(...shortScores.map((s) => s.score)) : null;
-          const statusLabel = account.supported ? (account.error ? "Error" : "Active") : "Unsupported";
-
-          return (
-            <div key={account.auth_index} className="border-b border-[var(--surface-border)] last:border-b-0">
-              <button
-                type="button"
-                onClick={() => onToggleCard(account.auth_index)}
-                 className="grid w-full grid-cols-[24px_minmax(0,1fr)_120px_120px_140px_140px] items-center px-3 py-2 text-left transition-colors hover:bg-[var(--surface-hover)]"
-               >
-                 <span className={cn("text-xs text-[var(--text-muted)] transition-transform", isRowExpanded && "rotate-180")}>⌄</span>
-                 <span className="truncate text-xs text-[var(--text-primary)]">{maskEmail(account.email)}</span>
-                 <span className="truncate text-xs capitalize text-[var(--text-secondary)]">{account.provider}</span>
-                <span className={cn("text-xs", account.error ? "text-rose-600" : account.supported ? "text-emerald-700" : "text-amber-700")}>{statusLabel}</span>
-                <span className="block pr-3">
-                  {longMin !== null ? (
-                    <>
-                      <span className="text-xs text-[var(--text-secondary)]">{Math.round(longMin * 100)}%</span>
-                      <span className="mt-1 block h-1.5 w-full overflow-hidden rounded-full bg-[var(--surface-muted)]">
-                        <span className={cn("block h-full", getCapacityBarClass(longMin))} style={{ width: `${Math.round(longMin * 100)}%` }} />
-                      </span>
-                    </>
-                  ) : (
-                    <span className="text-xs text-[var(--text-muted)]">-</span>
+      <div className="space-y-3">
+        {sections.map((section) => (
+          <div key={section.key} className="space-y-1">
+            {section.title && sections.length > 1 && (
+              <h3 className="px-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">{section.title}</h3>
+            )}
+            <div className="overflow-x-auto rounded-md border border-[var(--surface-border)] bg-[var(--surface-base)]">
+              <div className="min-w-[650px]">
+                <div
+                  className={cn(
+                    "border-b border-[var(--surface-border)] bg-[var(--surface-base)] px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]",
+                    section.modelFirstView
+                      ? "grid grid-cols-[24px_minmax(0,1fr)_110px_110px_120px_120px]"
+                      : "grid grid-cols-[24px_minmax(0,1fr)_120px_120px_140px_140px]"
                   )}
-                </span>
-                <span className="block pr-3">
-                  {shortMin !== null ? (
-                    <>
-                      <span className="text-xs text-[var(--text-secondary)]">{Math.round(shortMin * 100)}%</span>
-                      <span className="mt-1 block h-1.5 w-full overflow-hidden rounded-full bg-[var(--surface-muted)]">
-                        <span className={cn("block h-full", getCapacityBarClass(shortMin))} style={{ width: `${Math.round(shortMin * 100)}%` }} />
-                      </span>
-                    </>
-                  ) : (
-                    <span className="text-xs text-[var(--text-muted)]">-</span>
-                  )}
-                </span>
-               </button>
+                >
+                  <span></span>
+                  <span>Account</span>
+                  <span>Provider</span>
+                  <span>Status</span>
+                  <span>{section.modelFirstView ? "Ready" : "Long-Term"}</span>
+                  <span>{section.modelFirstView ? "Recovery" : "Short-Term"}</span>
+                </div>
 
-                {isRowExpanded && (
-                  <div className="border-t border-[var(--surface-border)] bg-[var(--surface-base)] px-4 py-3">
-                    {account.error && (
-                      <p className="mb-2 break-all text-xs text-rose-600">{account.error}</p>
-                    )}
-                    {!account.supported && !account.error && (
-                      <p className="mb-2 text-xs text-amber-700">Quota monitoring not available for this provider.</p>
-                    )}
+                {section.accounts.map((account) => {
+                  const isRowExpanded = expandedCards[account.auth_index];
+                  const scores = account.groups ? Object.values(calcAccountWindowScores(account.groups)) : [];
+                  const longScores = scores.filter((score) => !score.isShortTerm);
+                  const shortScores = scores.filter((score) => score.isShortTerm);
+                  const longMin = longScores.length > 0 ? Math.min(...longScores.map((score) => score.score)) : null;
+                  const shortMin = shortScores.length > 0 ? Math.min(...shortScores.map((score) => score.score)) : null;
+                  const statusLabel = account.supported ? (account.error ? "Error" : "Active") : "Unsupported";
+                  const accountSummary = isModelFirstAccount(account) ? summarizeModelFirstAccount(account) : null;
+                  const accountQuotaUnverified =
+                    isModelFirstAccount(account) && accountSummary
+                      ? isModelFirstAccountQuotaUnverified(account, accountSummary)
+                      : false;
+                  const modelFirstStatus = account.error
+                    ? "Error"
+                    : !account.supported
+                      ? "Unsupported"
+                      : accountSummary?.staleSnapshot
+                        ? "Stale"
+                        : accountQuotaUnverified
+                          ? "Snapshot"
+                          : "Ready";
 
-                    {account.groups && account.groups.length > 0 && (
-                      <div className="overflow-x-auto rounded-sm border border-[var(--surface-border)]">
-                        <div className="min-w-[400px]">
-                        {account.groups.map((group) => {
-                          const fraction = normalizeFraction(group.remainingFraction);
-                          const pct = fraction === null ? null : Math.round(fraction * 100);
-                          return (
-                            <div key={group.id} className="grid grid-cols-[minmax(0,1fr)_80px_160px] items-center border-b border-[var(--surface-border)] bg-[var(--surface-base)] px-3 py-2 last:border-b-0">
-                              <span className="truncate text-xs text-[var(--text-primary)]">{group.label}</span>
-                              <span className="text-xs text-[var(--text-secondary)]">{pct === null ? "-" : `${pct}%`}</span>
-                              <span className="truncate text-xs text-[var(--text-muted)]">{formatRelativeTime(group.resetTime)}</span>
+                  return (
+                    <div key={account.auth_index} className="border-b border-[var(--surface-border)] last:border-b-0">
+                      <button
+                        type="button"
+                        onClick={() => onToggleCard(account.auth_index)}
+                        className={cn(
+                          "w-full items-center px-3 py-2 text-left transition-colors hover:bg-[var(--surface-hover)]",
+                          section.modelFirstView
+                            ? "grid grid-cols-[24px_minmax(0,1fr)_110px_110px_120px_120px]"
+                            : "grid grid-cols-[24px_minmax(0,1fr)_120px_120px_140px_140px]"
+                        )}
+                      >
+                        <span className={cn("text-xs text-[var(--text-muted)] transition-transform", isRowExpanded && "rotate-180")}>v</span>
+                        <span className="truncate text-xs text-[var(--text-primary)]">{maskEmail(account.email)}</span>
+                        <span className="truncate text-xs capitalize text-[var(--text-secondary)]">{account.provider}</span>
+                        <span
+                          className={cn(
+                            "text-xs",
+                            section.modelFirstView
+                              ? account.error
+                                ? "text-rose-600"
+                                : accountSummary?.staleSnapshot || accountQuotaUnverified
+                                  ? "text-amber-700"
+                                  : account.supported
+                                    ? "text-emerald-700"
+                                    : "text-amber-700"
+                              : account.error
+                                ? "text-rose-600"
+                                : account.supported
+                                  ? "text-emerald-700"
+                                  : "text-amber-700"
+                          )}
+                        >
+                          {section.modelFirstView ? modelFirstStatus : statusLabel}
+                        </span>
+                        {section.modelFirstView ? (
+                          <>
+                            <span className="text-xs text-[var(--text-secondary)]">
+                              {accountSummary
+                                ? accountQuotaUnverified
+                                  ? "snapshot full"
+                                  : `${accountSummary.readyGroups}/${accountSummary.totalGroups}`
+                                : "-"}
+                            </span>
+                            <span className="text-xs text-[var(--text-muted)]">
+                              {accountSummary ? formatRelativeTime(accountSummary.nextRecoveryAt ?? accountSummary.nextWindowResetAt) : "-"}
+                            </span>
+                          </>
+                        ) : (
+                          <>
+                            <span className="block pr-3">
+                              {longMin !== null ? (
+                                <>
+                                  <span className="text-xs text-[var(--text-secondary)]">{Math.round(longMin * 100)}%</span>
+                                  <span className="mt-1 block h-1.5 w-full overflow-hidden rounded-full bg-[var(--surface-muted)]">
+                                    <span className={cn("block h-full", getCapacityBarClass(longMin))} style={{ width: `${Math.round(longMin * 100)}%` }} />
+                                  </span>
+                                </>
+                              ) : (
+                                <span className="text-xs text-[var(--text-muted)]">-</span>
+                              )}
+                            </span>
+                            <span className="block pr-3">
+                              {shortMin !== null ? (
+                                <>
+                                  <span className="text-xs text-[var(--text-secondary)]">{Math.round(shortMin * 100)}%</span>
+                                  <span className="mt-1 block h-1.5 w-full overflow-hidden rounded-full bg-[var(--surface-muted)]">
+                                    <span className={cn("block h-full", getCapacityBarClass(shortMin))} style={{ width: `${Math.round(shortMin * 100)}%` }} />
+                                  </span>
+                                </>
+                              ) : (
+                                <span className="text-xs text-[var(--text-muted)]">-</span>
+                              )}
+                            </span>
+                          </>
+                        )}
+                      </button>
+
+                      {isRowExpanded && (
+                        <div className="border-t border-[var(--surface-border)] bg-[var(--surface-base)] px-4 py-3">
+                          {account.error && <p className="mb-2 break-all text-xs text-rose-600">{account.error}</p>}
+                          {!account.supported && !account.error && (
+                            <p className="mb-2 text-xs text-amber-700">Quota monitoring not available for this provider.</p>
+                          )}
+                          {section.modelFirstView && accountSummary && (
+                            <div className="mb-2 flex flex-wrap gap-3 text-[11px] text-[var(--text-muted)]">
+                              <span>Snapshot: {accountSummary.staleSnapshot ? "stale" : "fresh"}</span>
+                              <span>Confidence: {accountQuotaUnverified ? "snapshot only" : "grouped ready"}</span>
+                              <span>Ready groups: {accountSummary.readyGroups}</span>
                             </div>
-                          );
-                        })}
+                          )}
+
+                          {account.groups && account.groups.length > 0 && (
+                            <div className="overflow-x-auto rounded-sm border border-[var(--surface-border)]">
+                              {section.modelFirstView ? (
+                                <div className="min-w-[900px]">
+                                  <div className="grid grid-cols-[minmax(0,1fr)_90px_110px_140px_140px_140px_160px] border-b border-[var(--surface-border)] bg-[var(--surface-base)] px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                                    <span>Group</span>
+                                    <span>Ready</span>
+                                    <span>Min / P50</span>
+                                    <span>Next Reset</span>
+                                    <span>Full Reset</span>
+                                    <span>Recovery</span>
+                                    <span>Bottleneck</span>
+                                  </div>
+                                  {account.groups.map((group) => {
+                                    const enrichedGroup = group.monitorMode === "model-first" ? group : enrichModelFirstGroup(group);
+                                    const minPct = normalizeFraction(enrichedGroup.minRemainingFraction ?? enrichedGroup.remainingFraction);
+                                    const p50Pct = normalizeFraction(enrichedGroup.p50RemainingFraction);
+                                    return (
+                                      <div
+                                        key={group.id}
+                                        className="grid grid-cols-[minmax(0,1fr)_90px_110px_140px_140px_140px_160px] items-center border-b border-[var(--surface-border)] bg-[var(--surface-base)] px-3 py-2 last:border-b-0"
+                                      >
+                                        <span className="truncate text-xs text-[var(--text-primary)]">{enrichedGroup.label}</span>
+                                        <span className="text-xs text-[var(--text-secondary)]">
+                                          {`${enrichedGroup.effectiveReadyModelCount ?? enrichedGroup.readyModelCount ?? 0}/${enrichedGroup.totalModelCount ?? enrichedGroup.models.length}`}
+                                        </span>
+                                        <span className="text-xs text-[var(--text-secondary)]">
+                                          {minPct === null ? "-" : `${Math.round(minPct * 100)}%`}
+                                          {p50Pct === null ? "" : ` / ${Math.round(p50Pct * 100)}%`}
+                                        </span>
+                                        <span className="text-xs text-[var(--text-muted)]">{formatRelativeTime(enrichedGroup.nextWindowResetAt ?? enrichedGroup.resetTime)}</span>
+                                        <span className="text-xs text-[var(--text-muted)]">{formatRelativeTime(enrichedGroup.fullWindowResetAt ?? enrichedGroup.resetTime)}</span>
+                                        <span className="text-xs text-[var(--text-muted)]">{formatRelativeTime(enrichedGroup.nextRecoveryAt)}</span>
+                                        <span className="truncate text-xs text-[var(--text-muted)]">{enrichedGroup.bottleneckModel ?? "-"}</span>
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+                              ) : (
+                                <div className="min-w-[400px]">
+                                  {account.groups.map((group) => {
+                                    const fraction = normalizeFraction(group.remainingFraction);
+                                    const pct = fraction === null ? null : Math.round(fraction * 100);
+                                    return (
+                                      <div
+                                        key={group.id}
+                                        className="grid grid-cols-[minmax(0,1fr)_80px_160px] items-center border-b border-[var(--surface-border)] bg-[var(--surface-base)] px-3 py-2 last:border-b-0"
+                                      >
+                                        <span className="truncate text-xs text-[var(--text-primary)]">{group.label}</span>
+                                        <span className="text-xs text-[var(--text-secondary)]">{pct === null ? "-" : `${pct}%`}</span>
+                                        <span className="truncate text-xs text-[var(--text-muted)]">{formatRelativeTime(group.resetTime)}</span>
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+                              )}
+                            </div>
+                          )}
                         </div>
-                      </div>
-                    )}
-                  </div>
-                )}
-             </div>
-           );
-          })}
-        </div>
-        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
 
       {filteredAccounts.length === 0 && !loading && (
         <div className="rounded-md border border-[var(--surface-border)] bg-[var(--surface-base)] p-6 text-center text-sm text-[var(--text-muted)]">

--- a/dashboard/src/lib/__tests__/model-first-monitoring.test.ts
+++ b/dashboard/src/lib/__tests__/model-first-monitoring.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  enrichModelFirstGroup,
+  isModelFirstAccountQuotaUnverified,
+  isModelFirstProviderQuotaUnverified,
+  summarizeModelFirstProvider,
+  type QuotaAccount,
+  type QuotaGroup,
+} from "../model-first-monitoring";
+
+describe("model-first monitoring helpers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-06T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("enriches grouped model data with min/p50 and reset metrics", () => {
+    const group: QuotaGroup = {
+      id: "gemini-3-pro",
+      label: "Gemini 3 Pro",
+      remainingFraction: 1,
+      resetTime: null,
+      models: [
+        {
+          id: "gemini-3-pro-high",
+          displayName: "Gemini 3 Pro High",
+          remainingFraction: 1,
+          resetTime: "2026-04-07T00:00:00Z",
+        },
+        {
+          id: "gemini-3-pro-low",
+          displayName: "Gemini 3 Pro Low",
+          remainingFraction: 0.5,
+          resetTime: "2026-04-06T20:00:00Z",
+        },
+        {
+          id: "gemini-3.1-pro-high",
+          displayName: "Gemini 3.1 Pro High",
+          remainingFraction: 0,
+          resetTime: "2026-04-08T00:00:00Z",
+        },
+      ],
+    };
+
+    const enriched = enrichModelFirstGroup(group);
+
+    expect(enriched.monitorMode).toBe("model-first");
+    expect(enriched.readyModelCount).toBe(2);
+    expect(enriched.depletedModelCount).toBe(1);
+    expect(enriched.totalModelCount).toBe(3);
+    expect(enriched.minRemainingFraction).toBe(0);
+    expect(enriched.p50RemainingFraction).toBe(0.5);
+    expect(enriched.nextWindowResetAt).toBe("2026-04-06T20:00:00.000Z");
+    expect(enriched.fullWindowResetAt).toBe("2026-04-08T00:00:00.000Z");
+    expect(enriched.nextRecoveryAt).toBe("2026-04-08T00:00:00.000Z");
+    expect(enriched.bottleneckModel).toBe("Gemini 3.1 Pro High");
+  });
+
+  it("summarizes provider readiness and stale snapshots from model-first accounts", () => {
+    const accounts: QuotaAccount[] = [
+      {
+        auth_index: "1",
+        provider: "antigravity",
+        supported: true,
+        monitorMode: "model-first",
+        snapshotFetchedAt: "2026-04-06T11:59:00.000Z",
+        groups: [
+          enrichModelFirstGroup({
+            id: "claude-gpt",
+            label: "Claude/GPT",
+            remainingFraction: 1,
+            resetTime: null,
+            models: [
+              {
+                id: "claude-sonnet-4-6",
+                displayName: "Claude Sonnet 4.6",
+                remainingFraction: 1,
+                resetTime: "2026-04-07T00:00:00Z",
+              },
+            ],
+          }),
+        ],
+      },
+      {
+        auth_index: "2",
+        provider: "antigravity",
+        supported: true,
+        monitorMode: "model-first",
+        snapshotFetchedAt: "2026-04-05T00:00:00.000Z",
+        groups: [
+          enrichModelFirstGroup({
+            id: "gemini-2-5-flash",
+            label: "Gemini 2.5 Flash",
+            remainingFraction: 0,
+            resetTime: null,
+            models: [
+              {
+                id: "gemini-2.5-flash",
+                displayName: "Gemini 2.5 Flash",
+                remainingFraction: 0,
+                resetTime: "2026-04-06T08:00:00Z",
+              },
+            ],
+          }),
+        ],
+      },
+    ];
+
+    const summary = summarizeModelFirstProvider(accounts);
+
+    expect(summary.totalAccounts).toBe(2);
+    expect(summary.readyAccounts).toBe(1);
+    expect(summary.staleAccounts).toBe(1);
+    expect(summary.groups).toHaveLength(2);
+    expect(summary.groups[0]?.label).toBe("Claude/GPT");
+    expect(summary.groups[1]?.label).toBe("Gemini 2.5 Flash");
+  });
+
+  it("falls back to model id when displayName is missing", () => {
+    const group: QuotaGroup = {
+      id: "gemini-2-5-flash",
+      label: "Gemini 2.5 Flash",
+      remainingFraction: 1,
+      resetTime: null,
+      models: [
+        {
+          id: "gemini-2.5-flash",
+          displayName: "",
+          remainingFraction: 0,
+          resetTime: "2026-04-06T18:00:00Z",
+        },
+      ],
+    };
+
+    const enriched = enrichModelFirstGroup(group);
+
+    expect(enriched.bottleneckModel).toBe("gemini-2.5-flash");
+  });
+
+  it("marks fully saturated snapshot-only accounts as unverified", () => {
+    const account: QuotaAccount = {
+      auth_index: "1",
+      provider: "antigravity",
+      supported: true,
+      monitorMode: "model-first",
+      snapshotFetchedAt: "2026-04-06T11:59:00.000Z",
+      groups: [
+        enrichModelFirstGroup({
+          id: "claude-gpt",
+          label: "Claude/GPT",
+          remainingFraction: 1,
+          resetTime: null,
+          models: [
+            {
+              id: "claude-sonnet-4-6",
+              displayName: "Claude Sonnet 4.6",
+              remainingFraction: 1,
+              resetTime: "2026-04-07T00:00:00Z",
+            },
+          ],
+        }),
+      ],
+    };
+
+    expect(isModelFirstAccountQuotaUnverified(account)).toBe(true);
+  });
+
+  it("marks fully saturated provider summaries as unverified", () => {
+    const accounts: QuotaAccount[] = [
+      {
+        auth_index: "1",
+        provider: "antigravity",
+        supported: true,
+        monitorMode: "model-first",
+        snapshotFetchedAt: "2026-04-06T11:59:00.000Z",
+        groups: [
+          enrichModelFirstGroup({
+            id: "claude-gpt",
+            label: "Claude/GPT",
+            remainingFraction: 1,
+            resetTime: null,
+            models: [
+              {
+                id: "claude-sonnet-4-6",
+                displayName: "Claude Sonnet 4.6",
+                remainingFraction: 1,
+                resetTime: "2026-04-07T00:00:00Z",
+              },
+            ],
+          }),
+        ],
+      },
+    ];
+
+    const summary = summarizeModelFirstProvider(accounts);
+    expect(isModelFirstProviderQuotaUnverified(summary)).toBe(true);
+  });
+});

--- a/dashboard/src/lib/__tests__/quota-window-classification.test.ts
+++ b/dashboard/src/lib/__tests__/quota-window-classification.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { isShortTermQuotaWindow } from "../quota-window-classification";
+
+describe("isShortTermQuotaWindow", () => {
+  it("keeps explicit short-term markers classified as short-term", () => {
+    expect(
+      isShortTermQuotaWindow({
+        id: "five-hour",
+        label: "5h Session",
+        resetTime: "2026-04-06T06:00:00.000Z",
+      })
+    ).toBe(true);
+  });
+
+  it("classifies the earlier Antigravity reset cluster as short-term", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-05T20:54:00.000Z"));
+
+    const groups = [
+      {
+        id: "other",
+        label: "Other",
+        resetTime: "2026-04-06T01:53:55.000Z",
+      },
+      {
+        id: "gemini-2-5-flash",
+        label: "Gemini 2.5 Flash",
+        resetTime: "2026-04-06T01:53:55.000Z",
+      },
+      {
+        id: "gemini-3-pro",
+        label: "Gemini 3 Pro",
+        resetTime: "2026-04-12T20:53:55.000Z",
+      },
+    ] as const;
+
+    expect(isShortTermQuotaWindow(groups[0], groups)).toBe(true);
+    expect(isShortTermQuotaWindow(groups[1], groups)).toBe(true);
+    expect(isShortTermQuotaWindow(groups[2], groups)).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it("treats windows without markers or reset time as long-term", () => {
+    expect(
+      isShortTermQuotaWindow({
+        id: "gemini-3-pro",
+        label: "Gemini 3 Pro",
+        resetTime: null,
+      })
+    ).toBe(false);
+  });
+});

--- a/dashboard/src/lib/model-first-monitoring.ts
+++ b/dashboard/src/lib/model-first-monitoring.ts
@@ -1,0 +1,352 @@
+export const ANTIGRAVITY_QUOTA_ENDPOINTS = [
+  "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
+  "https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+  "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+] as const;
+
+export const MODEL_FIRST_SNAPSHOT_STALE_MS = 180_000;
+
+export type QuotaMonitorMode = "window-based" | "model-first";
+
+export interface QuotaModel {
+  id: string;
+  displayName: string;
+  remainingFraction?: number | null;
+  resetTime: string | null;
+}
+
+export interface QuotaGroup {
+  id: string;
+  label: string;
+  remainingFraction?: number | null;
+  resetTime: string | null;
+  models: QuotaModel[];
+  monitorMode?: QuotaMonitorMode;
+  readyModelCount?: number;
+  depletedModelCount?: number;
+  totalModelCount?: number;
+  effectiveReadyModelCount?: number;
+  minRemainingFraction?: number | null;
+  p50RemainingFraction?: number | null;
+  nextWindowResetAt?: string | null;
+  fullWindowResetAt?: string | null;
+  nextRecoveryAt?: string | null;
+  fullRecoveryAt?: string | null;
+  bottleneckModel?: string | null;
+  hasMixedResetTimes?: boolean;
+}
+
+export interface QuotaAccount {
+  auth_index: string;
+  provider: string;
+  email?: string | null;
+  supported: boolean;
+  error?: string;
+  groups?: QuotaGroup[];
+  raw?: unknown;
+  monitorMode?: QuotaMonitorMode;
+  snapshotFetchedAt?: string | null;
+  snapshotSource?: string | null;
+  snapshotStale?: boolean;
+}
+
+export interface QuotaResponse {
+  accounts: QuotaAccount[];
+  generatedAt?: string;
+}
+
+export interface ModelFirstGroupSummary {
+  id: string;
+  label: string;
+  totalAccounts: number;
+  readyAccounts: number;
+  staleAccounts: number;
+  minRemainingFraction: number | null;
+  p50RemainingFraction: number | null;
+  nextWindowResetAt: string | null;
+  fullWindowResetAt: string | null;
+  nextRecoveryAt: string | null;
+  fullRecoveryAt: string | null;
+  bottleneckModel: string | null;
+}
+
+export interface ModelFirstAccountSummary {
+  totalGroups: number;
+  readyGroups: number;
+  staleSnapshot: boolean;
+  minRemainingFraction: number | null;
+  p50RemainingFraction: number | null;
+  nextWindowResetAt: string | null;
+  fullWindowResetAt: string | null;
+  nextRecoveryAt: string | null;
+}
+
+export interface ModelFirstProviderSummary {
+  totalAccounts: number;
+  readyAccounts: number;
+  staleAccounts: number;
+  minRemainingFraction: number | null;
+  p50RemainingFraction: number | null;
+  nextWindowResetAt: string | null;
+  fullWindowResetAt: string | null;
+  nextRecoveryAt: string | null;
+  groups: ModelFirstGroupSummary[];
+}
+
+function isFullFraction(value: number | null | undefined): boolean {
+  return normalizeFraction(value) === 1;
+}
+
+export function normalizeFraction(value: unknown): number | null {
+  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
+    return null;
+  }
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+export function isModelFirstProvider(provider: string | undefined | null): boolean {
+  if (typeof provider !== "string") return false;
+  const normalized = provider.trim().toLowerCase();
+  return normalized === "antigravity" || normalized === "gemini-cli" || normalized === "gemini";
+}
+
+export function isModelFirstAccount(account: Pick<QuotaAccount, "provider" | "monitorMode">): boolean {
+  return account.monitorMode === "model-first" || isModelFirstProvider(account.provider);
+}
+
+export function isStaleSnapshot(
+  snapshotFetchedAt: string | null | undefined,
+  nowMs = Date.now(),
+  staleAfterMs = MODEL_FIRST_SNAPSHOT_STALE_MS
+): boolean {
+  if (!snapshotFetchedAt) return true;
+  const fetchedAtMs = Date.parse(snapshotFetchedAt);
+  if (!Number.isFinite(fetchedAtMs)) return true;
+  return nowMs - fetchedAtMs > staleAfterMs;
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid] ?? null;
+}
+
+function parseReset(resetTime: string | null | undefined): number | null {
+  if (!resetTime) return null;
+  const parsed = Date.parse(resetTime);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function pickIso(timestamps: number[], pick: "min" | "max"): string | null {
+  if (timestamps.length === 0) return null;
+  const value = pick === "min" ? Math.min(...timestamps) : Math.max(...timestamps);
+  return new Date(value).toISOString();
+}
+
+function getModelDisplayName(model: QuotaModel): string {
+  return model.displayName?.trim() || model.id;
+}
+
+export function enrichModelFirstGroup(group: QuotaGroup): QuotaGroup {
+  const modelFractions = group.models
+    .map((model) => normalizeFraction(model.remainingFraction))
+    .filter((value): value is number => value !== null);
+  const readyModelCount = modelFractions.filter((value) => value > 0).length;
+  const depletedModelCount = modelFractions.filter((value) => value <= 0).length;
+  const allResetTimes = group.models
+    .map((model) => parseReset(model.resetTime))
+    .filter((value): value is number => value !== null);
+  const depletedResetTimes = group.models
+    .filter((model) => {
+      const remaining = normalizeFraction(model.remainingFraction);
+      return remaining !== null && remaining <= 0;
+    })
+    .map((model) => parseReset(model.resetTime))
+    .filter((value): value is number => value !== null);
+
+  const minRemainingFraction = modelFractions.length > 0 ? Math.min(...modelFractions) : null;
+  const p50RemainingFraction = median(modelFractions);
+  const nextWindowResetAt = pickIso(allResetTimes, "min");
+  const fullWindowResetAt = pickIso(allResetTimes, "max");
+  const nextRecoveryAt = pickIso(depletedResetTimes, "min");
+  const fullRecoveryAt = pickIso(depletedResetTimes, "max");
+
+  const bottleneck = [...group.models]
+    .sort((left, right) => {
+      const remainingLeft = normalizeFraction(left.remainingFraction) ?? Number.POSITIVE_INFINITY;
+      const remainingRight = normalizeFraction(right.remainingFraction) ?? Number.POSITIVE_INFINITY;
+      if (remainingLeft !== remainingRight) return remainingLeft - remainingRight;
+
+      const resetLeft = parseReset(left.resetTime) ?? Number.POSITIVE_INFINITY;
+      const resetRight = parseReset(right.resetTime) ?? Number.POSITIVE_INFINITY;
+      if (resetLeft !== resetRight) return resetLeft - resetRight;
+
+      return getModelDisplayName(left).localeCompare(getModelDisplayName(right));
+    })
+    .at(0);
+
+  const hasMixedResetTimes =
+    allResetTimes.length > 1 && Math.max(...allResetTimes) - Math.min(...allResetTimes) >= 30 * 60 * 1000;
+
+  return {
+    ...group,
+    monitorMode: "model-first",
+    remainingFraction: minRemainingFraction,
+    resetTime: nextWindowResetAt,
+    readyModelCount,
+    depletedModelCount,
+    totalModelCount: group.models.length,
+    effectiveReadyModelCount: readyModelCount,
+    minRemainingFraction,
+    p50RemainingFraction,
+    nextWindowResetAt,
+    fullWindowResetAt,
+    nextRecoveryAt,
+    fullRecoveryAt,
+    bottleneckModel: bottleneck ? getModelDisplayName(bottleneck) : null,
+    hasMixedResetTimes,
+  };
+}
+
+export function summarizeModelFirstAccount(account: QuotaAccount): ModelFirstAccountSummary {
+  const groups = (account.groups ?? []).map((group) =>
+    group.monitorMode === "model-first" ? group : enrichModelFirstGroup(group)
+  );
+  const minFractions = groups
+    .map((group) => normalizeFraction(group.minRemainingFraction ?? group.remainingFraction))
+    .filter((value): value is number => value !== null);
+  const p50Fractions = groups
+    .map((group) => normalizeFraction(group.p50RemainingFraction ?? group.remainingFraction))
+    .filter((value): value is number => value !== null);
+  const nextWindowResetTimes = groups
+    .map((group) => parseReset(group.nextWindowResetAt ?? group.resetTime))
+    .filter((value): value is number => value !== null);
+  const fullWindowResetTimes = groups
+    .map((group) => parseReset(group.fullWindowResetAt ?? group.resetTime))
+    .filter((value): value is number => value !== null);
+  const nextRecoveryTimes = groups
+    .map((group) => parseReset(group.nextRecoveryAt))
+    .filter((value): value is number => value !== null);
+
+  return {
+    totalGroups: groups.length,
+    readyGroups: groups.filter((group) => (group.effectiveReadyModelCount ?? group.readyModelCount ?? 0) > 0).length,
+    staleSnapshot: isStaleSnapshot(account.snapshotFetchedAt, Date.now()),
+    minRemainingFraction: minFractions.length > 0 ? Math.min(...minFractions) : null,
+    p50RemainingFraction: median(p50Fractions),
+    nextWindowResetAt: pickIso(nextWindowResetTimes, "min"),
+    fullWindowResetAt: pickIso(fullWindowResetTimes, "max"),
+    nextRecoveryAt: pickIso(nextRecoveryTimes, "min"),
+  };
+}
+
+export function isModelFirstAccountQuotaUnverified(
+  account: QuotaAccount,
+  summary = summarizeModelFirstAccount(account)
+): boolean {
+  if (!isModelFirstAccount(account) || summary.staleSnapshot) {
+    return false;
+  }
+
+  return isFullFraction(summary.minRemainingFraction) && isFullFraction(summary.p50RemainingFraction);
+}
+
+export function summarizeModelFirstProvider(accounts: QuotaAccount[]): ModelFirstProviderSummary {
+  const modelFirstAccounts = accounts.filter((account) => isModelFirstAccount(account));
+  const groupMap = new Map<string, Array<{ account: QuotaAccount; group: QuotaGroup }>>();
+
+  for (const account of modelFirstAccounts) {
+    for (const group of account.groups ?? []) {
+      const enriched = group.monitorMode === "model-first" ? group : enrichModelFirstGroup(group);
+      const bucket = groupMap.get(enriched.id) ?? [];
+      bucket.push({ account, group: enriched });
+      groupMap.set(enriched.id, bucket);
+    }
+  }
+
+  const groupSummaries = Array.from(groupMap.values()).map((entries) => {
+    const [firstEntry] = entries;
+    const fractions = entries.flatMap(({ group }) =>
+      group.models
+        .map((model) => normalizeFraction(model.remainingFraction))
+        .filter((value): value is number => value !== null)
+    );
+    const resets = entries.flatMap(({ group }) =>
+      group.models
+        .map((model) => parseReset(model.resetTime))
+        .filter((value): value is number => value !== null)
+    );
+    const depletedResets = entries.flatMap(({ group }) =>
+      group.models
+        .filter((model) => {
+          const remaining = normalizeFraction(model.remainingFraction);
+          return remaining !== null && remaining <= 0;
+        })
+        .map((model) => parseReset(model.resetTime))
+        .filter((value): value is number => value !== null)
+    );
+
+    return {
+      id: firstEntry?.group.id ?? "unknown",
+      label: firstEntry?.group.label ?? "Unknown",
+      totalAccounts: entries.length,
+      readyAccounts: entries.filter(({ group }) => (group.effectiveReadyModelCount ?? group.readyModelCount ?? 0) > 0).length,
+      staleAccounts: entries.filter(({ account }) => isStaleSnapshot(account.snapshotFetchedAt, Date.now())).length,
+      minRemainingFraction: fractions.length > 0 ? Math.min(...fractions) : null,
+      p50RemainingFraction: median(fractions),
+      nextWindowResetAt: pickIso(resets, "min"),
+      fullWindowResetAt: pickIso(resets, "max"),
+      nextRecoveryAt: pickIso(depletedResets, "min"),
+      fullRecoveryAt: pickIso(depletedResets, "max"),
+      bottleneckModel: firstEntry?.group.bottleneckModel ?? null,
+    };
+  });
+
+  groupSummaries.sort((left, right) => left.label.localeCompare(right.label));
+
+  const accountSummaries = modelFirstAccounts.map((account) => summarizeModelFirstAccount(account));
+  const nextWindowResetTimes = accountSummaries
+    .map((summary) => parseReset(summary.nextWindowResetAt))
+    .filter((value): value is number => value !== null);
+  const fullWindowResetTimes = accountSummaries
+    .map((summary) => parseReset(summary.fullWindowResetAt))
+    .filter((value): value is number => value !== null);
+  const nextRecoveryTimes = accountSummaries
+    .map((summary) => parseReset(summary.nextRecoveryAt))
+    .filter((value): value is number => value !== null);
+  const groupFractions = groupSummaries
+    .flatMap((summary) => [summary.minRemainingFraction, summary.p50RemainingFraction])
+    .filter((value): value is number => value !== null);
+
+  return {
+    totalAccounts: modelFirstAccounts.length,
+    readyAccounts: accountSummaries.filter((summary) => !summary.staleSnapshot && summary.readyGroups > 0).length,
+    staleAccounts: accountSummaries.filter((summary) => summary.staleSnapshot).length,
+    minRemainingFraction: groupFractions.length > 0 ? Math.min(...groupFractions) : null,
+    p50RemainingFraction: median(
+      groupSummaries
+        .map((summary) => summary.p50RemainingFraction)
+        .filter((value): value is number => value !== null)
+    ),
+    nextWindowResetAt: pickIso(nextWindowResetTimes, "min"),
+    fullWindowResetAt: pickIso(fullWindowResetTimes, "max"),
+    nextRecoveryAt: pickIso(nextRecoveryTimes, "min"),
+    groups: groupSummaries,
+  };
+}
+
+export function isModelFirstProviderQuotaUnverified(
+  summary: ModelFirstProviderSummary | null | undefined
+): boolean {
+  if (!summary || summary.totalAccounts === 0) {
+    return false;
+  }
+
+  return isFullFraction(summary.minRemainingFraction) && isFullFraction(summary.p50RemainingFraction);
+}

--- a/dashboard/src/lib/quota-window-classification.ts
+++ b/dashboard/src/lib/quota-window-classification.ts
@@ -1,0 +1,69 @@
+const HOUR_MS = 60 * 60 * 1000;
+const SHORT_TERM_CLUSTER_WINDOW_MS = 6 * HOUR_MS;
+const SHORT_TERM_CLUSTER_MIN_SPREAD_MS = 12 * HOUR_MS;
+const SHORT_TERM_RESET_FALLBACK_MS = 24 * HOUR_MS;
+
+export interface QuotaWindowLike {
+  id: string;
+  label: string;
+  resetTime: string | null;
+}
+
+function hasExplicitShortTermMarker(group: QuotaWindowLike): boolean {
+  const id = group.id.toLowerCase();
+  const label = group.label.toLowerCase();
+
+  return (
+    id.includes("five-hour") ||
+    id.includes("primary") ||
+    id.includes("request") ||
+    id.includes("token") ||
+    label.includes("5h") ||
+    label.includes("5m") ||
+    label.includes("request") ||
+    label.includes("token")
+  );
+}
+
+function parseResetTime(resetTime: string | null): number | null {
+  if (!resetTime) return null;
+
+  const timestamp = new Date(resetTime).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+export function isShortTermQuotaWindow(
+  group: QuotaWindowLike,
+  siblingGroups: readonly QuotaWindowLike[] = []
+): boolean {
+  if (hasExplicitShortTermMarker(group)) {
+    return true;
+  }
+
+  const groupReset = parseResetTime(group.resetTime);
+  if (groupReset === null) {
+    return false;
+  }
+
+  const siblingResets = siblingGroups
+    .map((candidate) => parseResetTime(candidate.resetTime))
+    .filter((value): value is number => value !== null)
+    .sort((left, right) => left - right);
+
+  if (siblingResets.length >= 2) {
+    const earliestReset = siblingResets[0] ?? 0;
+    const latestReset = siblingResets[siblingResets.length - 1] ?? 0;
+
+    // Antigravity exposes grouped model quotas without explicit window names.
+    // When there are distinct reset clusters, the earlier cluster behaves like
+    // the short-term window and the later cluster behaves like the long-term one.
+    if (
+      latestReset - earliestReset >= SHORT_TERM_CLUSTER_MIN_SPREAD_MS &&
+      groupReset - earliestReset <= SHORT_TERM_CLUSTER_WINDOW_MS
+    ) {
+      return true;
+    }
+  }
+
+  return groupReset - Date.now() <= SHORT_TERM_RESET_FALLBACK_MS;
+}


### PR DESCRIPTION
Add model-first quota monitoring for Antigravity accounts and sync the change on top of the latest upstream main.

This introduces grouped model-family quota aggregation for Antigravity snapshots, surfaces freshness and recovery metadata in the quota API, and updates the quota dashboard to render model-first summaries, charts, warnings, and detailed grouped account views.

The UI portion was rebased onto the current upstream theme-token changes, so the new quota views now use the same CSS variable-based styling as the latest original version instead of the older hardcoded colors.

This also adds coverage for the new Antigravity quota parsing and quota window classification behavior.