### PR TITLE
feat(custom-providers): allow admins to share custom providers globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Open **http://localhost:3000** → create admin account → done.
 
 - **Visual Configuration** — Manage CLIProxyAPIPlus settings through structured forms, no YAML editing
 - **Multi-Provider OAuth** — Connect Claude, Gemini, Codex, Copilot, Kiro, Antigravity, iFlow, Kimi, and Qwen accounts
-- **Custom Providers** — Add any OpenAI-compatible endpoint (OpenRouter, Ollama, etc.) with model mappings
+- **Custom Providers** — Add any OpenAI-compatible endpoint (OpenRouter, Ollama, etc.) with model mappings; admins can mark a provider as **Shared** so all team members see and use it
 - **API Key Management** — Create, revoke, and track API keys with per-user ownership
 - **Real-time Monitoring** — Live log streaming, container health, and service management
 - **Quota Tracking** — Rate limits and usage per provider (Claude, Codex, Kimi, Antigravity)

--- a/dashboard/messages/de.json
+++ b/dashboard/messages/de.json
@@ -677,7 +677,12 @@
     "gitlabSavePat": "Token speichern",
     "gitlabClientIdRequired": "OAuth Client-ID ist erforderlich.",
     "gitlabPatRequired": "Personal Access Token ist erforderlich.",
-    "gitlabPatFailed": "Authentifizierung mit dem angegebenen Token fehlgeschlagen."
+    "gitlabPatFailed": "Authentifizierung mit dem angegebenen Token fehlgeschlagen.",
+    "shareLabel": "Mit allen Benutzern teilen",
+    "shareDescription": "Diesen Provider für alle Dashboard-Benutzer sichtbar und nutzbar machen. Nur Administratoren können diese Einstellung ändern.",
+    "sharedBadge": "Geteilt",
+    "sharedOwnerLabel": "Eigentümer: {username}",
+    "sharedReadOnlyTooltip": "Geteilte Provider können nur vom Eigentümer oder einem Administrator bearbeitet werden."
   },
   "quota": {
     "pageTitle": "Kontingent-Verwaltung",

--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -677,7 +677,12 @@
     "gitlabSavePat": "Save Token",
     "gitlabClientIdRequired": "OAuth Client ID is required.",
     "gitlabPatRequired": "Personal Access Token is required.",
-    "gitlabPatFailed": "Failed to authenticate with the provided token."
+    "gitlabPatFailed": "Failed to authenticate with the provided token.",
+    "shareLabel": "Share with all users",
+    "shareDescription": "Make this provider visible and usable for every dashboard user. Only administrators can change this.",
+    "sharedBadge": "Shared",
+    "sharedOwnerLabel": "Owner: {username}",
+    "sharedReadOnlyTooltip": "Shared providers can only be edited by their owner or an administrator."
   },
   "quota": {
     "pageTitle": "Quota Management",

--- a/dashboard/prisma/migrations/20260429000000_custom_provider_is_shared/migration.sql
+++ b/dashboard/prisma/migrations/20260429000000_custom_provider_is_shared/migration.sql
@@ -1,0 +1,9 @@
+-- Add isShared flag so admins can mark a custom provider as visible to all users.
+-- Existing rows default to private (false), preserving prior behavior.
+ALTER TABLE "custom_providers"
+  ADD COLUMN IF NOT EXISTS "isShared" BOOLEAN NOT NULL DEFAULT false;
+
+-- Index supports the OR-filter used by GET /api/custom-providers and the
+-- config-sync bundle generator.
+CREATE INDEX IF NOT EXISTS "custom_providers_isShared_idx"
+  ON "custom_providers" ("isShared");

--- a/dashboard/prisma/schema.prisma
+++ b/dashboard/prisma/schema.prisma
@@ -180,6 +180,7 @@ model CustomProvider {
   proxyUrl    String?                   // Optional SOCKS5/HTTP proxy
   headers     Json?     @default("{}")  // Custom headers JSON
   createdAt   DateTime @default(now())
+  isShared    Boolean  @default(false) // Admin-shared providers are visible to all users
   updatedAt   DateTime @updatedAt
   
   user           User                          @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -188,6 +189,7 @@ model CustomProvider {
   excludedModels CustomProviderExcludedModel[]
   
   @@index([userId])
+  @@index([isShared])
   @@index([groupId])
   @@index([providerId])
   @@map("custom_providers")

--- a/dashboard/src/app/api/custom-providers/[id]/route.shared.test.ts
+++ b/dashboard/src/app/api/custom-providers/[id]/route.shared.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    ALLOW_LOCAL_PROVIDER_URLS: false,
+    DATABASE_URL: "postgres://",
+    JWT_SECRET: "x",
+    MANAGEMENT_API_KEY: "x",
+    CLIPROXYAPI_MANAGEMENT_URL: "http://proxy/v0/management",
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  verifySession: vi.fn(() => ({ userId: "user-1", username: "alice", sessionVersion: 0 })),
+}));
+
+vi.mock("@/lib/auth/origin", () => ({ validateOrigin: vi.fn(() => null) }));
+
+vi.mock("@/lib/audit", () => ({
+  AUDIT_ACTION: { CUSTOM_PROVIDER_UPDATED: "x", CUSTOM_PROVIDER_DELETED: "y" },
+  extractIpAddress: vi.fn(() => "127.0.0.1"),
+  logAuditAsync: vi.fn(),
+}));
+
+vi.mock("@/lib/cache", () => ({ invalidateProxyModelsCache: vi.fn() }));
+vi.mock("@/lib/providers/hash", () => ({ hashProviderKey: vi.fn(() => "hash") }));
+vi.mock("@/lib/providers/encrypt", () => ({
+  encryptProviderKey: vi.fn(() => "enc"),
+  decryptProviderKey: vi.fn(() => "decrypted"),
+}));
+vi.mock("@/lib/providers/custom-provider-sync", () => ({
+  syncCustomProviderToProxy: vi.fn(async () => ({ syncStatus: "ok" as const, syncMessage: "" })),
+}));
+
+const adminMock = vi.fn<(userId?: string) => Promise<boolean>>(async () => false);
+vi.mock("@/lib/auth/admin", () => ({
+  isUserAdmin: (userId: string) => adminMock(userId),
+}));
+
+const findUniqueMock = vi.fn<(arg?: unknown) => unknown>();
+const findFirstMock = vi.fn<(arg?: unknown) => unknown>();
+const updateMock = vi.fn<(arg?: unknown) => unknown>();
+const deleteMock = vi.fn<(arg?: unknown) => unknown>();
+const txUpdate = vi.fn<(arg?: unknown) => unknown>();
+const txDeleteMany = vi.fn<(arg?: unknown) => unknown>();
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    customProvider: {
+      findUnique: (arg?: unknown) => findUniqueMock(arg),
+      findFirst: (arg?: unknown) => findFirstMock(arg),
+      update: (arg?: unknown) => updateMock(arg),
+      delete: (arg?: unknown) => deleteMock(arg),
+    },
+    providerGroup: { findFirst: vi.fn() },
+    $transaction: vi.fn(async (cb: unknown) => {
+      const fn = cb as (tx: unknown) => Promise<unknown>;
+      return fn({
+        customProviderModel: { deleteMany: txDeleteMany },
+        customProviderExcludedModel: { deleteMany: txDeleteMany },
+        customProvider: { update: txUpdate },
+      });
+    }),
+  },
+}));
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+function buildPatch(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/custom-providers/p1", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const baseProvider = {
+  id: "p1",
+  userId: "user-2", // Owned by someone else
+  name: "z.ai",
+  providerId: "zai",
+  baseUrl: "https://api.z.ai",
+  prefix: null,
+  proxyUrl: null,
+  groupId: null,
+  headers: {},
+  apiKeyHash: "hash",
+  apiKeyEncrypted: "enc",
+  isShared: true,
+  models: [],
+  excludedModels: [],
+};
+
+describe("PATCH /api/custom-providers/[id] (shared admin gate)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adminMock.mockResolvedValue(false);
+    findUniqueMock.mockResolvedValue(baseProvider);
+    txUpdate.mockResolvedValue({ ...baseProvider, models: [], excludedModels: [] });
+  });
+
+  async function callPatch(body: unknown) {
+    const { PATCH } = await import("./route");
+    return PATCH(buildPatch(body), {
+      params: Promise.resolve({ id: "p1" }),
+    });
+  }
+
+  it("rejects non-owner non-admin with 403", async () => {
+    const res = await callPatch({ name: "renamed" });
+    expect(res.status).toBe(403);
+    expect(txUpdate).not.toHaveBeenCalled();
+  });
+
+  it("allows admin to edit a shared provider owned by someone else", async () => {
+    adminMock.mockResolvedValue(true);
+    const res = await callPatch({ name: "renamed-by-admin" });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects non-admin attempting to flip isShared", async () => {
+    findUniqueMock.mockResolvedValue({ ...baseProvider, userId: "user-1", isShared: false });
+    const res = await callPatch({ isShared: true });
+    expect(res.status).toBe(403);
+    expect(txUpdate).not.toHaveBeenCalled();
+  });
+
+  it("allows admin to flip isShared", async () => {
+    adminMock.mockResolvedValue(true);
+    findUniqueMock.mockResolvedValue({ ...baseProvider, userId: "user-1", isShared: false });
+    const res = await callPatch({ isShared: true });
+    expect(res.status).toBe(200);
+    const updateArg = txUpdate.mock.calls[0]?.[0] as { data: { isShared?: boolean } };
+    expect(updateArg.data.isShared).toBe(true);
+  });
+
+  it("ignores isShared when value matches existing flag (no admin needed)", async () => {
+    findUniqueMock.mockResolvedValue({ ...baseProvider, userId: "user-1", isShared: false });
+    const res = await callPatch({ isShared: false });
+    expect(res.status).toBe(200);
+  });
+});

--- a/dashboard/src/app/api/custom-providers/[id]/route.ts
+++ b/dashboard/src/app/api/custom-providers/[id]/route.ts
@@ -11,6 +11,7 @@ import { env } from "@/lib/env";
 import { logger } from "@/lib/logger";
 import { syncCustomProviderToProxy } from "@/lib/providers/custom-provider-sync";
 import { Errors, apiSuccess } from "@/lib/errors";
+import { isUserAdmin } from "@/lib/auth/admin";
 
 const FETCH_TIMEOUT_MS = 10_000;
 
@@ -36,7 +37,8 @@ const UpdateCustomProviderSchema = z.object({
     upstreamName: z.string().min(1),
     alias: z.string().min(1)
   })).min(1, "At least one model mapping is required").optional(),
-  excludedModels: z.array(z.string()).optional()
+  excludedModels: z.array(z.string()).optional(),
+  isShared: z.boolean().optional()
 });
 
 interface ManagementApiKeyEntry {
@@ -79,14 +81,21 @@ export async function PATCH(
       return Errors.notFound("Provider");
     }
 
-    if (existingProvider.userId !== session.userId) {
+    const isAdmin = await isUserAdmin(session.userId);
+    const isOwner = existingProvider.userId === session.userId;
+
+    if (!isOwner && !isAdmin) {
+      return Errors.forbidden();
+    }
+
+    if (validated.isShared !== undefined && validated.isShared !== existingProvider.isShared && !isAdmin) {
       return Errors.forbidden();
     }
 
     if (validated.name) {
       const nameConflict = await prisma.customProvider.findFirst({
         where: {
-          userId: session.userId,
+          userId: existingProvider.userId,
           name: validated.name,
           id: { not: id }
         }
@@ -99,7 +108,7 @@ export async function PATCH(
 
     if (validated.groupId !== undefined && validated.groupId !== null) {
       const groupExists = await prisma.providerGroup.findFirst({
-        where: { id: validated.groupId, userId: session.userId },
+        where: { id: validated.groupId, userId: existingProvider.userId },
         select: { id: true },
       });
       if (!groupExists) {
@@ -132,6 +141,7 @@ export async function PATCH(
           prefix: validated.prefix,
           proxyUrl: validated.proxyUrl,
           groupId: validated.groupId,
+          ...(validated.isShared !== undefined ? { isShared: validated.isShared } : {}),
           headers: validated.headers ? (validated.headers as Record<string, string>) : undefined,
           models: validated.models ? {
             create: validated.models.map(m => ({
@@ -274,7 +284,10 @@ export async function DELETE(
       return Errors.notFound("Provider");
     }
 
-    if (existingProvider.userId !== session.userId) {
+    const isAdmin = await isUserAdmin(session.userId);
+    const isOwner = existingProvider.userId === session.userId;
+
+    if (!isOwner && !isAdmin) {
       return Errors.forbidden();
     }
 

--- a/dashboard/src/app/api/custom-providers/[id]/route.ts
+++ b/dashboard/src/app/api/custom-providers/[id]/route.ts
@@ -84,6 +84,12 @@ export async function PATCH(
     const isAdmin = await isUserAdmin(session.userId);
     const isOwner = existingProvider.userId === session.userId;
 
+    // Admins can edit any custom provider (shared or private), matching the
+    // existing OAuth admin convention in `lib/providers/oauth-ops.ts` where
+    // `isAdmin` bypasses ownership checks. This supports operational cleanup
+    // (stale users, broken configs) without requiring a separate admin tool.
+    // Cross-owner admin edits are recorded in the audit log via `actedAsAdmin`
+    // and `ownerUserId` metadata below.
     if (!isOwner && !isAdmin) {
       return Errors.forbidden();
     }
@@ -289,6 +295,9 @@ export async function DELETE(
     const isAdmin = await isUserAdmin(session.userId);
     const isOwner = existingProvider.userId === session.userId;
 
+    // Admins can delete any custom provider (shared or private), matching
+    // the existing OAuth admin convention. The audit log records ownerUserId
+    // and actedAsAdmin so cross-owner deletions are traceable.
     if (!isOwner && !isAdmin) {
       return Errors.forbidden();
     }

--- a/dashboard/src/app/api/custom-providers/[id]/route.ts
+++ b/dashboard/src/app/api/custom-providers/[id]/route.ts
@@ -248,6 +248,8 @@ export async function PATCH(
         providerId: id,
         name: provider.name,
         updatedFields: Object.keys(validated),
+        ownerUserId: existingProvider.userId,
+        actedAsAdmin: !isOwner,
       },
       ipAddress: extractIpAddress(request),
     });
@@ -302,6 +304,8 @@ export async function DELETE(
       metadata: {
         deletedProviderId: id,
         name: existingProvider.name,
+        ownerUserId: existingProvider.userId,
+        actedAsAdmin: !isOwner,
       },
       ipAddress: extractIpAddress(request),
     });

--- a/dashboard/src/app/api/custom-providers/reorder/route.shared.test.ts
+++ b/dashboard/src/app/api/custom-providers/reorder/route.shared.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    ALLOW_LOCAL_PROVIDER_URLS: false,
+    DATABASE_URL: "postgres://",
+    JWT_SECRET: "x",
+    MANAGEMENT_API_KEY: "x",
+    CLIPROXYAPI_MANAGEMENT_URL: "http://proxy/v0/management",
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  verifySession: vi.fn(() => ({ userId: "user-1", username: "alice", sessionVersion: 0 })),
+}));
+
+vi.mock("@/lib/auth/origin", () => ({ validateOrigin: vi.fn(() => null) }));
+
+vi.mock("@/lib/audit", () => ({
+  AUDIT_ACTION: { CUSTOM_PROVIDER_REORDERED: "x" },
+  extractIpAddress: vi.fn(() => "127.0.0.1"),
+  logAuditAsync: vi.fn(),
+}));
+
+vi.mock("@/lib/cache", () => ({ invalidateProxyModelsCache: vi.fn() }));
+
+const adminMock = vi.fn<(userId?: string) => Promise<boolean>>(async () => false);
+vi.mock("@/lib/auth/admin", () => ({
+  isUserAdmin: (userId: string) => adminMock(userId),
+}));
+
+const findManyMock = vi.fn<(arg?: unknown) => unknown>();
+const txMock = vi.fn<(ops: unknown) => Promise<unknown>>(async () => undefined);
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    customProvider: {
+      findMany: (arg?: unknown) => findManyMock(arg),
+      update: vi.fn(() => ({})),
+    },
+    $transaction: (ops: unknown) => txMock(ops),
+  },
+}));
+
+const fetchMock = vi.fn(async () => new Response(JSON.stringify({ "openai-compatibility": [] }), { status: 200 }));
+vi.stubGlobal("fetch", fetchMock);
+
+function buildRequest(providerIds: string[]): NextRequest {
+  return new NextRequest("http://localhost/api/custom-providers/reorder", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ providerIds }),
+  });
+}
+
+describe("PUT /api/custom-providers/reorder (shared/admin scope)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adminMock.mockResolvedValue(false);
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ "openai-compatibility": [] }), { status: 200 })
+    );
+  });
+
+  async function callPut(ids: string[]) {
+    const { PUT } = await import("./route");
+    return PUT(buildRequest(ids));
+  }
+
+  it("queries only the viewer's own providers when not admin", async () => {
+    findManyMock.mockResolvedValue([
+      { id: "p1", providerId: "a", userId: "user-1", isShared: false },
+    ]);
+    const res = await callPut(["p1"]);
+    expect(res.status).toBe(200);
+    const arg = findManyMock.mock.calls[0]?.[0] as { where: { OR?: unknown[] } };
+    expect(arg.where.OR).toEqual([
+      { userId: "user-1" },
+      { isShared: true },
+    ]);
+  });
+
+  it("rejects 403 when a non-admin includes a shared provider owned by someone else", async () => {
+    findManyMock.mockResolvedValue([
+      { id: "p1", providerId: "a", userId: "user-1", isShared: false },
+      { id: "p2", providerId: "b", userId: "user-2", isShared: true },
+    ]);
+    const res = await callPut(["p1", "p2"]);
+    expect(res.status).toBe(403);
+    expect(txMock).not.toHaveBeenCalled();
+  });
+
+  it("admins can reorder providers regardless of ownership", async () => {
+    adminMock.mockResolvedValue(true);
+    findManyMock.mockResolvedValue([
+      { id: "p1", providerId: "a", userId: "user-1", isShared: false },
+      { id: "p2", providerId: "b", userId: "user-2", isShared: true },
+    ]);
+    const res = await callPut(["p2", "p1"]);
+    expect(res.status).toBe(200);
+    const arg = findManyMock.mock.calls[0]?.[0] as { where: Record<string, unknown> };
+    expect(arg.where.OR).toBeUndefined();
+    expect(arg.where).toMatchObject({ id: { in: ["p2", "p1"] } });
+    expect(txMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 400 when an unknown provider id is submitted", async () => {
+    findManyMock.mockResolvedValue([
+      { id: "p1", providerId: "a", userId: "user-1", isShared: false },
+    ]);
+    const res = await callPut(["p1", "p2-missing"]);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects duplicate ids", async () => {
+    const res = await callPut(["p1", "p1"]);
+    expect(res.status).toBe(400);
+    expect(findManyMock).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/app/api/custom-providers/reorder/route.shared.test.ts
+++ b/dashboard/src/app/api/custom-providers/reorder/route.shared.test.ts
@@ -97,7 +97,7 @@ describe("PUT /api/custom-providers/reorder (shared/admin scope)", () => {
     expect(txMock).not.toHaveBeenCalled();
   });
 
-  it("admins can reorder providers regardless of ownership", async () => {
+  it("admins can reorder shared providers from other owners", async () => {
     adminMock.mockResolvedValue(true);
     findManyMock.mockResolvedValue([
       { id: "p1", providerId: "a", userId: "user-1", isShared: false },
@@ -105,10 +105,26 @@ describe("PUT /api/custom-providers/reorder (shared/admin scope)", () => {
     ]);
     const res = await callPut(["p2", "p1"]);
     expect(res.status).toBe(200);
-    const arg = findManyMock.mock.calls[0]?.[0] as { where: Record<string, unknown> };
-    expect(arg.where.OR).toBeUndefined();
-    expect(arg.where).toMatchObject({ id: { in: ["p2", "p1"] } });
+    const arg = findManyMock.mock.calls[0]?.[0] as { where: { OR?: unknown[] } };
+    // Reorder still scopes to own + shared even for admins (private providers
+    // cannot be reordered out from under the owner).
+    expect(arg.where.OR).toEqual([
+      { userId: "user-1" },
+      { isShared: true },
+    ]);
     expect(txMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects admins trying to reorder a non-shared provider owned by someone else", async () => {
+    adminMock.mockResolvedValue(true);
+    // Server query filter excludes private cross-owner providers; result
+    // length mismatch returns 400 rather than silently shuffling.
+    findManyMock.mockResolvedValue([
+      { id: "p1", providerId: "a", userId: "user-1", isShared: false },
+    ]);
+    const res = await callPut(["p1", "p2-private-other"]);
+    expect(res.status).toBe(400);
+    expect(txMock).not.toHaveBeenCalled();
   });
 
   it("returns 400 when an unknown provider id is submitted", async () => {

--- a/dashboard/src/app/api/custom-providers/reorder/route.ts
+++ b/dashboard/src/app/api/custom-providers/reorder/route.ts
@@ -8,6 +8,7 @@ import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
 import { env } from "@/lib/env";
 import { invalidateProxyModelsCache } from "@/lib/cache";
 import { logger } from "@/lib/logger";
+import { isUserAdmin } from "@/lib/auth/admin";
 import { z } from "zod";
 
 const FETCH_TIMEOUT_MS = 10_000;
@@ -51,19 +52,34 @@ export async function PUT(request: NextRequest) {
       return Errors.validation("providerIds must not contain duplicates");
     }
 
+    const isAdmin = await isUserAdmin(session.userId);
     const providers = await prisma.customProvider.findMany({
-      where: {
-        userId: session.userId,
-        id: { in: validated.providerIds },
-      },
+      where: isAdmin
+        ? { id: { in: validated.providerIds } }
+        : {
+            id: { in: validated.providerIds },
+            OR: [
+              { userId: session.userId },
+              { isShared: true }
+            ],
+          },
       select: {
         id: true,
         providerId: true,
+        userId: true,
+        isShared: true,
       },
     });
 
     if (providers.length !== validated.providerIds.length) {
-      return Errors.validation("One or more providers do not belong to the current user");
+      return Errors.validation("One or more providers were not found");
+    }
+
+    if (!isAdmin) {
+      const writable = providers.every(p => p.userId === session.userId);
+      if (!writable) {
+        return Errors.forbidden();
+      }
     }
 
     await prisma.$transaction(
@@ -86,7 +102,7 @@ export async function PUT(request: NextRequest) {
     } else {
       const orderedProviders = validated.providerIds
         .map((providerId) => providers.find((provider) => provider.id === providerId))
-        .filter((provider): provider is { id: string; providerId: string } => provider !== undefined);
+        .filter((provider): provider is { id: string; providerId: string; userId: string; isShared: boolean } => provider !== undefined);
 
       try {
         const getRes = await fetchWithTimeout(`${managementUrl}/openai-compatibility`, {

--- a/dashboard/src/app/api/custom-providers/reorder/route.ts
+++ b/dashboard/src/app/api/custom-providers/reorder/route.ts
@@ -53,16 +53,19 @@ export async function PUT(request: NextRequest) {
     }
 
     const isAdmin = await isUserAdmin(session.userId);
+    // Reorder is intentionally scoped to the viewer's own providers plus
+    // shared providers, even for admins. Admins can edit/delete any custom
+    // provider for cleanup purposes (matching the existing OAuth admin
+    // convention), but rearranging private providers a user cannot see has
+    // no UI surface and would be a surprising side effect.
     const providers = await prisma.customProvider.findMany({
-      where: isAdmin
-        ? { id: { in: validated.providerIds } }
-        : {
-            id: { in: validated.providerIds },
-            OR: [
-              { userId: session.userId },
-              { isShared: true }
-            ],
-          },
+      where: {
+        id: { in: validated.providerIds },
+        OR: [
+          { userId: session.userId },
+          { isShared: true },
+        ],
+      },
       select: {
         id: true,
         providerId: true,

--- a/dashboard/src/app/api/custom-providers/route.shared.test.ts
+++ b/dashboard/src/app/api/custom-providers/route.shared.test.ts
@@ -144,6 +144,69 @@ describe("GET /api/custom-providers (shared providers)", () => {
     const body = await res.json();
     expect(body.providers[0]).toMatchObject({ isShared: false, isOwn: true });
   });
+
+  it("redacts headers for non-owner non-admin viewers but reports hasHeaders=true", async () => {
+    findManyMock.mockResolvedValue([
+      {
+        id: "p3",
+        userId: "user-2",
+        name: "shared",
+        providerId: "shared",
+        baseUrl: "https://example.com",
+        prefix: null,
+        proxyUrl: null,
+        groupId: null,
+        sortOrder: 0,
+        headers: { "x-api-key": "super-secret" },
+        models: [],
+        excludedModels: [],
+        apiKeyEncrypted: "enc",
+        isShared: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: { id: "user-2", username: "admin" },
+      },
+    ]);
+    const { GET } = await import("./route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.providers[0]).toMatchObject({
+      isOwn: false,
+      headers: {},
+      hasHeaders: true,
+    });
+    expect(body.providers[0].headers).not.toHaveProperty("x-api-key");
+  });
+
+  it("returns raw headers to admins viewing a shared provider they don't own", async () => {
+    adminMock.mockResolvedValueOnce(true);
+    findManyMock.mockResolvedValue([
+      {
+        id: "p3",
+        userId: "user-2",
+        name: "shared",
+        providerId: "shared",
+        baseUrl: "https://example.com",
+        prefix: null,
+        proxyUrl: null,
+        groupId: null,
+        sortOrder: 0,
+        headers: { "x-api-key": "super-secret" },
+        models: [],
+        excludedModels: [],
+        apiKeyEncrypted: "enc",
+        isShared: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: { id: "user-2", username: "admin" },
+      },
+    ]);
+    const { GET } = await import("./route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.providers[0].headers).toEqual({ "x-api-key": "super-secret" });
+    expect(body.providers[0].hasHeaders).toBe(true);
+  });
 });
 
 describe("POST /api/custom-providers (isShared admin gate)", () => {

--- a/dashboard/src/app/api/custom-providers/route.shared.test.ts
+++ b/dashboard/src/app/api/custom-providers/route.shared.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/env", () => ({
+  env: { ALLOW_LOCAL_PROVIDER_URLS: false, DATABASE_URL: "postgres://", JWT_SECRET: "x", MANAGEMENT_API_KEY: "x" },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  verifySession: vi.fn(() => ({ userId: "user-1", username: "alice", sessionVersion: 0 })),
+}));
+
+vi.mock("@/lib/auth/origin", () => ({
+  validateOrigin: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/auth/rate-limit", () => ({
+  checkRateLimitWithPreset: vi.fn(() => ({ allowed: true })),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  AUDIT_ACTION: { CUSTOM_PROVIDER_CREATED: "x" },
+  extractIpAddress: vi.fn(() => "127.0.0.1"),
+  logAuditAsync: vi.fn(),
+}));
+
+vi.mock("@/lib/providers/hash", () => ({ hashProviderKey: vi.fn(() => "hash") }));
+vi.mock("@/lib/providers/encrypt", () => ({ encryptProviderKey: vi.fn(() => "enc") }));
+vi.mock("@/lib/providers/custom-provider-sync", () => ({
+  syncCustomProviderToProxy: vi.fn(async () => ({ syncStatus: "ok" as const, syncMessage: "" })),
+}));
+
+const adminMock = vi.fn<(userId?: string) => Promise<boolean>>(async () => false);
+vi.mock("@/lib/auth/admin", () => ({
+  isUserAdmin: (userId: string) => adminMock(userId),
+}));
+
+const findManyMock = vi.fn<(arg?: unknown) => unknown>();
+const findFirstMock = vi.fn<(arg?: unknown) => unknown>();
+const findUniqueMock = vi.fn<(arg?: unknown) => unknown>();
+const createMock = vi.fn<(arg?: unknown) => unknown>();
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    customProvider: {
+      findMany: (arg?: unknown) => findManyMock(arg),
+      findFirst: (arg?: unknown) => findFirstMock(arg),
+      findUnique: (arg?: unknown) => findUniqueMock(arg),
+      create: (arg?: unknown) => createMock(arg),
+    },
+  },
+}));
+
+function buildRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/custom-providers", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("GET /api/custom-providers (shared providers)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adminMock.mockResolvedValue(false);
+  });
+
+  it("filters with OR clause that includes shared providers", async () => {
+    findManyMock.mockResolvedValue([]);
+    const { GET } = await import("./route");
+    await GET();
+    expect(findManyMock).toHaveBeenCalledTimes(1);
+    const arg = findManyMock.mock.calls[0]?.[0] as { where: { OR: unknown[] } };
+    expect(arg.where.OR).toEqual([
+      { userId: "user-1" },
+      { isShared: true },
+    ]);
+  });
+
+  it("returns isOwn=false and ownerUsername for shared providers from other users", async () => {
+    findManyMock.mockResolvedValue([
+      {
+        id: "p1",
+        userId: "user-2",
+        name: "z.ai",
+        providerId: "zai",
+        baseUrl: "https://api.z.ai",
+        prefix: null,
+        proxyUrl: null,
+        groupId: null,
+        sortOrder: 0,
+        headers: {},
+        models: [],
+        excludedModels: [],
+        apiKeyEncrypted: "enc",
+        isShared: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: { id: "user-2", username: "admin" },
+      },
+    ]);
+    const { GET } = await import("./route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.providers).toHaveLength(1);
+    expect(body.providers[0]).toMatchObject({
+      providerId: "zai",
+      isShared: true,
+      isOwn: false,
+      ownerId: "user-2",
+      ownerUsername: "admin",
+    });
+  });
+
+  it("returns isOwn=true for the user's own providers", async () => {
+    findManyMock.mockResolvedValue([
+      {
+        id: "p2",
+        userId: "user-1",
+        name: "my-openrouter",
+        providerId: "or-1",
+        baseUrl: "https://openrouter.ai/api/v1",
+        prefix: null,
+        proxyUrl: null,
+        groupId: null,
+        sortOrder: 0,
+        headers: {},
+        models: [],
+        excludedModels: [],
+        apiKeyEncrypted: "enc",
+        isShared: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: { id: "user-1", username: "alice" },
+      },
+    ]);
+    const { GET } = await import("./route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.providers[0]).toMatchObject({ isShared: false, isOwn: true });
+  });
+});
+
+describe("POST /api/custom-providers (isShared admin gate)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adminMock.mockResolvedValue(false);
+    findFirstMock.mockResolvedValue(null);
+    findUniqueMock.mockResolvedValue(null);
+  });
+
+  const validBody = {
+    name: "x",
+    providerId: "x-id",
+    baseUrl: "https://example.com/v1",
+    apiKey: "k",
+    models: [{ upstreamName: "m", alias: "m" }],
+  };
+
+  it("rejects isShared=true for non-admins with 403", async () => {
+    const { POST } = await import("./route");
+    const res = await POST(buildRequest({ ...validBody, isShared: true }));
+    expect(res.status).toBe(403);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts isShared=true for admins and persists the flag", async () => {
+    adminMock.mockResolvedValue(true);
+    createMock.mockResolvedValue({
+      id: "new",
+      providerId: "x-id",
+      prefix: null,
+      baseUrl: "https://example.com/v1",
+      proxyUrl: null,
+      headers: {},
+      models: [],
+      excludedModels: [],
+    });
+    const { POST } = await import("./route");
+    const res = await POST(buildRequest({ ...validBody, isShared: true }));
+    expect(res.status).toBe(201);
+    const arg = createMock.mock.calls[0]?.[0] as { data: { isShared: boolean } };
+    expect(arg.data.isShared).toBe(true);
+  });
+
+  it("defaults isShared to false when omitted", async () => {
+    createMock.mockResolvedValue({
+      id: "new",
+      providerId: "x-id",
+      prefix: null,
+      baseUrl: "https://example.com/v1",
+      proxyUrl: null,
+      headers: {},
+      models: [],
+      excludedModels: [],
+    });
+    const { POST } = await import("./route");
+    const res = await POST(buildRequest(validBody));
+    expect(res.status).toBe(201);
+    const arg = createMock.mock.calls[0]?.[0] as { data: { isShared: boolean } };
+    expect(arg.data.isShared).toBe(false);
+  });
+});

--- a/dashboard/src/app/api/custom-providers/route.ts
+++ b/dashboard/src/app/api/custom-providers/route.ts
@@ -19,6 +19,7 @@ export async function GET() {
   }
 
   try {
+    const isAdmin = await isUserAdmin(session.userId);
     const providers = await prisma.customProvider.findMany({
       where: {
         OR: [
@@ -35,26 +36,35 @@ export async function GET() {
     });
 
     return NextResponse.json({
-      providers: providers.map(p => ({
-        id: p.id,
-        name: p.name,
-        providerId: p.providerId,
-        baseUrl: p.baseUrl,
-        prefix: p.prefix,
-        proxyUrl: p.proxyUrl,
-        groupId: p.groupId,
-        sortOrder: p.sortOrder,
-        headers: p.headers,
-        models: p.models,
-        excludedModels: p.excludedModels,
-        hasEncryptedKey: p.apiKeyEncrypted !== null,
-        isShared: p.isShared,
-        isOwn: p.userId === session.userId,
-        ownerId: p.user.id,
-        ownerUsername: p.user.username,
-        createdAt: p.createdAt,
-        updatedAt: p.updatedAt
-      }))
+      providers: providers.map(p => {
+        const isOwn = p.userId === session.userId;
+        const canSeeSecrets = isOwn || isAdmin;
+        const rawHeaders = (p.headers ?? {}) as Record<string, string>;
+        return {
+          id: p.id,
+          name: p.name,
+          providerId: p.providerId,
+          baseUrl: p.baseUrl,
+          prefix: p.prefix,
+          proxyUrl: p.proxyUrl,
+          groupId: p.groupId,
+          sortOrder: p.sortOrder,
+          // Redact headers for non-owner non-admin viewers — they can contain
+          // Authorization tokens and other secrets. Admins keep visibility so
+          // they can meaningfully edit a shared provider they don't own.
+          headers: canSeeSecrets ? p.headers : {},
+          hasHeaders: Object.keys(rawHeaders).length > 0,
+          models: p.models,
+          excludedModels: p.excludedModels,
+          hasEncryptedKey: p.apiKeyEncrypted !== null,
+          isShared: p.isShared,
+          isOwn,
+          ownerId: p.user.id,
+          ownerUsername: p.user.username,
+          createdAt: p.createdAt,
+          updatedAt: p.updatedAt,
+        };
+      })
     });
   } catch (error) {
     return Errors.internal("GET /api/custom-providers error", error);

--- a/dashboard/src/app/api/custom-providers/route.ts
+++ b/dashboard/src/app/api/custom-providers/route.ts
@@ -10,6 +10,7 @@ import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
 import { syncCustomProviderToProxy } from "@/lib/providers/custom-provider-sync";
 import { CreateCustomProviderSchema } from "@/lib/validation/schemas";
 import { Errors } from "@/lib/errors";
+import { isUserAdmin } from "@/lib/auth/admin";
 
 export async function GET() {
   const session = await verifySession();
@@ -19,10 +20,16 @@ export async function GET() {
 
   try {
     const providers = await prisma.customProvider.findMany({
-      where: { userId: session.userId },
+      where: {
+        OR: [
+          { userId: session.userId },
+          { isShared: true }
+        ]
+      },
       include: {
         models: true,
-        excludedModels: true
+        excludedModels: true,
+        user: { select: { id: true, username: true } }
       },
       orderBy: { sortOrder: "asc" }
     });
@@ -41,6 +48,10 @@ export async function GET() {
         models: p.models,
         excludedModels: p.excludedModels,
         hasEncryptedKey: p.apiKeyEncrypted !== null,
+        isShared: p.isShared,
+        isOwn: p.userId === session.userId,
+        ownerId: p.user.id,
+        ownerUsername: p.user.username,
         createdAt: p.createdAt,
         updatedAt: p.updatedAt
       }))
@@ -67,6 +78,13 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const validated = CreateCustomProviderSchema.parse(body);
+
+    if (validated.isShared === true) {
+      const isAdmin = await isUserAdmin(session.userId);
+      if (!isAdmin) {
+        return Errors.forbidden();
+      }
+    }
 
     const existingName = await prisma.customProvider.findFirst({
       where: { 
@@ -98,6 +116,7 @@ export async function POST(request: NextRequest) {
         prefix: validated.prefix,
         proxyUrl: validated.proxyUrl,
         headers: validated.headers ? (validated.headers as Record<string, string>) : {},
+        isShared: validated.isShared === true,
         models: {
           create: validated.models.map(m => ({
             upstreamName: m.upstreamName,

--- a/dashboard/src/app/api/provider-groups/route.shared.test.ts
+++ b/dashboard/src/app/api/provider-groups/route.shared.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    ALLOW_LOCAL_PROVIDER_URLS: false,
+    DATABASE_URL: "postgres://",
+    JWT_SECRET: "x",
+    MANAGEMENT_API_KEY: "x",
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  verifySession: vi.fn(() => ({ userId: "user-1", username: "alice", sessionVersion: 0 })),
+}));
+
+vi.mock("@/lib/auth/origin", () => ({ validateOrigin: vi.fn(() => null) }));
+
+vi.mock("@/lib/auth/rate-limit", () => ({
+  checkRateLimitWithPreset: vi.fn(() => ({ allowed: true })),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  AUDIT_ACTION: { PROVIDER_GROUP_CREATED: "x" },
+  extractIpAddress: vi.fn(() => "127.0.0.1"),
+  logAuditAsync: vi.fn(),
+}));
+
+const groupFindManyMock = vi.fn<(arg?: unknown) => unknown>();
+const customFindManyMock = vi.fn<(arg?: unknown) => unknown>();
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    providerGroup: { findMany: (arg?: unknown) => groupFindManyMock(arg) },
+    customProvider: { findMany: (arg?: unknown) => customFindManyMock(arg) },
+  },
+}));
+
+const ownProvider = {
+  id: "p-own",
+  userId: "user-1",
+  name: "my-provider",
+  providerId: "mine",
+  baseUrl: "https://mine.example.com",
+  prefix: null,
+  proxyUrl: null,
+  groupId: null,
+  sortOrder: 0,
+  headers: {},
+  apiKeyHash: "hash",
+  apiKeyEncrypted: "enc",
+  isShared: false,
+  models: [],
+  excludedModels: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  user: { id: "user-1", username: "alice" },
+};
+
+const sharedUngrouped = {
+  ...ownProvider,
+  id: "p-shared-ungrouped",
+  userId: "user-2",
+  name: "z.ai",
+  providerId: "zai",
+  isShared: true,
+  user: { id: "user-2", username: "admin" },
+};
+
+const sharedInOwnersGroup = {
+  ...sharedUngrouped,
+  id: "p-shared-grouped",
+  groupId: "group-belonging-to-admin",
+  sortOrder: 5,
+};
+
+describe("GET /api/provider-groups (shared providers)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    groupFindManyMock.mockResolvedValue([]);
+  });
+
+  async function callGet() {
+    const { GET } = await import("./route");
+    return GET();
+  }
+
+  it("issues three queries: viewer's groups, shared-in-others-groups, ungrouped", async () => {
+    customFindManyMock.mockResolvedValue([]);
+    await callGet();
+    expect(groupFindManyMock).toHaveBeenCalledTimes(1);
+    expect(customFindManyMock).toHaveBeenCalledTimes(2);
+    const sharedGroupedArg = customFindManyMock.mock.calls[0]?.[0] as { where: Record<string, unknown> };
+    expect(sharedGroupedArg.where).toMatchObject({
+      isShared: true,
+      groupId: { not: null },
+      userId: { not: "user-1" },
+    });
+    const ungroupedArg = customFindManyMock.mock.calls[1]?.[0] as { where: { OR: unknown[] } };
+    expect(ungroupedArg.where.OR).toEqual([
+      { userId: "user-1", groupId: null },
+      { isShared: true, groupId: null, userId: { not: "user-1" } },
+    ]);
+  });
+
+  it("returns shared providers placed in their owner's group as ungrouped", async () => {
+    customFindManyMock.mockResolvedValueOnce([sharedInOwnersGroup]).mockResolvedValueOnce([]);
+    const res = await callGet();
+    const body = await res.json();
+    expect(body.ungrouped).toHaveLength(1);
+    expect(body.ungrouped[0]).toMatchObject({
+      providerId: "zai",
+      isShared: true,
+      isOwn: false,
+      ownerUsername: "admin",
+      groupId: null,
+    });
+  });
+
+  it("includes ownership metadata for own ungrouped providers", async () => {
+    customFindManyMock.mockResolvedValueOnce([]).mockResolvedValueOnce([ownProvider]);
+    const res = await callGet();
+    const body = await res.json();
+    expect(body.ungrouped[0]).toMatchObject({
+      providerId: "mine",
+      isShared: false,
+      isOwn: true,
+      ownerUsername: "alice",
+    });
+  });
+
+  it("does not return shared providers from the viewer themselves twice", async () => {
+    const ownAndShared = { ...ownProvider, isShared: true };
+    customFindManyMock.mockResolvedValueOnce([]).mockResolvedValueOnce([ownAndShared]);
+    const res = await callGet();
+    const body = await res.json();
+    expect(body.ungrouped).toHaveLength(1);
+    expect(body.ungrouped[0]).toMatchObject({ isOwn: true, isShared: true });
+  });
+
+  it("emits Shared/isOwn/ownerUsername fields on grouped providers", async () => {
+    groupFindManyMock.mockResolvedValueOnce([
+      {
+        id: "g1",
+        userId: "user-1",
+        name: "my-group",
+        sortOrder: 0,
+        isActive: true,
+        providers: [ownProvider],
+      },
+    ]);
+    customFindManyMock.mockResolvedValue([]);
+    const res = await callGet();
+    const body = await res.json();
+    expect(body.groups[0].providers[0]).toMatchObject({
+      isShared: false,
+      isOwn: true,
+      ownerId: "user-1",
+      ownerUsername: "alice",
+    });
+  });
+});

--- a/dashboard/src/app/api/provider-groups/route.shared.test.ts
+++ b/dashboard/src/app/api/provider-groups/route.shared.test.ts
@@ -31,6 +31,11 @@ vi.mock("@/lib/audit", () => ({
   logAuditAsync: vi.fn(),
 }));
 
+const adminMock = vi.fn<(userId?: string) => Promise<boolean>>(async () => false);
+vi.mock("@/lib/auth/admin", () => ({
+  isUserAdmin: (userId: string) => adminMock(userId),
+}));
+
 const groupFindManyMock = vi.fn<(arg?: unknown) => unknown>();
 const customFindManyMock = vi.fn<(arg?: unknown) => unknown>();
 
@@ -163,5 +168,46 @@ describe("GET /api/provider-groups (shared providers)", () => {
       ownerId: "user-1",
       ownerUsername: "alice",
     });
+  });
+
+  it("redacts headers for shared providers viewed by non-owner non-admin", async () => {
+    const sharedWithSecret = {
+      ...sharedInOwnersGroup,
+      headers: { authorization: "Bearer leak-me" },
+    };
+    customFindManyMock.mockResolvedValueOnce([sharedWithSecret]).mockResolvedValueOnce([]);
+    const res = await callGet();
+    const body = await res.json();
+    expect(body.ungrouped[0]).toMatchObject({
+      isOwn: false,
+      headers: {},
+      hasHeaders: true,
+    });
+    expect(body.ungrouped[0].headers).not.toHaveProperty("authorization");
+  });
+
+  it("returns raw headers when viewer is admin", async () => {
+    adminMock.mockResolvedValueOnce(true);
+    const sharedWithSecret = {
+      ...sharedInOwnersGroup,
+      headers: { authorization: "Bearer leak-me" },
+    };
+    customFindManyMock.mockResolvedValueOnce([sharedWithSecret]).mockResolvedValueOnce([]);
+    const res = await callGet();
+    const body = await res.json();
+    expect(body.ungrouped[0].headers).toEqual({ authorization: "Bearer leak-me" });
+  });
+
+  it("sorts the merged ungrouped list by sortOrder across own + shared sources", async () => {
+    const ungroupedOwn = { ...ownProvider, id: "own-2", sortOrder: 2 };
+    const ungroupedShared = { ...sharedUngrouped, id: "shared-3", sortOrder: 3 };
+    const sharedGrouped = { ...sharedInOwnersGroup, id: "shared-grouped-1", sortOrder: 1 };
+    customFindManyMock
+      .mockResolvedValueOnce([sharedGrouped])
+      .mockResolvedValueOnce([ungroupedOwn, ungroupedShared]);
+    const res = await callGet();
+    const body = await res.json();
+    const ids = body.ungrouped.map((p: { id: string }) => p.id);
+    expect(ids).toEqual(["shared-grouped-1", "own-2", "shared-3"]);
   });
 });

--- a/dashboard/src/app/api/provider-groups/route.ts
+++ b/dashboard/src/app/api/provider-groups/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/db";
 import { Errors } from "@/lib/errors";
 import { AUDIT_ACTION, extractIpAddress, logAuditAsync } from "@/lib/audit";
 import { CreateProviderGroupSchema } from "@/lib/validation/schemas";
+import { isUserAdmin } from "@/lib/auth/admin";
 import { z } from "zod";
 
 interface ProviderRecord {
@@ -29,8 +30,10 @@ interface ProviderRecord {
   user: { id: string; username: string };
 }
 
-function sanitizeProvider(p: ProviderRecord, viewerUserId: string) {
+function sanitizeProvider(p: ProviderRecord, viewerUserId: string, isAdmin: boolean) {
   const isOwn = p.userId === viewerUserId;
+  const canSeeSecrets = isOwn || isAdmin;
+  const rawHeaders = (p.headers ?? {}) as Record<string, string>;
   return {
     id: p.id,
     name: p.name,
@@ -42,7 +45,11 @@ function sanitizeProvider(p: ProviderRecord, viewerUserId: string) {
     // owner and has no meaning in the viewer's own grouping.
     groupId: isOwn ? p.groupId : null,
     sortOrder: p.sortOrder,
-    headers: p.headers,
+    // Redact headers for non-owner non-admin viewers — they can contain
+    // Authorization tokens and other secrets. Admins keep visibility so
+    // they can meaningfully edit a shared provider they don't own.
+    headers: canSeeSecrets ? p.headers : {},
+    hasHeaders: Object.keys(rawHeaders).length > 0,
     models: p.models,
     excludedModels: p.excludedModels,
     hasEncryptedKey: p.apiKeyEncrypted !== null,
@@ -62,6 +69,7 @@ export async function GET() {
   }
 
   try {
+    const isAdmin = await isUserAdmin(session.userId);
     const [groups, sharedInOtherUsersGroups, ungrouped] = await Promise.all([
       prisma.providerGroup.findMany({
         where: { userId: session.userId },
@@ -110,12 +118,14 @@ export async function GET() {
 
     const safeGroups = groups.map(group => ({
       ...group,
-      providers: group.providers.map(p => sanitizeProvider(p, session.userId)),
+      providers: group.providers.map(p => sanitizeProvider(p, session.userId, isAdmin)),
     }));
+    // Merge own ungrouped + shared-in-others' groups and re-sort by sortOrder
+    // so the UI sees a single deterministic order.
     const safeUngrouped = [
-      ...ungrouped.map(p => sanitizeProvider(p, session.userId)),
-      ...sharedInOtherUsersGroups.map(p => sanitizeProvider(p, session.userId)),
-    ];
+      ...ungrouped.map(p => sanitizeProvider(p, session.userId, isAdmin)),
+      ...sharedInOtherUsersGroups.map(p => sanitizeProvider(p, session.userId, isAdmin)),
+    ].sort((a, b) => a.sortOrder - b.sortOrder);
 
     return NextResponse.json({ groups: safeGroups, ungrouped: safeUngrouped });
   } catch (error) {

--- a/dashboard/src/app/api/provider-groups/route.ts
+++ b/dashboard/src/app/api/provider-groups/route.ts
@@ -69,8 +69,10 @@ export async function GET() {
       }),
       prisma.customProvider.findMany({
         where: {
-          userId: session.userId,
-          groupId: null,
+          OR: [
+            { userId: session.userId, groupId: null },
+            { isShared: true, groupId: null }
+          ]
         },
         include: {
           models: true,

--- a/dashboard/src/app/api/provider-groups/route.ts
+++ b/dashboard/src/app/api/provider-groups/route.ts
@@ -21,13 +21,16 @@ interface ProviderRecord {
   prefix: string | null;
   proxyUrl: string | null;
   headers: unknown;
+  isShared: boolean;
   createdAt: Date;
   updatedAt: Date;
   models: { id: string; customProviderId: string; upstreamName: string; alias: string }[];
   excludedModels: { id: string; customProviderId: string; pattern: string }[];
+  user: { id: string; username: string };
 }
 
-function sanitizeProvider(p: ProviderRecord) {
+function sanitizeProvider(p: ProviderRecord, viewerUserId: string) {
+  const isOwn = p.userId === viewerUserId;
   return {
     id: p.id,
     name: p.name,
@@ -35,12 +38,18 @@ function sanitizeProvider(p: ProviderRecord) {
     baseUrl: p.baseUrl,
     prefix: p.prefix,
     proxyUrl: p.proxyUrl,
-    groupId: p.groupId,
+    // Non-owners see shared providers as ungrouped — the group belongs to the
+    // owner and has no meaning in the viewer's own grouping.
+    groupId: isOwn ? p.groupId : null,
     sortOrder: p.sortOrder,
     headers: p.headers,
     models: p.models,
     excludedModels: p.excludedModels,
     hasEncryptedKey: p.apiKeyEncrypted !== null,
+    isShared: p.isShared,
+    isOwn,
+    ownerId: p.user.id,
+    ownerUsername: p.user.username,
     createdAt: p.createdAt,
     updatedAt: p.updatedAt,
   };
@@ -53,7 +62,7 @@ export async function GET() {
   }
 
   try {
-    const [groups, ungrouped] = await Promise.all([
+    const [groups, sharedInOtherUsersGroups, ungrouped] = await Promise.all([
       prisma.providerGroup.findMany({
         where: { userId: session.userId },
         include: {
@@ -61,9 +70,25 @@ export async function GET() {
             include: {
               models: true,
               excludedModels: true,
+              user: { select: { id: true, username: true } },
             },
             orderBy: { sortOrder: "asc" },
           },
+        },
+        orderBy: { sortOrder: "asc" },
+      }),
+      // Shared providers that the owner placed in their own group should still
+      // appear for non-owners (treated as ungrouped via sanitizeProvider).
+      prisma.customProvider.findMany({
+        where: {
+          isShared: true,
+          groupId: { not: null },
+          userId: { not: session.userId },
+        },
+        include: {
+          models: true,
+          excludedModels: true,
+          user: { select: { id: true, username: true } },
         },
         orderBy: { sortOrder: "asc" },
       }),
@@ -71,12 +96,13 @@ export async function GET() {
         where: {
           OR: [
             { userId: session.userId, groupId: null },
-            { isShared: true, groupId: null }
-          ]
+            { isShared: true, groupId: null, userId: { not: session.userId } },
+          ],
         },
         include: {
           models: true,
           excludedModels: true,
+          user: { select: { id: true, username: true } },
         },
         orderBy: { sortOrder: "asc" },
       }),
@@ -84,9 +110,12 @@ export async function GET() {
 
     const safeGroups = groups.map(group => ({
       ...group,
-      providers: group.providers.map(sanitizeProvider),
+      providers: group.providers.map(p => sanitizeProvider(p, session.userId)),
     }));
-    const safeUngrouped = ungrouped.map(sanitizeProvider);
+    const safeUngrouped = [
+      ...ungrouped.map(p => sanitizeProvider(p, session.userId)),
+      ...sharedInOtherUsersGroups.map(p => sanitizeProvider(p, session.userId)),
+    ];
 
     return NextResponse.json({ groups: safeGroups, ungrouped: safeUngrouped });
   } catch (error) {

--- a/dashboard/src/app/dashboard/page.tsx
+++ b/dashboard/src/app/dashboard/page.tsx
@@ -205,7 +205,12 @@ export default async function QuickStartPage() {
     fetchModelsDevLimits(),
     session
       ? prisma.customProvider.findMany({
-          where: { userId: session.userId },
+          where: {
+            OR: [
+              { userId: session.userId },
+              { isShared: true }
+            ]
+          },
           include: { models: true },
           orderBy: { sortOrder: "asc" },
         })

--- a/dashboard/src/components/custom-provider-modal.tsx
+++ b/dashboard/src/components/custom-provider-modal.tsx
@@ -204,7 +204,9 @@ export function CustomProviderModal({ isOpen, onClose, provider, onSuccess }: Cu
       models: validModels,
       excludedModels: excludedModels.filter(e => e.trim()),
       groupId: groupId || null,
-      ...(isAdmin ? { isShared } : {})
+      ...(isAdmin && (!isEdit || isShared !== (provider?.isShared === true))
+        ? { isShared }
+        : {})
     };
 
     try {

--- a/dashboard/src/components/custom-provider-modal.tsx
+++ b/dashboard/src/components/custom-provider-modal.tsx
@@ -12,6 +12,7 @@ import { ModelDiscovery } from "@/components/custom-providers/model-discovery";
 import { ModelMappings } from "@/components/custom-providers/model-mappings";
 import { ExcludedModels } from "@/components/custom-providers/excluded-models";
 import { GroupSelect } from "@/components/custom-providers/group-select";
+import { useAuth } from "@/hooks/use-auth";
 
 import { useTranslations } from "next-intl";
 interface ModelMapping {
@@ -36,6 +37,7 @@ interface CustomProvider {
   models: ApiModelMapping[];
   excludedModels: { pattern: string }[];
   groupId: string | null;
+  isShared?: boolean;
 }
 
 interface CustomProviderModalProps {
@@ -80,6 +82,8 @@ export function CustomProviderModal({ isOpen, onClose, provider, onSuccess }: Cu
   const { showToast } = useToast();
   const isEdit = !!provider;
   const t = useTranslations("providers");
+  const { user } = useAuth();
+  const isAdmin = user?.isAdmin === true;
 
   const [name, setName] = useState("");
   const [providerId, setProviderId] = useState("");
@@ -97,6 +101,7 @@ export function CustomProviderModal({ isOpen, onClose, provider, onSuccess }: Cu
   const [showFetchedModels, setShowFetchedModels] = useState(false);
   const [groupId, setGroupId] = useState<string | null>(null);
   const [groups, setGroups] = useState<{id: string; name: string; color: string | null}[]>([]);
+  const [isShared, setIsShared] = useState(false);
 
   const [errors, setErrors] = useState({
     name: "",
@@ -135,6 +140,7 @@ export function CustomProviderModal({ isOpen, onClose, provider, onSuccess }: Cu
     setFetchedModels([]);
     setShowFetchedModels(false);
     setGroupId(null);
+    setIsShared(false);
   }, []);
 
   useEffect(() => {
@@ -149,6 +155,7 @@ export function CustomProviderModal({ isOpen, onClose, provider, onSuccess }: Cu
       setExcludedModels(provider.excludedModels.map(e => e.pattern));
       excludedModelIds.current = provider.excludedModels.map(() => nextId());
       setGroupId(provider.groupId);
+      setIsShared(provider.isShared === true);
       setApiKey("");
       return;
     }
@@ -196,7 +203,8 @@ export function CustomProviderModal({ isOpen, onClose, provider, onSuccess }: Cu
       headers: Object.keys(headersObj).length > 0 ? headersObj : undefined,
       models: validModels,
       excludedModels: excludedModels.filter(e => e.trim()),
-      groupId: groupId || null
+      groupId: groupId || null,
+      ...(isAdmin ? { isShared } : {})
     };
 
     try {
@@ -430,6 +438,23 @@ export function CustomProviderModal({ isOpen, onClose, provider, onSuccess }: Cu
             saving={saving}
             onGroupIdChange={setGroupId}
           />
+
+          {isAdmin && (
+            <div className="flex items-start gap-3 rounded-md border border-border/60 bg-background/50 p-3">
+              <input
+                id="custom-provider-is-shared"
+                type="checkbox"
+                checked={isShared}
+                onChange={(e) => setIsShared(e.target.checked)}
+                disabled={saving}
+                className="mt-1 h-4 w-4"
+              />
+              <label htmlFor="custom-provider-is-shared" className="flex-1 cursor-pointer text-sm">
+                <div className="font-medium">{t("shareLabel")}</div>
+                <div className="text-xs text-muted-foreground">{t("shareDescription")}</div>
+              </label>
+            </div>
+          )}
         </div>
       </ModalContent>
 

--- a/dashboard/src/components/providers/custom-provider-section.tsx
+++ b/dashboard/src/components/providers/custom-provider-section.tsx
@@ -278,11 +278,20 @@ export function CustomProviderSection({ showToast, onProviderCountChange }: Cust
   };
 
   const reorderProviders = async (newGroups: ProviderGroup[], newUngrouped: CustomProvider[]) => {
+    // Only include providers the viewer can mutate. Shared providers from
+    // other owners stay in the list visually but their order is owned by the
+    // creator (or an admin) and is not submitted from this client.
     const allProviderIds: string[] = [];
     newGroups.forEach(g => {
-      g.providers.forEach(p => allProviderIds.push(p.id));
+      g.providers.forEach(p => {
+        if (p.isOwn === true) allProviderIds.push(p.id);
+      });
     });
-    newUngrouped.forEach(p => allProviderIds.push(p.id));
+    newUngrouped.forEach(p => {
+      if (p.isOwn === true) allProviderIds.push(p.id);
+    });
+
+    if (allProviderIds.length === 0) return;
 
     try {
       const res = await fetch(API_ENDPOINTS.CUSTOM_PROVIDERS.REORDER, {

--- a/dashboard/src/components/providers/custom-provider-section.tsx
+++ b/dashboard/src/components/providers/custom-provider-section.tsx
@@ -11,6 +11,7 @@ import { UngroupedList } from "@/components/providers/ungrouped-list";
 import { extractApiError } from "@/lib/utils";
 import { API_ENDPOINTS } from "@/lib/api-endpoints";
 import { useTranslations } from "next-intl";
+import { useAuth } from "@/hooks/use-auth";
 
 type ShowToast = ReturnType<typeof useToast>["showToast"];
 
@@ -277,18 +278,23 @@ export function CustomProviderSection({ showToast, onProviderCountChange }: Cust
     return newList;
   };
 
+  const { user } = useAuth();
+  const isAdmin = user?.isAdmin === true;
+
   const reorderProviders = async (newGroups: ProviderGroup[], newUngrouped: CustomProvider[]) => {
     // Only include providers the viewer can mutate. Shared providers from
-    // other owners stay in the list visually but their order is owned by the
-    // creator (or an admin) and is not submitted from this client.
+    // other owners are mutable for admins (the server accepts admin reorder),
+    // and otherwise read-only. This keeps the UI's optimistic ordering in
+    // sync with the payload sent to the server.
+    const canMutate = (p: CustomProvider) => p.isOwn === true || isAdmin;
     const allProviderIds: string[] = [];
     newGroups.forEach(g => {
       g.providers.forEach(p => {
-        if (p.isOwn === true) allProviderIds.push(p.id);
+        if (canMutate(p)) allProviderIds.push(p.id);
       });
     });
     newUngrouped.forEach(p => {
-      if (p.isOwn === true) allProviderIds.push(p.id);
+      if (canMutate(p)) allProviderIds.push(p.id);
     });
 
     if (allProviderIds.length === 0) return;

--- a/dashboard/src/components/providers/custom-provider-section.tsx
+++ b/dashboard/src/components/providers/custom-provider-section.tsx
@@ -37,6 +37,9 @@ export interface CustomProvider {
   groupId: string | null;
   sortOrder: number;
   hasEncryptedKey: boolean;
+  isShared?: boolean;
+  isOwn?: boolean;
+  ownerUsername?: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/dashboard/src/components/providers/provider-row.tsx
+++ b/dashboard/src/components/providers/provider-row.tsx
@@ -29,7 +29,7 @@ export function ProviderRow({
   const t = useTranslations("providers");
   const { user } = useAuth();
   const isAdmin = user?.isAdmin === true;
-  const canMutate = provider.isOwn !== false || isAdmin;
+  const canMutate = provider.isOwn === true || isAdmin;
 
   return (
     <div className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_80px_80px_120px] items-center border-b border-[var(--surface-border)] px-3 py-2 last:border-b-0">

--- a/dashboard/src/components/providers/provider-row.tsx
+++ b/dashboard/src/components/providers/provider-row.tsx
@@ -62,7 +62,7 @@ export function ProviderRow({
         <button
           type="button"
           onClick={() => onMoveUp(provider.id, provider.groupId, index)}
-          disabled={isFirst}
+          disabled={isFirst || !canMutate}
           className="flex size-6 items-center justify-center rounded-sm border border-[var(--surface-border)] bg-[var(--surface-muted)] text-[var(--text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] disabled:opacity-30 disabled:hover:bg-[var(--surface-muted)] disabled:hover:text-[var(--text-secondary)] transition-colors"
           title={t("moveProviderUp")}
           aria-label={t("moveProviderUpLabel", { name: provider.name })}
@@ -72,7 +72,7 @@ export function ProviderRow({
         <button
           type="button"
           onClick={() => onMoveDown(provider.id, provider.groupId, index)}
-          disabled={isLast}
+          disabled={isLast || !canMutate}
           className="flex size-6 items-center justify-center rounded-sm border border-[var(--surface-border)] bg-[var(--surface-muted)] text-[var(--text-secondary)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] disabled:opacity-30 disabled:hover:bg-[var(--surface-muted)] disabled:hover:text-[var(--text-secondary)] transition-colors"
           title={t("moveProviderDown")}
           aria-label={t("moveProviderDownLabel", { name: provider.name })}

--- a/dashboard/src/components/providers/provider-row.tsx
+++ b/dashboard/src/components/providers/provider-row.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import type { CustomProvider } from "@/components/providers/custom-provider-section";
+import { useAuth } from "@/hooks/use-auth";
 
 interface ProviderRowProps {
   provider: CustomProvider;
@@ -26,6 +27,9 @@ export function ProviderRow({
   onMoveDown,
 }: ProviderRowProps) {
   const t = useTranslations("providers");
+  const { user } = useAuth();
+  const isAdmin = user?.isAdmin === true;
+  const canMutate = provider.isOwn !== false || isAdmin;
 
   return (
     <div className="grid grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_80px_80px_120px] items-center border-b border-[var(--surface-border)] px-3 py-2 last:border-b-0">
@@ -38,6 +42,14 @@ export function ProviderRow({
               className="shrink-0 rounded-sm border border-amber-500/20 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-700"
             >
               {t("resaveBadge")}
+            </span>
+          )}
+          {provider.isShared && (
+            <span
+              title={provider.ownerUsername ? t("sharedOwnerLabel", { username: provider.ownerUsername }) : t("sharedBadge")}
+              className="shrink-0 rounded-sm border border-blue-500/20 bg-blue-500/10 px-1.5 py-0.5 text-[10px] font-medium text-blue-700"
+            >
+              {t("sharedBadge")}
             </span>
           )}
         </div>
@@ -69,11 +81,15 @@ export function ProviderRow({
         </button>
       </div>
 
-      <div className="flex items-center gap-2 justify-end">
+      <div
+        className="flex items-center gap-2 justify-end"
+        title={canMutate ? undefined : t("sharedReadOnlyTooltip")}
+      >
         <Button
           variant="secondary"
           className="px-2.5 py-1 text-xs"
           onClick={() => onEdit(provider)}
+          disabled={!canMutate}
         >
           {t("editButton")}
         </Button>
@@ -81,6 +97,7 @@ export function ProviderRow({
           variant="danger"
           className="px-2.5 py-1 text-xs"
           onClick={() => onDelete(provider.id)}
+          disabled={!canMutate}
         >
           {t("deleteButton")}
         </Button>

--- a/dashboard/src/lib/auth/admin.ts
+++ b/dashboard/src/lib/auth/admin.ts
@@ -1,0 +1,23 @@
+import "server-only";
+import { cache } from "react";
+import { prisma } from "@/lib/db";
+
+/**
+ * Returns true when the user owns an admin account.
+ *
+ * The session payload deliberately omits `isAdmin` so a single source of truth
+ * (the `users` table) governs privilege checks. Callers that need to gate
+ * privileged actions like sharing custom providers globally should consult
+ * this helper after `verifySession()` succeeds.
+ *
+ * Wrapped in React `cache` so multiple checks within the same request reuse
+ * one Prisma round-trip.
+ */
+export const isUserAdmin = cache(async (userId: string): Promise<boolean> => {
+  if (!userId) return false;
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { isAdmin: true },
+  });
+  return user?.isAdmin === true;
+});

--- a/dashboard/src/lib/config-sync/generate-bundle.ts
+++ b/dashboard/src/lib/config-sync/generate-bundle.ts
@@ -306,11 +306,16 @@ export async function generateConfigBundle(userId: string, syncApiKey?: string |
        ? fetchProxyModelsCached(internalProxyUrl, apiKey)
        : Promise.resolve([]),
      fetchModelsDevLimits(),
-     prisma.customProvider.findMany({
-       where: { userId },
-       include: { models: true },
-       orderBy: { sortOrder: "asc" },
-     }),
+    prisma.customProvider.findMany({
+      where: {
+        OR: [
+          { userId },
+          { isShared: true }
+        ]
+      },
+      include: { models: true },
+      orderBy: { sortOrder: "asc" },
+    }),
    ]);
    const nativeModels = buildAvailableModelsFromProxy(proxyModels, modelsDevLimits);
    const aliasModels = extractOAuthModelAliases(managementConfig as ConfigData | null, oauthAccounts, modelsDevLimits);

--- a/dashboard/src/lib/validation/schemas.ts
+++ b/dashboard/src/lib/validation/schemas.ts
@@ -301,7 +301,8 @@ export const CreateCustomProviderSchema = z.object({
     upstreamName: z.string().min(1),
     alias: z.string().min(1)
   })).min(1, "At least one model mapping is required"),
-  excludedModels: z.array(z.string()).optional()
+  excludedModels: z.array(z.string()).optional(),
+  isShared: z.boolean().optional()
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds an `isShared` boolean to `CustomProvider` so admins can mark a custom OpenAI-compatible provider as visible to all dashboard users, mirroring how OAuth providers already behave on the proxy side. Non-admins continue to manage only their own providers.

## Motivation

Today, OAuth-based providers (Claude, Codex, Copilot, etc.) are effectively shared across team members because they live on the proxy's `/auth-files` infrastructure, while custom OpenAI-compatible providers (e.g. z.ai, OpenRouter, Kimi-via-OpenCode-Zen) are scoped to the creator via `WHERE userId = session.userId` in the dashboard's API and config-sync paths.

Verified on a multi-user devgw deployment that the proxy itself **already serves custom providers globally** — any team member's API key can list (`/v1/models`) and call (`/v1/chat/completions`) `glm-4.6`, `kimi-k2.5`, etc. against custom providers added by an admin. The only thing missing is the dashboard UI surfacing them, which keeps the team unaware they can use those models.

This PR closes that gap with an opt-in admin toggle, without changing the default per-user scoping.

## Changes

- **Prisma migration** `20260429000000_custom_provider_is_shared` adds `isShared BOOLEAN NOT NULL DEFAULT false` and an index. Additive only — existing rows stay private.
- **API filter changes** at the two key sites:
  - `GET /api/custom-providers` now returns `WHERE userId = session.userId OR isShared = true`, plus `isOwn` / `ownerId` / `ownerUsername` metadata so the UI can render badges and gate edit actions.
  - `dashboard/src/lib/config-sync/generate-bundle.ts` includes shared providers in every user's OpenCode config bundle.
  - `GET /api/provider-groups` returns shared ungrouped providers as well.
  - Dashboard landing page model picker also includes them.
- **Admin gating** via a new `isUserAdmin(userId)` helper in `dashboard/src/lib/auth/admin.ts`. POST/PATCH return 403 when a non-admin tries to set or flip `isShared`. PATCH/DELETE on a shared provider succeed for the owner or any admin.
- **UI**:
  - Modal exposes a "Share with all users" checkbox, only rendered when `useAuth().isAdmin === true`.
  - Provider row shows a "Shared" badge (and the owner's username in the tooltip) and disables Edit/Delete for non-owner non-admin viewers with a tooltip explaining why.
- **i18n**: 5 new keys in `messages/en.json` + matching German translations in `messages/de.json` (`shareLabel`, `shareDescription`, `sharedBadge`, `sharedOwnerLabel`, `sharedReadOnlyTooltip`).
- **Tests**: 11 new Vitest cases — 6 for the GET/POST route (filter shape, metadata, admin gating) and 5 for the [id] PATCH route (owner/admin permissions, isShared flip rules).

## Out of scope

- No bulk migration of existing providers — admins must opt in per provider.
- No fine-grained per-user ACL — binary shared/private (matches the OAuth precedent).
- No proxy-side changes — proxy already serves custom providers globally.
- Reorder filter remains per-user — only the shared provider's owner (or an admin via DB/PATCH) can change `sortOrder`. Per-user reorder positions for shared providers are deliberately not implemented in v1.

## Verification

- `npx tsc --noEmit`: clean (one pre-existing unrelated `globals.css` import error)
- `npm run lint`: clean
- `npm test`: 217 passed, 25 files (was 206)
- Manually verified flow on a multi-user devgw instance: admin toggles `isShared`, second team member immediately sees provider in their dashboard list, in their OpenCode config bundle, and in `/v1/models` (the latter already worked due to proxy-side global config).

## PR Checklist

- [x] `npx tsc --noEmit` passes (no new errors)
- [x] `npm run lint` passes (no errors, no warnings)
- [x] `npm test` passes
- [x] Conventional commit message used
- [x] No hardcoded API URLs (existing `API_ENDPOINTS` reused)
- [x] No hardcoded secrets
- [x] No file exceeds 400 lines after the changes