### PR TITLE
fix(oauth-ui): Add bulk cooldown clear action

### DIFF
--- a/dashboard/src/components/providers/oauth-credential-list.tsx
+++ b/dashboard/src/components/providers/oauth-credential-list.tsx
@@ -47,6 +47,7 @@ interface OAuthCredentialListProps {
   onForceSuspend: (authId: string, groupId: string) => void;
   onLiftManual: (authId: string, groupId: string) => void;
   onClearCooldown: (authId: string, groupId: string) => void;
+  onClearAllCooldowns: (authId: string) => void;
 }
 
 function parseStatusMessage(raw: string | null): string | null {
@@ -123,6 +124,7 @@ export function OAuthCredentialList({
   onForceSuspend,
   onLiftManual,
   onClearCooldown,
+  onClearAllCooldowns,
 }: OAuthCredentialListProps) {
   const t = useTranslations("providers");
   const [expandedAccounts, setExpandedAccounts] = useState<Record<string, boolean>>({});
@@ -150,7 +152,13 @@ export function OAuthCredentialList({
         </div>
       ) : (
         <div className="divide-y divide-[var(--surface-border)] rounded-md border border-[var(--surface-border)] bg-[var(--surface-base)]">
-          {accounts.map((account) => (
+          {accounts.map((account) => {
+            const hasAnyAutoCooldown =
+              Array.isArray(account.quotaGroups) &&
+              account.quotaGroups.some((group) => Boolean(group.autoSuspendedUntil));
+            const bulkClearActionKey = account.authId ? `${account.authId}:auto-clear-all` : null;
+
+            return (
             <div key={account.id} className="group p-3">
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0 flex-1 space-y-2">
@@ -177,6 +185,16 @@ export function OAuthCredentialList({
                 </div>
                 {currentUser && (account.isOwn || currentUser.isAdmin) && (
                   <div className="flex shrink-0 items-center gap-2">
+                    {currentUser.isAdmin && account.authId && hasAnyAutoCooldown && (
+                      <Button
+                        variant="secondary"
+                        className="px-2.5 py-1 text-xs"
+                        disabled={quotaActionKey === bulkClearActionKey}
+                        onClick={() => onClearAllCooldowns(account.authId as string)}
+                      >
+                        {quotaActionKey === bulkClearActionKey ? "..." : "Clear all cooldowns"}
+                      </Button>
+                    )}
                     {currentUser.isAdmin && !account.ownerUsername && (
                       <Button
                         variant="secondary"
@@ -208,7 +226,7 @@ export function OAuthCredentialList({
               {expandedAccounts[account.id] && Array.isArray(account.quotaGroups) && account.quotaGroups.length > 0 && (
                 <div className="mt-3 space-y-2 rounded-md border border-[var(--surface-border)] bg-[var(--surface-muted)]/20 p-3">
                   {account.quotaGroups.map((group) => {
-                    const actionBase = `${account.id}:${group.groupId}`;
+                    const actionBase = `${account.authId ?? account.id}:${group.groupId}`;
                     const isManual = group.manualSuspended;
                     const hasAuto = Boolean(group.autoSuspendedUntil);
                     return (
@@ -278,7 +296,8 @@ export function OAuthCredentialList({
                 </div>
               )}
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </>

--- a/dashboard/src/components/providers/oauth-section.tsx
+++ b/dashboard/src/components/providers/oauth-section.tsx
@@ -395,6 +395,32 @@ export function OAuthSection({
     }
   };
 
+  const clearAllQuotaGroupCooldowns = async (authId: string) => {
+    const actionKey = `${authId}:auto-clear-all`;
+    setQuotaActionKey(actionKey);
+    try {
+      const res = await fetch(API_ENDPOINTS.MANAGEMENT.AUTH_FILE_QUOTA_GROUPS_AUTO_CLEAR, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          auth_id: authId,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        showToast(extractApiError(data, "Failed to clear quota cooldowns"), "error");
+        return;
+      }
+      showToast("All quota cooldowns cleared", "success");
+      await loadAccounts();
+      await refreshProviders();
+    } catch {
+      showToast(t("toastNetworkError"), "error");
+    } finally {
+      setQuotaActionKey(null);
+    }
+  };
+
   const openAuthPopup = (url: string) => {
     const popup = window.open(url, "oauth", "width=600,height=800");
     return popup !== null;
@@ -990,6 +1016,7 @@ export function OAuthSection({
             onForceSuspend={(authId, groupId) => void updateQuotaGroupManual(authId, groupId, true)}
             onLiftManual={(authId, groupId) => void updateQuotaGroupManual(authId, groupId, false)}
             onClearCooldown={(authId, groupId) => void clearQuotaGroupCooldown(authId, groupId)}
+            onClearAllCooldowns={(authId) => void clearAllQuotaGroupCooldowns(authId)}
           />
 
           <div className="rounded-sm border border-[var(--surface-border)] bg-[var(--surface-base)] p-3 text-xs text-[var(--text-muted)]">


### PR DESCRIPTION
Add an account-level action for clearing all OAuth auto cooldowns.

When an upstream quota resets earlier than the stored cooldown window, operators
currently have to clear each quota group one by one. This adds a single action
on the account card that calls the new backend bulk-clear path.

The existing per-group controls stay in place, and the bulk action only appears
when the account actually has active auto cooldowns.