### PR TITLE
chore(ts): enable noUncheckedIndexedAccess and fix resulting regressions

### DIFF
--- a/dashboard/src/app/api/agent-config-slim/route.test.ts
+++ b/dashboard/src/app/api/agent-config-slim/route.test.ts
@@ -112,7 +112,10 @@ describe("PUT /api/agent-config-slim", () => {
     expect(data.overrides.council.presets.default.master.variant).toBe("high");
 
     expect(upsertMock).toHaveBeenCalledTimes(1);
-    const saved = upsertMock.mock.calls[0][0].create.slimOverrides as Record<string, unknown>;
+    const upsertCall = upsertMock.mock.calls[0];
+    expect(upsertCall).toBeDefined();
+    const [upsertArgs] = upsertCall!;
+    const saved = upsertArgs.create.slimOverrides as Record<string, unknown>;
     expect(saved.interview).toEqual({ maxQuestions: 3, dashboard: true, port: 43211 });
     expect(saved.websearch).toEqual({ provider: "tavily" });
   });

--- a/dashboard/src/app/api/containers/[name]/action/route.ts
+++ b/dashboard/src/app/api/containers/[name]/action/route.ts
@@ -49,6 +49,9 @@ export async function POST(
 
     const typedAction: ActionValue = validated.action;
     const config = CONTAINER_CONFIG[name];
+    if (!config) {
+      return Errors.notFound("Container");
+    }
 
     const permissionKey = `allow${typedAction.charAt(0).toUpperCase()}${typedAction.slice(1)}` as
       | "allowStart"

--- a/dashboard/src/app/api/containers/[name]/logs/route.ts
+++ b/dashboard/src/app/api/containers/[name]/logs/route.ts
@@ -62,6 +62,9 @@ export async function GET(
 
     const logLines = allOutput ? allOutput.split("\n") : [];
     const config = CONTAINER_CONFIG[name];
+    if (!config) {
+      return Errors.notFound("Container");
+    }
 
     return apiSuccess({
       lines: logLines,

--- a/dashboard/src/app/api/containers/list/route.ts
+++ b/dashboard/src/app/api/containers/list/route.ts
@@ -5,6 +5,8 @@ import { CONTAINER_CONFIG, getAllowedActions, type ContainerAction } from "@/lib
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { logger } from "@/lib/logger";
+import { Errors } from "@/lib/errors";
+
 
 const execFileAsync = promisify(execFile);
 const DOCKER_COMMAND_TIMEOUT_MS = 8000;
@@ -64,15 +66,31 @@ export async function GET() {
 
     const lines = stdout.trim().split("\n").filter(Boolean);
 
-    const results = await Promise.all(
-      lines.map(async (line) => {
-        const [name, status, state] = line.split("\t");
-        const config = CONTAINER_CONFIG[name];
+    const parsedContainers: Array<{
+      name: string;
+      status: string;
+      state: string;
+      config: (typeof CONTAINER_CONFIG)[string];
+    }> = [];
 
-        if (!config) {
-          return null;
-        }
+    for (const line of lines) {
+      const [name, status, state] = line.split("\t");
+      if (!name || !status || !state) {
+        logger.error({ line }, "Malformed docker ps output");
+        return Errors.internal("Failed to list containers");
+      }
 
+      const config = CONTAINER_CONFIG[name];
+      if (!config) {
+        logger.error({ containerName: name }, "Missing container configuration");
+        return Errors.internal("Failed to list containers");
+      }
+
+      parsedContainers.push({ name, status, state, config });
+    }
+
+    const containers = await Promise.all(
+      parsedContainers.map(async ({ name, status, state, config }): Promise<ContainerInfo> => {
         let uptime: number | null = null;
         let cpu: string | null = null;
         let memory: string | null = null;
@@ -124,8 +142,6 @@ export async function GET() {
         };
       })
     );
-
-    const containers = results.filter((c): c is ContainerInfo => c !== null);
 
     return NextResponse.json(containers);
   } catch (error) {

--- a/dashboard/src/app/api/containers/list/route.ts
+++ b/dashboard/src/app/api/containers/list/route.ts
@@ -5,7 +5,6 @@ import { CONTAINER_CONFIG, getAllowedActions, type ContainerAction } from "@/lib
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { logger } from "@/lib/logger";
-import { Errors } from "@/lib/errors";
 
 
 const execFileAsync = promisify(execFile);
@@ -76,14 +75,14 @@ export async function GET() {
     for (const line of lines) {
       const [name, status, state] = line.split("\t");
       if (!name || !status || !state) {
-        logger.error({ line }, "Malformed docker ps output");
-        return Errors.internal("Failed to list containers");
+        logger.warn({ line }, "Skipping malformed docker ps line");
+        continue;
       }
 
       const config = CONTAINER_CONFIG[name];
       if (!config) {
-        logger.error({ containerName: name }, "Missing container configuration");
-        return Errors.internal("Failed to list containers");
+        logger.warn({ containerName: name }, "Skipping container without configuration");
+        continue;
       }
 
       parsedContainers.push({ name, status, state, config });

--- a/dashboard/src/app/api/custom-providers/fetch-models/route.test.ts
+++ b/dashboard/src/app/api/custom-providers/fetch-models/route.test.ts
@@ -125,7 +125,9 @@ describe("POST /api/custom-providers/fetch-models (issue #197)", () => {
     const { POST } = await import("./route");
     const res = await POST(buildRequest({ baseUrl: "http://localhost:11434/v1" }));
     expect(res.status).toBe(200);
-    const [, init] = fetchMock.mock.calls[0];
+    const fetchCall = fetchMock.mock.calls[0];
+    expect(fetchCall).toBeDefined();
+    const [, init] = fetchCall!;
     expect(init.headers).not.toHaveProperty("Authorization");
   });
 
@@ -139,7 +141,9 @@ describe("POST /api/custom-providers/fetch-models (issue #197)", () => {
     const { POST } = await import("./route");
     const res = await POST(buildRequest({ baseUrl: "http://localhost:11434/v1", apiKey: "secret" }));
     expect(res.status).toBe(200);
-    const [, init] = fetchMock.mock.calls[0];
+    const fetchCall = fetchMock.mock.calls[0];
+    expect(fetchCall).toBeDefined();
+    const [, init] = fetchCall!;
     expect(init.headers.Authorization).toBe("Bearer secret");
   });
 });

--- a/dashboard/src/app/api/custom-providers/fetch-models/route.ts
+++ b/dashboard/src/app/api/custom-providers/fetch-models/route.ts
@@ -141,7 +141,7 @@ function isPrivateHost(hostname: string, allowLocal: boolean): boolean {
   const hexMatch = ipv6.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
   if (hexMatch) {
     const [, hiPart, loPart] = hexMatch;
-    if (!hiPart || !loPart) return false;
+    if (!hiPart || !loPart) return true; // fail closed: unparseable mapped IPv6 is treated as private
     const hi = parseInt(hiPart, 16);
     const lo = parseInt(loPart, 16);
     const a = (hi >> 8) & 0xff;

--- a/dashboard/src/app/api/custom-providers/fetch-models/route.ts
+++ b/dashboard/src/app/api/custom-providers/fetch-models/route.ts
@@ -49,8 +49,9 @@ function expandIPv6(raw: string): string | null {
   const parts = value.split("::");
   if (parts.length > 2) return null;
 
-  const head = parts[0] === "" ? [] : parts[0].split(":");
-  const tail = parts.length === 2 && parts[1] !== "" ? parts[1].split(":") : [];
+  const [headPart = "", tailPart = ""] = parts;
+  const head = headPart === "" ? [] : headPart.split(":");
+  const tail = parts.length === 2 && tailPart !== "" ? tailPart.split(":") : [];
   const missing = 8 - head.length - tail.length;
   if (missing < 0) return null;
   if (parts.length === 1 && head.length !== 8) return null;
@@ -139,8 +140,10 @@ function isPrivateHost(hostname: string, allowLocal: boolean): boolean {
   }
   const hexMatch = ipv6.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
   if (hexMatch) {
-    const hi = parseInt(hexMatch[1], 16);
-    const lo = parseInt(hexMatch[2], 16);
+    const [, hiPart, loPart] = hexMatch;
+    if (!hiPart || !loPart) return false;
+    const hi = parseInt(hiPart, 16);
+    const lo = parseInt(loPart, 16);
     const a = (hi >> 8) & 0xff;
     const b = hi & 0xff;
     const c = (lo >> 8) & 0xff;

--- a/dashboard/src/app/api/management/oauth-callback/route.ts
+++ b/dashboard/src/app/api/management/oauth-callback/route.ts
@@ -332,10 +332,11 @@ export async function POST(request: NextRequest) {
 
       if (runUnclaimed) {
         const unclaimedCandidates = await findUnclaimedAuthFiles(afterAuthFiles, provider);
-        if (unclaimedCandidates.length === 1) {
+        const [unclaimedCandidate] = unclaimedCandidates;
+        if (unclaimedCandidates.length === 1 && unclaimedCandidate) {
           candidateFiles = unclaimedCandidates;
           logger.info(
-            { provider, strategy: "unclaimed-single", name: unclaimedCandidates[0].name },
+            { provider, strategy: "unclaimed-single", name: unclaimedCandidate.name },
             "OAuth callback: matched single unclaimed auth file for provider"
           );
           break;
@@ -345,10 +346,11 @@ export async function POST(request: NextRequest) {
           const newAndUnclaimed = unclaimedCandidates.filter(
             (f) => !preCallbackNames.has(f.name)
           );
-          if (newAndUnclaimed.length === 1) {
+          const [newUnclaimedCandidate] = newAndUnclaimed;
+          if (newAndUnclaimed.length === 1 && newUnclaimedCandidate) {
             candidateFiles = newAndUnclaimed;
             logger.info(
-              { provider, strategy: "unclaimed-new", name: newAndUnclaimed[0].name },
+              { provider, strategy: "unclaimed-new", name: newUnclaimedCandidate.name },
               "OAuth callback: matched single new unclaimed auth file"
             );
             break;

--- a/dashboard/src/app/api/update/check/route.ts
+++ b/dashboard/src/app/api/update/check/route.ts
@@ -62,7 +62,11 @@ async function getCurrentImageDigest(): Promise<{ version: string; digest: strin
     ]);
     
     const [image, fullDigest] = stdout.trim().split(" ");
-    const tagVersion = image.includes(":") ? image.split(":")[1] : "latest";
+    if (!image || !fullDigest) {
+      return { version: "unknown", digest: "unknown", fullDigest: "unknown" };
+    }
+    const [, imageTag] = image.split(":");
+    const tagVersion = imageTag ?? "latest";
     const cleanDigest = fullDigest.replace("sha256:", "");
     
     return { 
@@ -95,7 +99,7 @@ async function checkGitHubBuildStatus(skipCache = false): Promise<boolean> {
       fetch(`${base}&status=queued`, { cache: "no-store", headers }),
     ]);
 
-    const [inProgressData, queuedData]: GitHubRunsResponse[] = await Promise.all([
+    const [inProgressData, queuedData]: [GitHubRunsResponse, GitHubRunsResponse] = await Promise.all([
       inProgressRes.ok
         ? inProgressRes.json()
         : inProgressRes.body?.cancel().then(() => ({})) ?? Promise.resolve({}),

--- a/dashboard/src/app/api/update/dashboard/check/route.ts
+++ b/dashboard/src/app/api/update/dashboard/check/route.ts
@@ -24,7 +24,7 @@ interface VersionInfo {
   releaseNotes: string | null;
 }
 
-function parseVersion(tag: string): number[] | null {
+function parseVersion(tag: string): [number, number, number] | null {
   const match = tag.replace(/^.*v/, "").match(/^(\d+)\.(\d+)\.(\d+)/);
   if (!match) return null;
   return [Number(match[1]), Number(match[2]), Number(match[3])];
@@ -35,11 +35,14 @@ function isNewerVersion(current: string, latest: string): boolean {
   const lat = parseVersion(latest);
   if (!cur || !lat) return false;
 
-  for (let i = 0; i < 3; i++) {
-    if (lat[i] > cur[i]) return true;
-    if (lat[i] < cur[i]) return false;
-  }
-  return false;
+  const [curMajor, curMinor, curPatch] = cur;
+  const [latMajor, latMinor, latPatch] = lat;
+
+  if (latMajor > curMajor) return true;
+  if (latMajor < curMajor) return false;
+  if (latMinor > curMinor) return true;
+  if (latMinor < curMinor) return false;
+  return latPatch > curPatch;
 }
 
 async function getRemoteVersion(skipCache = false): Promise<RemoteVersionData | null> {

--- a/dashboard/src/app/api/usage/history/route.ts
+++ b/dashboard/src/app/api/usage/history/route.ts
@@ -63,6 +63,7 @@ interface LatencySummary {
 function isValidDateParam(dateString: string): boolean {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(dateString)) return false;
   const [year, month, day] = dateString.split("-").map(Number);
+  if (year === undefined || month === undefined || day === undefined) return false;
   const date = new Date(year, month - 1, day);
   return date.getFullYear() === year
     && date.getMonth() === month - 1

--- a/dashboard/src/app/dashboard/admin/logs/page.tsx
+++ b/dashboard/src/app/dashboard/admin/logs/page.tsx
@@ -26,13 +26,16 @@ interface LogStats {
   persistent: boolean;
 }
 
+const DEFAULT_LEVEL_BADGE_CLASS =
+  "text-[var(--text-muted)] bg-[var(--surface-muted)] border-[var(--surface-border)]";
+
 const LEVEL_COLORS: Record<string, string> = {
   error: "text-red-600 bg-red-500/100/10 border-red-500/20",
   fatal: "text-red-600 bg-red-500/100/10 border-red-500/20",
   warn: "text-yellow-700 bg-yellow-500/100/10 border-yellow-500/20",
   info: "text-blue-600 bg-blue-500/100/10 border-blue-500/20",
-  debug: "text-[var(--text-muted)] bg-[var(--surface-muted)] border-[var(--surface-border)]",
-  trace: "text-[var(--text-muted)] bg-[var(--surface-muted)] border-[var(--surface-border)]",
+  debug: DEFAULT_LEVEL_BADGE_CLASS,
+  trace: DEFAULT_LEVEL_BADGE_CLASS,
 };
 
 const LEVEL_FILTERS = ["all", "error", "warn", "info", "debug"] as const;
@@ -199,7 +202,7 @@ export default function AdminLogsPage() {
   };
 
   const getLevelBadgeClass = (level: string): string => {
-    return LEVEL_COLORS[level] ?? LEVEL_COLORS.debug;
+    return LEVEL_COLORS[level] ?? DEFAULT_LEVEL_BADGE_CLASS;
   };
 
   const renderLogDetails = (log: LogEntry): string => {

--- a/dashboard/src/app/dashboard/config/page.tsx
+++ b/dashboard/src/app/dashboard/config/page.tsx
@@ -505,18 +505,33 @@ export default function ConfigPage() {
     const entries = [...(aliases[provider] ?? [])];
     const entry = entries[index];
     if (!entry) return;
-    if (field === "fork") {
-      if (typeof value !== "boolean") return;
-      entries[index] = { ...entry, fork: value };
-    } else if (field === "name") {
-      if (typeof value !== "string") return;
-      entries[index] = { ...entry, name: value };
-    } else if (field === "alias") {
-      if (typeof value !== "string") return;
-      entries[index] = { ...entry, alias: value };
-    } else {
-      if (typeof value !== "string") return;
-      entries[index] = { ...entry, _id: value };
+    switch (field) {
+      case "fork": {
+        if (typeof value !== "boolean") return;
+        entries[index] = { ...entry, fork: value };
+        break;
+      }
+      case "name": {
+        if (typeof value !== "string") return;
+        entries[index] = { ...entry, name: value };
+        break;
+      }
+      case "alias": {
+        if (typeof value !== "string") return;
+        entries[index] = { ...entry, alias: value };
+        break;
+      }
+      case "_id": {
+        if (typeof value !== "string") return;
+        entries[index] = { ...entry, _id: value };
+        break;
+      }
+      default: {
+        // Exhaustiveness: adding a new field to OAuthModelAliasEntry must add a case here.
+        const _exhaustive: never = field;
+        void _exhaustive;
+        return;
+      }
     }
     setConfig({
       ...config,

--- a/dashboard/src/app/dashboard/config/page.tsx
+++ b/dashboard/src/app/dashboard/config/page.tsx
@@ -301,10 +301,12 @@ export default function ConfigPage() {
       for (const key of Object.keys(FIELD_ENDPOINTS) as (keyof Config)[]) {
         const oldVal = originalConfig[key];
         const newVal = config[key];
-        if (JSON.stringify(oldVal) !== JSON.stringify(newVal)) {
-          const success = await updateField(FIELD_ENDPOINTS[key], newVal);
-          if (success) successCount++;
+        const endpoint = FIELD_ENDPOINTS[key];
+        if (!endpoint || JSON.stringify(oldVal) === JSON.stringify(newVal)) {
+          continue;
         }
+        const success = await updateField(endpoint, newVal);
+        if (success) successCount++;
       }
 
       // Check nested fields (quota-exceeded)
@@ -501,7 +503,21 @@ export default function ConfigPage() {
     if (!config) return;
     const aliases = config["oauth-model-alias"] ?? {};
     const entries = [...(aliases[provider] ?? [])];
-    entries[index] = { ...entries[index], [field]: value };
+    const entry = entries[index];
+    if (!entry) return;
+    if (field === "fork") {
+      if (typeof value !== "boolean") return;
+      entries[index] = { ...entry, fork: value };
+    } else if (field === "name") {
+      if (typeof value !== "string") return;
+      entries[index] = { ...entry, name: value };
+    } else if (field === "alias") {
+      if (typeof value !== "string") return;
+      entries[index] = { ...entry, alias: value };
+    } else {
+      if (typeof value !== "string") return;
+      entries[index] = { ...entry, _id: value };
+    }
     setConfig({
       ...config,
       "oauth-model-alias": { ...aliases, [provider]: entries },

--- a/dashboard/src/app/dashboard/monitoring/page.tsx
+++ b/dashboard/src/app/dashboard/monitoring/page.tsx
@@ -74,13 +74,16 @@ function parseLogLine(line: string, index: number): LogLine {
   const match = line.match(logRegex);
 
   if (match) {
-    return {
-      id: `${match[1]}-${index}`,
-      timestamp: match[1],
-      level: match[2].toLowerCase(),
-      message: match[3],
-      raw: line,
-    };
+    const [, timestamp, level, message] = match;
+    if (timestamp && level && message) {
+      return {
+        id: `${timestamp}-${index}`,
+        timestamp,
+        level: level.toLowerCase(),
+        message,
+        raw: line,
+      };
+    }
   }
 
   return {

--- a/dashboard/src/app/dashboard/page.tsx
+++ b/dashboard/src/app/dashboard/page.tsx
@@ -198,7 +198,8 @@ export default async function QuickStartPage() {
 
   const providerCount = configProviderCount + activeOAuthProviders.size;
 
-  const apiKeyForProxy = userApiKeys.length > 0 ? userApiKeys[0].key : "";
+  const [firstUserApiKey] = userApiKeys;
+  const apiKeyForProxy = firstUserApiKey?.key ?? "";
   const [proxyModels, modelsDevLimits, customProviders] = await Promise.all([
     apiKeyForProxy ? fetchProxyModels(getInternalProxyUrl(), apiKeyForProxy) : Promise.resolve([]),
     fetchModelsDevLimits(),

--- a/dashboard/src/components/custom-provider-modal.tsx
+++ b/dashboard/src/components/custom-provider-modal.tsx
@@ -240,7 +240,9 @@ export function CustomProviderModal({ isOpen, onClose, provider, onSuccess }: Cu
 
   const updateModelMapping = (index: number, field: 'upstreamName' | 'alias', value: string) => {
     const updated = [...models];
-    updated[index][field] = value;
+    const model = updated[index];
+    if (!model) return;
+    model[field] = value;
     setModels(updated);
   };
 
@@ -254,7 +256,9 @@ export function CustomProviderModal({ isOpen, onClose, provider, onSuccess }: Cu
 
   const updateHeader = (index: number, field: 'key' | 'value', value: string) => {
     const updated = [...headers];
-    updated[index][field] = value;
+    const header = updated[index];
+    if (!header) return;
+    header[field] = value;
     setHeaders(updated);
   };
 

--- a/dashboard/src/components/oh-my-opencode-config-generator.tsx
+++ b/dashboard/src/components/oh-my-opencode-config-generator.tsx
@@ -329,10 +329,12 @@ export function OhMyOpenCodeConfigGenerator(props: OhMyOpenCodeConfigGeneratorPr
     newValue: string | number,
   ) => {
     const newRows = [...providerConcurrencyRows];
+    const row = newRows[index];
+    if (!row) return;
     if (field === "key") {
-      newRows[index].key = newValue as string;
+      row.key = newValue as string;
     } else {
-      newRows[index].value = newValue as number;
+      row.value = newValue as number;
     }
     setProviderConcurrencyRows(newRows);
     const providerConcurrency = Object.fromEntries(newRows.map((row) => [row.key, row.value]));
@@ -358,10 +360,12 @@ export function OhMyOpenCodeConfigGenerator(props: OhMyOpenCodeConfigGeneratorPr
 
   const handleModelConcurrencyChange = (index: number, field: "key" | "value", newValue: string | number) => {
     const newRows = [...modelConcurrencyRows];
+    const row = newRows[index];
+    if (!row) return;
     if (field === "key") {
-      newRows[index].key = newValue as string;
+      row.key = newValue as string;
     } else {
-      newRows[index].value = newValue as number;
+      row.value = newValue as number;
     }
     setModelConcurrencyRows(newRows);
     const modelConcurrency = Object.fromEntries(newRows.map((row) => [row.key, row.value]));
@@ -556,9 +560,13 @@ export function OhMyOpenCodeConfigGenerator(props: OhMyOpenCodeConfigGeneratorPr
           label: AGENT_ROLES[agent] ?? agent,
         });
       } else {
+        const model = overrideModel ?? chain[0];
+        if (model === undefined) {
+          continue;
+        }
         agentAssignments.push({
           name: agent,
-          model: overrideModel ?? chain[0],
+          model,
           isOverride: !!overrideModel,
           isUnresolved: true,
           config: agentConfig,
@@ -610,9 +618,13 @@ export function OhMyOpenCodeConfigGenerator(props: OhMyOpenCodeConfigGeneratorPr
           label: CATEGORY_ROLES[category] ?? category,
         });
       } else {
+        const model = overrideModel ?? chain[0];
+        if (model === undefined) {
+          continue;
+        }
         categoryAssignments.push({
           name: category,
-          model: overrideModel ?? chain[0],
+          model,
           isOverride: !!overrideModel,
           isUnresolved: true,
           config: categoryConfig,

--- a/dashboard/src/components/opencode-config-generator.tsx
+++ b/dashboard/src/components/opencode-config-generator.tsx
@@ -287,7 +287,9 @@ export function OpenCodeConfigGenerator(props: OpenCodeConfigGeneratorProps) {
 
   const handleUpdateEnvRow = (index: number, field: "key" | "value", value: string) => {
     const newRows = [...envRows];
-    newRows[index][field] = value;
+    const row = newRows[index];
+    if (!row) return;
+    row[field] = value;
     setEnvRows(newRows);
   };
 
@@ -396,7 +398,7 @@ export function OpenCodeConfigGenerator(props: OpenCodeConfigGeneratorProps) {
           <div className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
             <span className="inline-flex h-2 w-2 rounded-full bg-emerald-400" />
             <span>
-              {t("usingApiKeyPrefix")} <strong className="text-[var(--text-secondary)]">{apiKeys[0].name || t("unnamedKey")}</strong>
+              {t("usingApiKeyPrefix")} <strong className="text-[var(--text-secondary)]">{selectedEntry?.name || t("unnamedKey")}</strong>
             </span>
           </div>
         )

--- a/dashboard/src/components/providers/custom-provider-section.tsx
+++ b/dashboard/src/components/providers/custom-provider-section.tsx
@@ -205,7 +205,10 @@ export function CustomProviderSection({ showToast, onProviderCountChange }: Cust
   const handleMoveGroupUp = async (groupId: string, index: number) => {
     if (index === 0) return;
     const newGroups = [...groups];
-    [newGroups[index - 1], newGroups[index]] = [newGroups[index], newGroups[index - 1]];
+    const currentGroup = newGroups[index];
+    const previousGroup = newGroups[index - 1];
+    if (!currentGroup || !previousGroup) return;
+    [newGroups[index - 1], newGroups[index]] = [currentGroup, previousGroup];
 
     setGroups(newGroups);
 
@@ -230,7 +233,10 @@ export function CustomProviderSection({ showToast, onProviderCountChange }: Cust
   const handleMoveGroupDown = async (groupId: string, index: number) => {
     if (index === groups.length - 1) return;
     const newGroups = [...groups];
-    [newGroups[index], newGroups[index + 1]] = [newGroups[index + 1], newGroups[index]];
+    const currentGroup = newGroups[index];
+    const nextGroup = newGroups[index + 1];
+    if (!currentGroup || !nextGroup) return;
+    [newGroups[index], newGroups[index + 1]] = [nextGroup, currentGroup];
 
     setGroups(newGroups);
 
@@ -255,9 +261,15 @@ export function CustomProviderSection({ showToast, onProviderCountChange }: Cust
   const moveProviderInList = (list: CustomProvider[], index: number, direction: 'up' | 'down') => {
     const newList = [...list];
     if (direction === 'up' && index > 0) {
-      [newList[index - 1], newList[index]] = [newList[index], newList[index - 1]];
+      const currentProvider = newList[index];
+      const previousProvider = newList[index - 1];
+      if (!currentProvider || !previousProvider) return newList;
+      [newList[index - 1], newList[index]] = [currentProvider, previousProvider];
     } else if (direction === 'down' && index < newList.length - 1) {
-      [newList[index], newList[index + 1]] = [newList[index + 1], newList[index]];
+      const currentProvider = newList[index];
+      const nextProvider = newList[index + 1];
+      if (!currentProvider || !nextProvider) return newList;
+      [newList[index], newList[index + 1]] = [nextProvider, currentProvider];
     }
     return newList;
   };
@@ -295,9 +307,11 @@ export function CustomProviderSection({ showToast, onProviderCountChange }: Cust
     if (groupId) {
       const groupIndex = newGroups.findIndex(g => g.id === groupId);
       if (groupIndex !== -1) {
+        const group = newGroups[groupIndex];
+        if (!group) return;
         newGroups[groupIndex] = {
-          ...newGroups[groupIndex],
-          providers: moveProviderInList(newGroups[groupIndex].providers, index, 'up')
+          ...group,
+          providers: moveProviderInList(group.providers, index, 'up')
         };
         setGroups(newGroups);
       }
@@ -322,9 +336,11 @@ export function CustomProviderSection({ showToast, onProviderCountChange }: Cust
     if (groupId) {
       const groupIndex = newGroups.findIndex(g => g.id === groupId);
       if (groupIndex !== -1) {
+        const group = newGroups[groupIndex];
+        if (!group) return;
         newGroups[groupIndex] = {
-          ...newGroups[groupIndex],
-          providers: moveProviderInList(newGroups[groupIndex].providers, index, 'down')
+          ...group,
+          providers: moveProviderInList(group.providers, index, 'down')
         };
         setGroups(newGroups);
       }

--- a/dashboard/src/components/usage/cost-estimation.tsx
+++ b/dashboard/src/components/usage/cost-estimation.tsx
@@ -96,12 +96,14 @@ function aggregateByProvider(entries: ModelCostEntry[]): ProviderCostEntry[] {
   const providerMap: Record<string, ProviderCostEntry> = {};
   for (const entry of entries) {
     if (!entry.priced) continue;
-    if (!providerMap[entry.provider]) {
-      providerMap[entry.provider] = { provider: entry.provider, estimatedCost: 0, models: 0, requests: 0 };
+    let provider = providerMap[entry.provider];
+    if (!provider) {
+      provider = { provider: entry.provider, estimatedCost: 0, models: 0, requests: 0 };
+      providerMap[entry.provider] = provider;
     }
-    providerMap[entry.provider].estimatedCost += entry.estimatedCost;
-    providerMap[entry.provider].models += 1;
-    providerMap[entry.provider].requests += entry.requests;
+    provider.estimatedCost += entry.estimatedCost;
+    provider.models += 1;
+    provider.requests += entry.requests;
   }
   return Object.values(providerMap).sort((a, b) => b.estimatedCost - a.estimatedCost);
 }

--- a/dashboard/src/hooks/use-focus-trap.ts
+++ b/dashboard/src/hooks/use-focus-trap.ts
@@ -42,6 +42,10 @@ export function useFocusTrap(
 
       const firstElement = focusableElements[0];
       const lastElement = focusableElements[focusableElements.length - 1];
+      if (!firstElement || !lastElement) {
+        event.preventDefault();
+        return;
+      }
 
       if (event.shiftKey) {
         if (

--- a/dashboard/src/lib/__tests__/notification-dismissal.test.ts
+++ b/dashboard/src/lib/__tests__/notification-dismissal.test.ts
@@ -59,8 +59,9 @@ describe("addDismissedId", () => {
       `${DISMISSED_KEY_PREFIX}userId123`,
       expect.any(String)
     );
-    const callArgs = localStorageMock.setItem.mock.calls[0];
-    expect(callArgs[0]).toBe("header_notifications_dismissed_userId123");
+    const [callArgs] = localStorageMock.setItem.mock.calls;
+    expect(callArgs).toBeDefined();
+    expect(callArgs![0]).toBe("header_notifications_dismissed_userId123");
   });
 
   it("caps at MAX_DISMISSED entries, evicts oldest", () => {
@@ -91,7 +92,9 @@ describe("filterNotifications", () => {
     const dismissedIds = new Set(["health-db", "health-proxy"]);
     const result = filterNotifications(notifications, dismissedIds);
     expect(result.length).toBe(1);
-    expect(result[0].id).toBe("update-dashboard");
+    const [notification] = result;
+    expect(notification).toBeDefined();
+    expect(notification!.id).toBe("update-dashboard");
   });
 
   it("returns all notifications when dismissed set is empty", () => {

--- a/dashboard/src/lib/__tests__/oh-my-opencode-config.test.ts
+++ b/dashboard/src/lib/__tests__/oh-my-opencode-config.test.ts
@@ -114,8 +114,10 @@ describe("oh-my-opencode config", () => {
     expect(config).not.toBeNull();
     const typedConfig = config as Record<string, unknown>;
     const agents = typedConfig.agents as Record<string, { ultrawork?: { model?: string; variant?: string } }>;
+    const sisyphus = agents.sisyphus;
 
-    expect(agents.sisyphus.ultrawork).toEqual({
+    expect(sisyphus).toBeDefined();
+    expect(sisyphus!.ultrawork).toEqual({
       model: "cliproxyapi/claude-opus-4.6",
       variant: "max",
     });
@@ -134,18 +136,26 @@ describe("oh-my-opencode config", () => {
     const categories = typedConfig.categories as Record<string, { model: string; fallback_models?: string[] }>;
 
     // explore chain: grok-code-fast-1 → minimax-m2.7-highspeed → minimax-m2.7 → claude-haiku-4.5 → gpt-5-nano
-    expect(agents.explore.model).toBe("cliproxyapi/claude-haiku-4.5");
-    expect(agents.explore.fallback_models).toContain("cliproxyapi/gpt-5-nano");
+    const explore = agents.explore;
+    expect(explore).toBeDefined();
+    expect(explore!.model).toBe("cliproxyapi/claude-haiku-4.5");
+    expect(explore!.fallback_models).toContain("cliproxyapi/gpt-5-nano");
 
     // librarian chain: minimax-m2.7 → minimax-m2.7-highspeed → claude-haiku-4.5 → gpt-5-nano
-    expect(agents.librarian.model).toBe("cliproxyapi/claude-haiku-4.5");
+    const librarian = agents.librarian;
+    expect(librarian).toBeDefined();
+    expect(librarian!.model).toBe("cliproxyapi/claude-haiku-4.5");
 
     // quick category: gpt-5.4-mini → claude-haiku-4.5 → gemini-3-flash → minimax-m2.7 → gpt-5-nano
-    expect(categories.quick.model).toBe("cliproxyapi/claude-haiku-4.5");
-    expect(categories.quick.fallback_models).toContain("cliproxyapi/gemini-3-flash");
+    const quick = categories.quick;
+    expect(quick).toBeDefined();
+    expect(quick!.model).toBe("cliproxyapi/claude-haiku-4.5");
+    expect(quick!.fallback_models).toContain("cliproxyapi/gemini-3-flash");
 
     // writing category: gemini-3-flash → kimi-k2.5 → claude-sonnet-4.6 → minimax-m2.7
-    expect(categories.writing.model).toBe("cliproxyapi/gemini-3-flash");
+    const writing = categories.writing;
+    expect(writing).toBeDefined();
+    expect(writing!.model).toBe("cliproxyapi/gemini-3-flash");
   });
 
   it("auto-generates fallback_models from chain when no override", () => {
@@ -153,12 +163,15 @@ describe("oh-my-opencode config", () => {
     expect(config).not.toBeNull();
     const typedConfig = config as Record<string, unknown>;
     const agents = typedConfig.agents as Record<string, { model: string; fallback_models?: string[] }>;
+    const sisyphus = agents.sisyphus;
 
     // sisyphus chain: claude-opus-4.6 → kimi-k2.5 → k2p5 → gpt-5.4 → glm-5 → big-pickle
-    expect(agents.sisyphus.model).toBe("cliproxyapi/claude-opus-4.6");
-    expect(agents.sisyphus.fallback_models).toContain("cliproxyapi/k2p5");
-    expect(agents.sisyphus.fallback_models).toContain("cliproxyapi/gpt-5.4");
-    expect(agents.sisyphus.fallback_models).toContain("cliproxyapi/glm-5");
+    expect(sisyphus).toBeDefined();
+    expect(sisyphus!.model).toBe("cliproxyapi/claude-opus-4.6");
+    expect(sisyphus!.fallback_models).toContain("cliproxyapi/k2p5");
+    expect(sisyphus!.fallback_models).toContain("cliproxyapi/gpt-5.4");
+    expect(sisyphus!.fallback_models).toContain("cliproxyapi/glm-5");
+
   });
 
   it("returns null when no models available", () => {
@@ -174,12 +187,14 @@ describe("oh-my-opencode config", () => {
     expect(config).not.toBeNull();
     const typedConfig = config as Record<string, unknown>;
     const agents = typedConfig.agents as Record<string, { model: string; fallback_models?: string[] }>;
+    const sisyphus = agents.sisyphus;
 
-    expect(agents.sisyphus.model).toBe("cliproxyapi/k2p5");
-    expect(agents.sisyphus.fallback_models).toContain("cliproxyapi/gpt-5.4");
-    expect(agents.sisyphus.fallback_models).toContain("cliproxyapi/glm-5");
-    expect(agents.sisyphus.fallback_models).not.toContain("cliproxyapi/claude-opus-4.6");
-    expect(agents.sisyphus.fallback_models).not.toContain("cliproxyapi/k2p5");
+    expect(sisyphus).toBeDefined();
+    expect(sisyphus!.model).toBe("cliproxyapi/k2p5");
+    expect(sisyphus!.fallback_models).toContain("cliproxyapi/gpt-5.4");
+    expect(sisyphus!.fallback_models).toContain("cliproxyapi/glm-5");
+    expect(sisyphus!.fallback_models).not.toContain("cliproxyapi/claude-opus-4.6");
+    expect(sisyphus!.fallback_models).not.toContain("cliproxyapi/k2p5");
   });
 
   it("computes category override fallback from override position", () => {
@@ -190,11 +205,13 @@ describe("oh-my-opencode config", () => {
     expect(config).not.toBeNull();
     const typedConfig = config as Record<string, unknown>;
     const categories = typedConfig.categories as Record<string, { model: string; fallback_models?: string[] }>;
+    const visualEngineering = categories["visual-engineering"];
 
-    expect(categories["visual-engineering"].model).toBe("cliproxyapi/glm-5");
-    expect(categories["visual-engineering"].fallback_models).toContain("cliproxyapi/claude-opus-4.6");
-    expect(categories["visual-engineering"].fallback_models).toContain("cliproxyapi/k2p5");
-    expect(categories["visual-engineering"].fallback_models).not.toContain("cliproxyapi/gemini-3.1-pro");
+    expect(visualEngineering).toBeDefined();
+    expect(visualEngineering!.model).toBe("cliproxyapi/glm-5");
+    expect(visualEngineering!.fallback_models).toContain("cliproxyapi/claude-opus-4.6");
+    expect(visualEngineering!.fallback_models).toContain("cliproxyapi/k2p5");
+    expect(visualEngineering!.fallback_models).not.toContain("cliproxyapi/gemini-3.1-pro");
   });
 
   it("uses no fallbacks when override model is not in chain", () => {
@@ -205,9 +222,11 @@ describe("oh-my-opencode config", () => {
     expect(config).not.toBeNull();
     const typedConfig = config as Record<string, unknown>;
     const agents = typedConfig.agents as Record<string, { model: string; fallback_models?: string[] }>;
+    const sisyphus = agents.sisyphus;
 
-    expect(agents.sisyphus.model).toBe("cliproxyapi/big-pickle");
-    expect(agents.sisyphus.fallback_models).toBeUndefined();
+    expect(sisyphus).toBeDefined();
+    expect(sisyphus!.model).toBe("cliproxyapi/big-pickle");
+    expect(sisyphus!.fallback_models).toBeUndefined();
   });
 
   it("drops ultrawork.model when ultrawork model is not available", () => {
@@ -223,10 +242,13 @@ describe("oh-my-opencode config", () => {
     expect(config).not.toBeNull();
     const typedConfig = config as Record<string, unknown>;
     const agents = typedConfig.agents as Record<string, { ultrawork?: { model?: string; variant?: string } }>;
+    const sisyphus = agents.sisyphus;
+    const ultrawork = sisyphus?.ultrawork;
 
-    expect(agents.sisyphus.ultrawork).toBeDefined();
-    expect(agents.sisyphus.ultrawork?.model).toBeUndefined();
-    expect(agents.sisyphus.ultrawork?.variant).toBe("max");
+    expect(sisyphus).toBeDefined();
+    expect(ultrawork).toBeDefined();
+    expect(ultrawork!.model).toBeUndefined();
+    expect(ultrawork!.variant).toBe("max");
   });
 
   it("prefixes ultrawork.model when ultrawork model is available", () => {
@@ -242,9 +264,13 @@ describe("oh-my-opencode config", () => {
     expect(config).not.toBeNull();
     const typedConfig = config as Record<string, unknown>;
     const agents = typedConfig.agents as Record<string, { ultrawork?: { model?: string; variant?: string } }>;
+    const sisyphus = agents.sisyphus;
+    const ultrawork = sisyphus?.ultrawork;
 
-    expect(agents.sisyphus.ultrawork?.model).toBe("cliproxyapi/gpt-5.4");
-    expect(agents.sisyphus.ultrawork?.variant).toBe("max");
+    expect(sisyphus).toBeDefined();
+    expect(ultrawork).toBeDefined();
+    expect(ultrawork!.model).toBe("cliproxyapi/gpt-5.4");
+    expect(ultrawork!.variant).toBe("max");
   });
 
   it("applyPreset does not create empty concurrency objects", () => {
@@ -342,7 +368,9 @@ describe("oh-my-opencode config", () => {
       expect(config).not.toBeNull();
       const typedConfig = config as Record<string, unknown>;
       const agents = typedConfig.agents as Record<string, { model: string }>;
-      expect(agents.sisyphus.model).toBe("cliproxyapi/k2p5");
+      const sisyphus = agents.sisyphus;
+      expect(sisyphus).toBeDefined();
+      expect(sisyphus!.model).toBe("cliproxyapi/k2p5");
     });
   });
 
@@ -410,7 +438,9 @@ describe("oh-my-opencode config", () => {
       const result = getMissingPresetModels(preset, []);
       // Only sisyphus.model is "missing", prometheus has no model to check
       expect(result).toHaveLength(1);
-      expect(result[0].model).toBe("claude-opus-4.6");
+      const [missingModel] = result;
+      expect(missingModel).toBeDefined();
+      expect(missingModel!.model).toBe("claude-opus-4.6");
     });
   });
 });

--- a/dashboard/src/lib/__tests__/oh-my-opencode-presets.test.ts
+++ b/dashboard/src/lib/__tests__/oh-my-opencode-presets.test.ts
@@ -28,11 +28,13 @@ describe("oh-my-opencode presets", () => {
     ]);
 
     expect(presets).toHaveLength(1);
-    expect(presets[0].config.agents?.hephaestus?.permission).toEqual({
+    const [preset] = presets;
+    expect(preset).toBeDefined();
+    expect(preset!.config.agents?.hephaestus?.permission).toEqual({
       edit: "allow",
       bash: { git: "allow", test: "allow" },
     });
-    expect(presets[0].config.agents?.oracle?.thinking).toEqual({
+    expect(preset!.config.agents?.oracle?.thinking).toEqual({
       type: "enabled",
       budgetTokens: 120000,
     });
@@ -86,7 +88,9 @@ describe("oh-my-opencode presets", () => {
     ] as unknown[]);
 
     expect(presets).toHaveLength(1);
-    expect(presets[0].name).toBe("valid");
+    const [preset] = presets;
+    expect(preset).toBeDefined();
+    expect(preset!.name).toBe("valid");
   });
 
   it("returns bundled presets with valid structure", () => {
@@ -121,7 +125,9 @@ describe("oh-my-opencode presets", () => {
     ]);
 
     expect(presets).toHaveLength(1);
-    expect(presets[0].config.agents?.sisyphus?.temperature).toBe(0.5);
-    expect("unknownField" in (presets[0].config.agents?.sisyphus ?? {})).toBe(false);
+    const [preset] = presets;
+    expect(preset).toBeDefined();
+    expect(preset!.config.agents?.sisyphus?.temperature).toBe(0.5);
+    expect("unknownField" in (preset!.config.agents?.sisyphus ?? {})).toBe(false);
   });
 });

--- a/dashboard/src/lib/__tests__/slim-config-chains.test.ts
+++ b/dashboard/src/lib/__tests__/slim-config-chains.test.ts
@@ -103,10 +103,13 @@ describe("buildSlimConfig – preset and global override semantics", () => {
     });
 
     const generated = expectGeneratedConfig(config);
+    const agents = generated.agents;
     // Root agents should override presets at runtime and be emitted separately.
-    expect(generated.agents).toBeDefined();
-    expect(generated.agents?.orchestrator.model).toBe("cliproxyapi/model-b");
-    expect(generated.agents?.orchestrator.variant).toBe("root");
+    expect(agents).toBeDefined();
+    const orchestrator = agents!.orchestrator;
+    expect(orchestrator).toBeDefined();
+    expect(orchestrator!.model).toBe("cliproxyapi/model-b");
+    expect(orchestrator!.variant).toBe("root");
     expect(generated.presets?.test?.orchestrator?.model).toBe("cliproxyapi/model-a");
     expect(generated.presets?.test?.orchestrator?.variant).toBe("preset");
   });
@@ -120,8 +123,14 @@ describe("buildSlimConfig – preset and global override semantics", () => {
     });
 
     const generated = expectGeneratedConfig(config);
-    expect(generated.agents?.observer.model).toBe("external/observer-model");
-    expect(generated.agents?.councillor.model).toBe("cliproxyapi/model-a");
+    const agents = generated.agents;
+    expect(agents).toBeDefined();
+    const observer = agents!.observer;
+    const councillor = agents!.councillor;
+    expect(observer).toBeDefined();
+    expect(councillor).toBeDefined();
+    expect(observer!.model).toBe("external/observer-model");
+    expect(councillor!.model).toBe("cliproxyapi/model-a");
   });
 
   it("preserves partial root overrides without inventing a new model", () => {

--- a/dashboard/src/lib/api-keys/sync.ts
+++ b/dashboard/src/lib/api-keys/sync.ts
@@ -87,10 +87,10 @@ export async function syncKeysToCliProxyApi(): Promise<SyncResult> {
     const payload = keyList;
 
     let lastError: Error | null = null;
-    const maxRetries = 3;
-    const delays = [1000, 2000, 4000];
+    const delays = [1000, 2000, 4000] as const;
+    const maxRetries = delays.length;
 
-    for (let attempt = 0; attempt < maxRetries; attempt++) {
+    for (const [attempt, delayMs] of delays.entries()) {
       try {
         const response = await fetch(`${MANAGEMENT_BASE_URL}/api-keys`, {
           method: "PUT",
@@ -113,7 +113,6 @@ export async function syncKeysToCliProxyApi(): Promise<SyncResult> {
         lastError = error instanceof Error ? error : new Error(String(error));
 
         if (attempt < maxRetries - 1) {
-          const delayMs = delays[attempt];
           logger.warn(
             { attempt: attempt + 1, delayMs, error: lastError.message },
             "Sync attempt failed, retrying"

--- a/dashboard/src/lib/auth/session.ts
+++ b/dashboard/src/lib/auth/session.ts
@@ -13,6 +13,7 @@ function parseExpiry(expiresIn: string): number {
   const [, valueText, unit] = match;
   if (!valueText || !unit) return DEFAULT_EXPIRY_MS;
   const value = parseInt(valueText, 10);
+  if (!Number.isFinite(value) || value <= 0) return DEFAULT_EXPIRY_MS;
   switch (unit) {
     case "s": return value * 1000;
     case "m": return value * 60 * 1000;

--- a/dashboard/src/lib/auth/session.ts
+++ b/dashboard/src/lib/auth/session.ts
@@ -10,9 +10,9 @@ const DEFAULT_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 function parseExpiry(expiresIn: string): number {
   const match = expiresIn.match(/^(\d+)([smhd])$/);
   if (!match) return DEFAULT_EXPIRY_MS;
-  const value = parseInt(match[1], 10);
-  if (!Number.isFinite(value) || value <= 0) return DEFAULT_EXPIRY_MS;
-  const unit = match[2];
+  const [, valueText, unit] = match;
+  if (!valueText || !unit) return DEFAULT_EXPIRY_MS;
+  const value = parseInt(valueText, 10);
   switch (unit) {
     case "s": return value * 1000;
     case "m": return value * 60 * 1000;

--- a/dashboard/src/lib/backup/export-import.ts
+++ b/dashboard/src/lib/backup/export-import.ts
@@ -245,7 +245,9 @@ export async function exportDatabase(exportedBy: string): Promise<BackupData> {
         createdAt: al.createdAt.toISOString(),
       });
     }
-    auditCursor = chunk[chunk.length - 1].id;
+    const lastAuditLog = chunk[chunk.length - 1];
+    if (!lastAuditLog) break;
+    auditCursor = lastAuditLog.id;
     if (chunk.length < EXPORT_CHUNK_SIZE) break;
   }
   modelCounts.auditLogs = backupAuditLogs.length;
@@ -279,7 +281,9 @@ export async function exportDatabase(exportedBy: string): Promise<BackupData> {
         collectedAt: ur.collectedAt.toISOString(),
       });
     }
-    usageCursor = chunk[chunk.length - 1].id;
+    const lastUsageRecord = chunk[chunk.length - 1];
+    if (!lastUsageRecord) break;
+    usageCursor = lastUsageRecord.id;
     if (chunk.length < EXPORT_CHUNK_SIZE) break;
   }
   modelCounts.usageRecords = backupUsageRecords.length;

--- a/dashboard/src/lib/config-generators/opencode.ts
+++ b/dashboard/src/lib/config-generators/opencode.ts
@@ -193,6 +193,7 @@ function deduplicateProxyModels(proxyModels: ProxyModel[]): ProxyModel[] {
     const dateMatch = id.match(/^(.+)-\d{8}$/);
     if (dateMatch) {
       const base = dateMatch[1];
+      if (base === undefined) return true;
       if (idSet.has(base)) return false;
       // Also check if dot-notation of the base exists
       // e.g. claude-opus-4-1-20250805 -> base claude-opus-4-1 -> check claude-opus-4.1

--- a/dashboard/src/lib/config-sync/generate-bundle.ts
+++ b/dashboard/src/lib/config-sync/generate-bundle.ts
@@ -288,7 +288,8 @@ export async function generateConfigBundle(userId: string, syncApiKey?: string |
       resolvedSyncApiKey = syncKeyRecord.key;
     }
 
-   const apiKey = resolvedSyncApiKey || userApiKey?.key || (apiKeyStrings.length > 0 ? apiKeyStrings[0] : "no-api-key-create-one-in-dashboard");
+   const [firstApiKey] = apiKeyStrings;
+   const apiKey = resolvedSyncApiKey || userApiKey?.key || (firstApiKey !== undefined ? firstApiKey : "no-api-key-create-one-in-dashboard");
 
    const usedApiKeyId = resolvedSyncApiKey ? syncApiKey : userApiKey?.id;
    if (usedApiKeyId) {
@@ -334,6 +335,7 @@ export async function generateConfigBundle(userId: string, syncApiKey?: string |
    const sortedFilteredIds = Object.keys(filteredModels).sort();
    for (const id of sortedFilteredIds) {
      const def = filteredModels[id];
+     if (!def) continue;
      const entry: Record<string, unknown> = {
        name: def.name,
        attachment: def.attachment,

--- a/dashboard/src/lib/fetch-utils.ts
+++ b/dashboard/src/lib/fetch-utils.ts
@@ -55,7 +55,8 @@ export async function fetchWithRetry(
       }
 
       // Wait before retry
-      await sleep(RETRY_DELAYS[i]);
+      const retryDelay = RETRY_DELAYS[i] ?? 0;
+      await sleep(retryDelay);
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
 
@@ -65,7 +66,8 @@ export async function fetchWithRetry(
       }
 
       // Wait before retry
-      await sleep(RETRY_DELAYS[i]);
+      const retryDelay = RETRY_DELAYS[i] ?? 0;
+      await sleep(retryDelay);
     }
   }
 

--- a/dashboard/src/lib/log-storage.ts
+++ b/dashboard/src/lib/log-storage.ts
@@ -117,9 +117,9 @@ function loadLogsFromFile(): void {
     const lines = content.trim().split("\n").filter(Boolean);
 
     const startIndex = Math.max(0, lines.length - MAX_MEMORY_LOGS);
-    for (let i = startIndex; i < lines.length; i++) {
+    for (const line of lines.slice(startIndex)) {
       try {
-        const entry = JSON.parse(lines[i]) as LogEntry;
+        const entry = JSON.parse(line) as LogEntry;
         if (!entry.levelLabel && entry.level) {
           entry.levelLabel = LEVEL_LABELS[entry.level] ?? "unknown";
         }

--- a/dashboard/src/lib/model-first-monitoring.ts
+++ b/dashboard/src/lib/model-first-monitoring.ts
@@ -134,7 +134,10 @@ function median(values: number[]): number | null {
   const sorted = [...values].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
   if (sorted.length % 2 === 0) {
-    return (sorted[mid - 1] + sorted[mid]) / 2;
+    const lower = sorted[mid - 1];
+    const upper = sorted[mid];
+    if (lower === undefined || upper === undefined) return null;
+    return (lower + upper) / 2;
   }
   return sorted[mid] ?? null;
 }

--- a/dashboard/src/lib/model-pricing.ts
+++ b/dashboard/src/lib/model-pricing.ts
@@ -173,7 +173,9 @@ export function resolveModelPrice(model: string, customPricing?: Record<string, 
   // Prefix match: try progressively shorter prefixes
   const keys = Object.keys(merged).sort((a, b) => b.length - a.length);
   for (const key of keys) {
-    if (lowerModel.startsWith(key)) return merged[key];
+    const matchedPrice = merged[key];
+    if (!matchedPrice) continue;
+    if (lowerModel.startsWith(key)) return matchedPrice;
   }
 
   // Try matching without provider prefix (e.g. "cliproxyapi/sonar-pro" → "sonar-pro")
@@ -181,7 +183,9 @@ export function resolveModelPrice(model: string, customPricing?: Record<string, 
   if (withoutPrefix) {
     if (merged[withoutPrefix]) return merged[withoutPrefix];
     for (const key of keys) {
-      if (withoutPrefix.startsWith(key)) return merged[key];
+      const matchedPrice = merged[key];
+      if (!matchedPrice) continue;
+      if (withoutPrefix.startsWith(key)) return matchedPrice;
     }
   }
 

--- a/dashboard/src/lib/providers/cascade.ts
+++ b/dashboard/src/lib/providers/cascade.ts
@@ -37,26 +37,36 @@ export async function cascadeDeleteUserProviders(
       select: { keyHash: true, provider: true },
     });
 
-    const keyResults = await Promise.allSettled(
+    const keyResults = await Promise.all(
       ownedKeys.map(async (key) => {
-        const removeResult = await removeKey(userId, key.keyHash, isAdmin);
-        if (!removeResult.ok) {
-          throw new Error(`Failed to remove ${key.provider} key ${key.keyHash}: ${removeResult.error}`);
+        try {
+          const removeResult = await removeKey(userId, key.keyHash, isAdmin);
+          if (!removeResult.ok) {
+            return {
+              ok: false as const,
+              error: `Failed to remove ${key.provider} key ${key.keyHash}: ${removeResult.error}`,
+              key,
+            };
+          }
+
+          return { ok: true as const, key };
+        } catch (error) {
+          return {
+            ok: false as const,
+            error: error instanceof Error ? error.message : `Failed to remove ${key.provider} key ${key.keyHash}`,
+            key,
+          };
         }
-        return key;
       })
     );
 
-    for (let i = 0; i < keyResults.length; i++) {
-      const settled = keyResults[i];
-      if (settled.status === "fulfilled") {
+    for (const keyResult of keyResults) {
+      if (keyResult.ok) {
         result.keysRemoved++;
       } else {
         result.keysFailedToRemove++;
-        const key = ownedKeys[i];
-        const errorMsg = settled.reason instanceof Error ? settled.reason.message : `Failed to remove ${key.provider} key ${key.keyHash}`;
-        result.errors.push(errorMsg);
-        logger.error({ provider: key.provider, keyHash: key.keyHash, error: errorMsg }, "Failed to remove provider key");
+        result.errors.push(keyResult.error);
+        logger.error({ provider: keyResult.key.provider, keyHash: keyResult.key.keyHash, error: keyResult.error }, "Failed to remove provider key");
       }
     }
 
@@ -65,26 +75,36 @@ export async function cascadeDeleteUserProviders(
       select: { accountName: true, provider: true },
     });
 
-    const oauthResults = await Promise.allSettled(
+    const oauthResults = await Promise.all(
       ownedOAuth.map(async (oauth) => {
-        const removeResult = await removeOAuthAccount(userId, oauth.accountName, isAdmin);
-        if (!removeResult.ok) {
-          throw new Error(`Failed to remove ${oauth.provider} OAuth account ${oauth.accountName}: ${removeResult.error}`);
+        try {
+          const removeResult = await removeOAuthAccount(userId, oauth.accountName, isAdmin);
+          if (!removeResult.ok) {
+            return {
+              ok: false as const,
+              error: `Failed to remove ${oauth.provider} OAuth account ${oauth.accountName}: ${removeResult.error}`,
+              oauth,
+            };
+          }
+
+          return { ok: true as const, oauth };
+        } catch (error) {
+          return {
+            ok: false as const,
+            error: error instanceof Error ? error.message : `Failed to remove ${oauth.provider} OAuth account ${oauth.accountName}`,
+            oauth,
+          };
         }
-        return oauth;
       })
     );
 
-    for (let i = 0; i < oauthResults.length; i++) {
-      const settled = oauthResults[i];
-      if (settled.status === "fulfilled") {
+    for (const oauthResult of oauthResults) {
+      if (oauthResult.ok) {
         result.oauthRemoved++;
       } else {
         result.oauthFailedToRemove++;
-        const oauth = ownedOAuth[i];
-        const errorMsg = settled.reason instanceof Error ? settled.reason.message : `Failed to remove ${oauth.provider} OAuth account ${oauth.accountName}`;
-        result.errors.push(errorMsg);
-        logger.error({ provider: oauth.provider, accountName: oauth.accountName, error: errorMsg }, "Failed to remove OAuth account");
+        result.errors.push(oauthResult.error);
+        logger.error({ provider: oauthResult.oauth.provider, accountName: oauthResult.oauth.accountName, error: oauthResult.error }, "Failed to remove OAuth account");
       }
     }
 

--- a/dashboard/src/lib/providers/oauth-ops.ts
+++ b/dashboard/src/lib/providers/oauth-ops.ts
@@ -189,7 +189,7 @@ export async function importOAuthCredential(
           return fileProvider === provider.toLowerCase();
         });
         if (providerMatches.length === 1) {
-          fallbackFile = providerMatches[0];
+          fallbackFile = providerMatches[0] ?? null;
         }
       }
 

--- a/dashboard/src/lib/share-code.ts
+++ b/dashboard/src/lib/share-code.ts
@@ -30,8 +30,8 @@ export function generateShareCode(): string {
   crypto.getRandomValues(bytes);
 
   let code = "";
-  for (let i = 0; i < 8; i++) {
-    const index = bytes[i] % SHARE_CODE_ALPHABET.length;
+  for (const byte of bytes) {
+    const index = byte % SHARE_CODE_ALPHABET.length;
     code += SHARE_CODE_ALPHABET[index];
   }
 

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
Cherry-pick of #200 onto `main` (that PR targeted `fix/issue-197-local-providers`, now merged).

## What this does
Enables `noUncheckedIndexedAccess: true` in `dashboard/tsconfig.json` and fixes every resulting error by narrowing at the point of access — no casts, no suppressions, no weakened types.

## Commits
1. **`chore(ts): enable noUncheckedIndexedAccess and fix 142 resulting errors`** — flag on, 36 source files narrowed, 4 test files use `expect(x).toBeDefined()` + `!`
2. **`fix(review): restore behavior regressions from noUncheckedIndexedAccess pass`** — three issues the reviewer caught on the first round:
   - `lib/auth/session.ts`: restored `!Number.isFinite(v) \|\| v <= 0` fallback in `parseExpiry`
   - `api/containers/list/route.ts`: switched `return Errors.internal` back to `continue + warn` (one bad line no longer 500s the whole list)
   - `api/custom-providers/fetch-models/route.ts`: flipped SSRF guard `return false` → `return true` so the fail-direction is closed
3. **`fix(review): make updateOAuthAliasEntry exhaustive over keyof OAuthModelAliasEntry`** — replaced trailing `else` (which hardcoded `_id`) with a `switch` + `never` default; adding a new field is now a compile error at the call site.

## Verification (on `main`)
| Gate | Result |
|---|---|
| `tsc --noEmit` | 0 errors |
| `eslint` | 0 warnings/errors |
| `vitest run` | 190/190 passed, 21 files |
| `next build` | Compiled successfully |

## Contract audit
- 0 new `any`, `as any`, `as unknown as`, `@ts-ignore`, `@ts-expect-error`
- 0 new non-null assertions outside test fixtures (all `!` sites follow `expect(x).toBeDefined()` in `__tests__/*.test.ts`)

## Not included (intentional)
`exactOptionalPropertyTypes`, `noPropertyAccessFromIndexSignature`, `noImplicitOverride`, `noFallthroughCasesInSwitch` — each its own cutover; bundling would turn one reviewable change into an unreviewable one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many dashboard API/UI code paths to add defensive checks required by `noUncheckedIndexedAccess`, with a few subtle behavior changes (e.g., container listing now skips malformed `docker ps` lines and SSRF guard fails closed on unparseable IPv6-mapped addresses). Overall risk is moderate due to broad surface area, but changes are largely null/undefined handling and type narrowing.
> 
> **Overview**
> Enables TypeScript `noUncheckedIndexedAccess` in `dashboard/tsconfig.json` and updates API routes, UI components, and config generators to **narrow/guard all index-based access** (array destructuring, regex groups, map entries) to avoid implicit `undefined`.
> 
> Includes a few targeted behavior hardenings: container APIs now return `notFound` when a container name lacks `CONTAINER_CONFIG`, container listing logs-and-skips malformed `docker ps` output instead of failing the whole request, and the custom-provider SSRF checks treat unparseable IPv6-mapped addresses as private (*fail closed*). Tests were adjusted to assert presence before non-null assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e265117ec5219258c06385234a7cf26e2f63a6a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->