### PR TITLE
feat(oauth): Add quota group controls

### DIFF
--- a/dashboard/src/app/api/management/[...path]/route.ts
+++ b/dashboard/src/app/api/management/[...path]/route.ts
@@ -74,8 +74,11 @@ const ALLOWED_MANAGEMENT_PATHS = new Set<string>([
   // Auth files
   "auth-files",
   "auth-files/models",
+  "auth-files/quota-groups",
   "auth-files/download",
   "auth-files/status",
+  "auth-files/quota-groups/manual",
+  "auth-files/quota-groups/auto/clear",
   "auth-files/fields",
 
   // Providers
@@ -86,6 +89,7 @@ const ALLOWED_MANAGEMENT_PATHS = new Set<string>([
   "oauth-callback",
   "oauth-excluded-models",
   "oauth-model-alias",
+  "oauth-quota-groups",
 
   // Ampcode
   "ampcode",

--- a/dashboard/src/components/providers/oauth-credential-list.tsx
+++ b/dashboard/src/components/providers/oauth-credential-list.tsx
@@ -1,11 +1,27 @@
 "use client";
 
+import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { OwnerBadge, type CurrentUserLike } from "@/components/providers/api-key-section";
 
+interface OAuthQuotaGroupState {
+  authId: string;
+  groupId: string;
+  label: string;
+  effectiveStatus: string;
+  manualSuspended: boolean;
+  manualReason: string | null;
+  autoSuspendedUntil: string | null;
+  autoReason: string | null;
+  sourceModel: string | null;
+  updatedAt: string | null;
+  updatedBy: string | null;
+}
+
 interface OAuthAccountWithOwnership {
   id: string;
+  authId: string | null;
   accountName: string;
   accountEmail: string | null;
   provider: string;
@@ -15,6 +31,7 @@ interface OAuthAccountWithOwnership {
   status: "active" | "error" | "disabled" | string;
   statusMessage: string | null;
   unavailable: boolean;
+  quotaGroups?: OAuthQuotaGroupState[];
 }
 
 interface OAuthCredentialListProps {
@@ -23,9 +40,13 @@ interface OAuthCredentialListProps {
   currentUser: CurrentUserLike | null;
   togglingAccountId: string | null;
   claimingAccountName: string | null;
+  quotaActionKey: string | null;
   onToggle: (accountId: string, currentlyDisabled: boolean) => void;
   onDelete: (accountId: string) => void;
   onClaim: (accountName: string) => void;
+  onForceSuspend: (authId: string, groupId: string) => void;
+  onLiftManual: (authId: string, groupId: string) => void;
+  onClearCooldown: (authId: string, groupId: string) => void;
 }
 
 function parseStatusMessage(raw: string | null): string | null {
@@ -95,11 +116,20 @@ export function OAuthCredentialList({
   currentUser,
   togglingAccountId,
   claimingAccountName,
+  quotaActionKey,
   onToggle,
   onDelete,
   onClaim,
+  onForceSuspend,
+  onLiftManual,
+  onClearCooldown,
 }: OAuthCredentialListProps) {
   const t = useTranslations("providers");
+  const [expandedAccounts, setExpandedAccounts] = useState<Record<string, boolean>>({});
+
+  const toggleExpanded = (accountId: string) => {
+    setExpandedAccounts((current) => ({ ...current, [accountId]: !current[accountId] }));
+  };
 
   return (
     <>
@@ -135,6 +165,15 @@ export function OAuthCredentialList({
                     <p className="truncate text-xs text-[var(--text-secondary)]">{account.accountEmail}</p>
                   )}
                   <p className="truncate text-xs font-mono text-[var(--text-muted)]">{account.accountName}</p>
+                  {Array.isArray(account.quotaGroups) && account.quotaGroups.length > 0 && (
+                    <button
+                      type="button"
+                      className="text-xs text-blue-600 hover:text-blue-700"
+                      onClick={() => toggleExpanded(account.id)}
+                    >
+                      {expandedAccounts[account.id] ? "Hide quota groups" : `Show quota groups (${account.quotaGroups.length})`}
+                    </button>
+                  )}
                 </div>
                 {currentUser && (account.isOwn || currentUser.isAdmin) && (
                   <div className="flex shrink-0 items-center gap-2">
@@ -166,6 +205,78 @@ export function OAuthCredentialList({
                   </div>
                 )}
               </div>
+              {expandedAccounts[account.id] && Array.isArray(account.quotaGroups) && account.quotaGroups.length > 0 && (
+                <div className="mt-3 space-y-2 rounded-md border border-[var(--surface-border)] bg-[var(--surface-muted)]/20 p-3">
+                  {account.quotaGroups.map((group) => {
+                    const actionBase = `${account.id}:${group.groupId}`;
+                    const isManual = group.manualSuspended;
+                    const hasAuto = Boolean(group.autoSuspendedUntil);
+                    return (
+                      <div
+                        key={`${account.id}:${group.groupId}`}
+                        className="rounded-md border border-[var(--surface-border)] bg-[var(--surface-base)] p-3"
+                      >
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="min-w-0 flex-1 space-y-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="text-sm font-medium text-[var(--text-primary)]">{group.label}</span>
+                              <span className="rounded-full bg-[var(--surface-muted)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                                {group.effectiveStatus.replaceAll("_", " ")}
+                              </span>
+                            </div>
+                            {group.manualReason && (
+                              <p className="text-xs text-[var(--text-secondary)]">Manual: {group.manualReason}</p>
+                            )}
+                            {group.autoSuspendedUntil && (
+                              <p className="text-xs text-[var(--text-secondary)]">
+                                Cooldown until {new Date(group.autoSuspendedUntil).toLocaleString()}
+                                {group.autoReason ? ` (${group.autoReason})` : ""}
+                              </p>
+                            )}
+                            {group.sourceModel && (
+                              <p className="truncate text-xs text-[var(--text-muted)]">Source model: {group.sourceModel}</p>
+                            )}
+                            {group.updatedAt && (
+                              <p className="text-[11px] text-[var(--text-muted)]">
+                                Updated {new Date(group.updatedAt).toLocaleString()}
+                                {group.updatedBy ? ` by ${group.updatedBy}` : ""}
+                              </p>
+                            )}
+                          </div>
+                          {currentUser?.isAdmin && account.authId && (
+                            <div className="flex flex-wrap items-center gap-2">
+                              <Button
+                                variant="secondary"
+                                className="px-2.5 py-1 text-xs"
+                                disabled={quotaActionKey === `${actionBase}:manual-on` || isManual}
+                                onClick={() => onForceSuspend(account.authId as string, group.groupId)}
+                              >
+                                {quotaActionKey === `${actionBase}:manual-on` ? "..." : "Force suspend"}
+                              </Button>
+                              <Button
+                                variant="secondary"
+                                className="px-2.5 py-1 text-xs"
+                                disabled={quotaActionKey === `${actionBase}:manual-off` || !isManual}
+                                onClick={() => onLiftManual(account.authId as string, group.groupId)}
+                              >
+                                {quotaActionKey === `${actionBase}:manual-off` ? "..." : "Lift manual"}
+                              </Button>
+                              <Button
+                                variant="secondary"
+                                className="px-2.5 py-1 text-xs"
+                                disabled={quotaActionKey === `${actionBase}:auto-clear` || !hasAuto}
+                                onClick={() => onClearCooldown(account.authId as string, group.groupId)}
+                              >
+                                {quotaActionKey === `${actionBase}:auto-clear` ? "..." : "Clear cooldown"}
+                              </Button>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/dashboard/src/components/providers/oauth-section.tsx
+++ b/dashboard/src/components/providers/oauth-section.tsx
@@ -222,6 +222,7 @@ export function OAuthSection({
   const [pendingOAuthDelete, setPendingOAuthDelete] = useState<{ accountId: string; accountName: string } | null>(null);
   const [togglingAccountId, setTogglingAccountId] = useState<string | null>(null);
   const [claimingAccountName, setClaimingAccountName] = useState<string | null>(null);
+  const [quotaActionKey, setQuotaActionKey] = useState<string | null>(null);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [importProviderId, setImportProviderId] = useState<OAuthProviderId | null>(null);
   const [importJsonContent, setImportJsonContent] = useState("");
@@ -312,6 +313,66 @@ export function OAuthSection({
       showToast(t("toastNetworkError"), "error");
     } finally {
       setClaimingAccountName(null);
+    }
+  };
+
+  const updateQuotaGroupManual = async (
+    authId: string,
+    groupId: string,
+    manualSuspended: boolean
+  ) => {
+    const actionKey = `${authId}:${groupId}:${manualSuspended ? "manual-on" : "manual-off"}`;
+    setQuotaActionKey(actionKey);
+    try {
+      const res = await fetch(API_ENDPOINTS.MANAGEMENT.AUTH_FILE_QUOTA_GROUPS_MANUAL, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          auth_id: authId,
+          group_id: groupId,
+          manual_suspended: manualSuspended,
+          reason: manualSuspended ? "dashboard_manual_suspend" : "",
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        showToast(extractApiError(data, "Failed to update quota group"), "error");
+        return;
+      }
+      showToast(manualSuspended ? "Quota group suspended" : "Manual suspension lifted", "success");
+      await loadAccounts();
+      await refreshProviders();
+    } catch {
+      showToast(t("toastNetworkError"), "error");
+    } finally {
+      setQuotaActionKey(null);
+    }
+  };
+
+  const clearQuotaGroupCooldown = async (authId: string, groupId: string) => {
+    const actionKey = `${authId}:${groupId}:auto-clear`;
+    setQuotaActionKey(actionKey);
+    try {
+      const res = await fetch(API_ENDPOINTS.MANAGEMENT.AUTH_FILE_QUOTA_GROUPS_AUTO_CLEAR, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          auth_id: authId,
+          group_id: groupId,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        showToast(extractApiError(data, "Failed to clear quota cooldown"), "error");
+        return;
+      }
+      showToast("Quota cooldown cleared", "success");
+      await loadAccounts();
+      await refreshProviders();
+    } catch {
+      showToast(t("toastNetworkError"), "error");
+    } finally {
+      setQuotaActionKey(null);
     }
   };
 
@@ -796,9 +857,13 @@ export function OAuthSection({
             currentUser={currentUser}
             togglingAccountId={togglingAccountId}
             claimingAccountName={claimingAccountName}
+            quotaActionKey={quotaActionKey}
             onToggle={toggleOAuthAccount}
             onDelete={confirmDeleteOAuth}
             onClaim={claimOAuthAccount}
+            onForceSuspend={(authId, groupId) => void updateQuotaGroupManual(authId, groupId, true)}
+            onLiftManual={(authId, groupId) => void updateQuotaGroupManual(authId, groupId, false)}
+            onClearCooldown={(authId, groupId) => void clearQuotaGroupCooldown(authId, groupId)}
           />
 
           <div className="rounded-sm border border-[var(--surface-border)] bg-[var(--surface-base)] p-3 text-xs text-[var(--text-muted)]">

--- a/dashboard/src/lib/api-endpoints.ts
+++ b/dashboard/src/lib/api-endpoints.ts
@@ -82,9 +82,13 @@ export const API_ENDPOINTS = {
     // OAuth
     OAUTH_EXCLUDED_MODELS: "/api/management/oauth-excluded-models",
     OAUTH_MODEL_ALIAS: "/api/management/oauth-model-alias",
+    OAUTH_QUOTA_GROUPS: "/api/management/oauth-quota-groups",
 
     // Auth files
     AUTH_FILES: "/api/management/auth-files",
+    AUTH_FILE_QUOTA_GROUPS: "/api/management/auth-files/quota-groups",
+    AUTH_FILE_QUOTA_GROUPS_MANUAL: "/api/management/auth-files/quota-groups/manual",
+    AUTH_FILE_QUOTA_GROUPS_AUTO_CLEAR: "/api/management/auth-files/quota-groups/auto/clear",
 
     // Providers
     OPENAI_COMPATIBILITY: "/api/management/openai-compatibility",

--- a/dashboard/src/lib/providers/management-api.ts
+++ b/dashboard/src/lib/providers/management-api.ts
@@ -91,6 +91,7 @@ export interface ListKeysResult {
 
 export interface OAuthAccountWithOwnership {
   id: string;
+  authId: string | null;
   accountName: string;
   accountEmail: string | null;
   provider: string;
@@ -100,6 +101,23 @@ export interface OAuthAccountWithOwnership {
   status: "active" | "error" | "disabled" | string;
   statusMessage: string | null;
   unavailable: boolean;
+  quotaGroups?: OAuthAccountQuotaGroupState[];
+}
+
+export interface OAuthAccountQuotaGroupState {
+  authId: string;
+  groupId: string;
+  label: string;
+  effectiveStatus: string;
+  manualSuspended: boolean;
+  manualReason: string | null;
+  autoSuspendedUntil: string | null;
+  autoReason: string | null;
+  sourceModel: string | null;
+  sourceProvider: string | null;
+  resetTimeSource: string | null;
+  updatedAt: string | null;
+  updatedBy: string | null;
 }
 
 export interface ListOAuthResult {

--- a/dashboard/src/lib/providers/oauth-ops.ts
+++ b/dashboard/src/lib/providers/oauth-ops.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { Prisma } from "@/generated/prisma/client";
 import { type OAuthProvider } from "./constants";
+import { normalizeImportedOAuthCredential } from "./oauth-import-normalization";
 import { invalidateUsageCaches, invalidateProxyModelsCache } from "@/lib/cache";
 import {
   fetchWithTimeout,
@@ -15,6 +16,7 @@ import {
   type ListOAuthResult,
   type ImportOAuthResult,
   type ToggleOAuthResult,
+  type OAuthAccountQuotaGroupState,
   type OAuthAccountWithOwnership,
 } from "./management-api";
 
@@ -63,20 +65,16 @@ export async function importOAuthCredential(
   }
 
   try {
-    // Validate JSON content
-    let parsedContent: unknown;
-    try {
-      parsedContent = JSON.parse(fileContent);
-    } catch {
-      return { ok: false, error: "Invalid JSON content" };
-    }
-
-    if (!parsedContent || typeof parsedContent !== "object" || Array.isArray(parsedContent)) {
-      return { ok: false, error: "Credential file must contain a JSON object, not an array" };
+    const normalizedCredential = normalizeImportedOAuthCredential(
+      provider as OAuthProvider,
+      fileContent
+    );
+    if (!normalizedCredential.ok) {
+      return { ok: false, error: normalizedCredential.error };
     }
 
     // Build multipart form data to upload to CLIProxyAPIPlus
-    const blob = new Blob([fileContent], { type: "application/json" });
+    const blob = new Blob([normalizedCredential.normalizedContent], { type: "application/json" });
     const formData = new FormData();
     formData.append("file", blob, fileName);
 
@@ -298,6 +296,48 @@ export async function listOAuthWithOwnership(
       unavailable?: boolean;
     }>;
 
+    const quotaGroupsByAuthId = new Map<string, OAuthAccountQuotaGroupState[]>();
+    try {
+      const quotaGroupsEndpoint = `${MANAGEMENT_BASE_URL}/auth-files/quota-groups`;
+      const quotaGroupsRes = await fetchWithTimeout(quotaGroupsEndpoint, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${MANAGEMENT_API_KEY}` },
+      });
+      if (quotaGroupsRes.ok) {
+        const quotaGroupsData = await quotaGroupsRes.json();
+        if (isRecord(quotaGroupsData) && Array.isArray(quotaGroupsData.items)) {
+          for (const raw of quotaGroupsData.items) {
+            if (!isRecord(raw) || typeof raw.auth_id !== "string" || typeof raw.group_id !== "string") {
+              continue;
+            }
+            const authId = raw.auth_id;
+            const items = quotaGroupsByAuthId.get(authId) ?? [];
+            items.push({
+              authId,
+              groupId: String(raw.group_id),
+              label: typeof raw.label === "string" ? raw.label : String(raw.group_id),
+              effectiveStatus: typeof raw.effective_status === "string" ? raw.effective_status : "available",
+              manualSuspended: raw.manual_suspended === true,
+              manualReason: typeof raw.manual_reason === "string" ? raw.manual_reason : null,
+              autoSuspendedUntil:
+                typeof raw.auto_suspended_until === "string" ? raw.auto_suspended_until : null,
+              autoReason: typeof raw.auto_reason === "string" ? raw.auto_reason : null,
+              sourceModel: typeof raw.source_model === "string" ? raw.source_model : null,
+              sourceProvider: typeof raw.source_provider === "string" ? raw.source_provider : null,
+              resetTimeSource: typeof raw.reset_time_source === "string" ? raw.reset_time_source : null,
+              updatedAt: typeof raw.updated_at === "string" ? raw.updated_at : null,
+              updatedBy: typeof raw.updated_by === "string" ? raw.updated_by : null,
+            });
+            quotaGroupsByAuthId.set(authId, items);
+          }
+        }
+      } else {
+        await quotaGroupsRes.body?.cancel();
+      }
+    } catch (error) {
+      logger.warn({ err: error }, "listOAuthWithOwnership: failed to fetch quota groups");
+    }
+
     const accountNames = authFiles.map((file) => file.name);
 
     const ownerships = await prisma.providerOAuthOwnership.findMany({
@@ -314,6 +354,7 @@ export async function listOAuthWithOwnership(
 
        return {
          id: canSeeDetails ? file.id : `account-${index + 1}`,
+         authId: canSeeDetails ? file.id : null,
          accountName: canSeeDetails ? file.name : `Account ${index + 1}`,
          accountEmail: canSeeDetails ? file.email || null : null,
          provider: file.provider || file.type || "unknown",
@@ -323,6 +364,7 @@ export async function listOAuthWithOwnership(
          status: file.status || "active",
          statusMessage: file.status_message || null,
          unavailable: file.unavailable ?? false,
+         quotaGroups: canSeeDetails ? quotaGroupsByAuthId.get(file.id) ?? [] : [],
        };
      });
 
@@ -332,6 +374,84 @@ export async function listOAuthWithOwnership(
     return {
       ok: false,
       error: error instanceof Error ? error.message : "Unknown error during OAuth listing",
+    };
+  }
+}
+
+export async function setOAuthQuotaGroupManualByAuthId(
+  authId: string,
+  groupId: string,
+  manualSuspended: boolean,
+  reason?: string
+): Promise<ToggleOAuthResult> {
+  if (!MANAGEMENT_API_KEY) {
+    return { ok: false, error: "Management API key not configured" };
+  }
+
+  try {
+    const endpoint = `${MANAGEMENT_BASE_URL}/auth-files/quota-groups/manual`;
+    const response = await fetchWithTimeout(endpoint, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${MANAGEMENT_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        auth_id: authId,
+        group_id: groupId,
+        manual_suspended: manualSuspended,
+        reason: reason ?? "",
+      }),
+    });
+    if (!response.ok) {
+      await response.body?.cancel();
+      return { ok: false, error: `Failed to update quota group: HTTP ${response.status}` };
+    }
+    invalidateUsageCaches();
+    invalidateProxyModelsCache();
+    return { ok: true };
+  } catch (error) {
+    logger.error({ err: error, authId, groupId, manualSuspended }, "setOAuthQuotaGroupManualByAuthId error");
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error updating quota group",
+    };
+  }
+}
+
+export async function clearOAuthQuotaGroupCooldownByAuthId(
+  authId: string,
+  groupId: string
+): Promise<ToggleOAuthResult> {
+  if (!MANAGEMENT_API_KEY) {
+    return { ok: false, error: "Management API key not configured" };
+  }
+
+  try {
+    const endpoint = `${MANAGEMENT_BASE_URL}/auth-files/quota-groups/auto/clear`;
+    const response = await fetchWithTimeout(endpoint, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${MANAGEMENT_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        auth_id: authId,
+        group_id: groupId,
+      }),
+    });
+    if (!response.ok) {
+      await response.body?.cancel();
+      return { ok: false, error: `Failed to clear cooldown: HTTP ${response.status}` };
+    }
+    invalidateUsageCaches();
+    invalidateProxyModelsCache();
+    return { ok: true };
+  } catch (error) {
+    logger.error({ err: error, authId, groupId }, "clearOAuthQuotaGroupCooldownByAuthId error");
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error clearing quota cooldown",
     };
   }
 }


### PR DESCRIPTION
Add quota-group visibility and controls to the OAuth account UI.
This wires the dashboard to the new management endpoints so each OAuth account can show group-level suspension state, the source model that triggered an automatic cooldown, and the exact cooldown-until timestamp.
It also adds admin actions for force suspend, lift manual suspension, and clear cooldown so operators can manage group state without editing config by hand.
This is intended to ship alongside the backend quota-group support in CLIProxyAPIPlus.