### PR TITLE
fix: perplexity-sidecar build context and client thread safety (fixes #212)

### DIFF
--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -119,7 +119,7 @@ services:
   # Only starts when COMPOSE_PROFILES includes "perplexity" (set by install.sh)
   perplexity-sidecar:
     profiles: ["perplexity"]
-    build: ${INSTALL_DIR:-.}/../perplexity-sidecar
+    build: ../perplexity-sidecar
     container_name: cliproxyapi-perplexity-sidecar
     restart: unless-stopped
     # Resource limits (calibrated from real usage: ~72MiB actual)

--- a/perplexity-sidecar/app.py
+++ b/perplexity-sidecar/app.py
@@ -232,6 +232,7 @@ threading.Thread(target=_startup_sync, daemon=True).start()
 
 _client: Perplexity | None = None
 _client_token_hash: str = ""
+_client_lock = threading.Lock()
 
 
 def _fetch_session_token_from_dashboard() -> str | None:
@@ -288,15 +289,16 @@ def get_client() -> Perplexity:
     token = _get_session_token()
     token_hash = token[:16] + token[-16:]
 
-    if _client is None or token_hash != _client_token_hash:
-        if _client is not None:
-            try:
-                _client.close()
-            except Exception:
-                pass
-        log.info("Initialising Perplexity client (token changed or first init)")
-        _client = Perplexity(session_token=token)
-        _client_token_hash = token_hash
+    with _client_lock:
+        if _client is None or token_hash != _client_token_hash:
+            if _client is not None:
+                try:
+                    _client.close()
+                except Exception:
+                    pass
+            log.info("Initialising Perplexity client (token changed or first init)")
+            _client = Perplexity(session_token=token)
+            _client_token_hash = token_hash
 
     return _client
 


### PR DESCRIPTION
## Summary

- Fixes #212 (partially — the runtime error screenshot was unreadable, but these two code issues are confirmed)

## Changes

### 1. Docker build context path (\infrastructure/docker-compose.yml\)

**Bug**: \uild: \/../perplexity-sidecar\ resolves incorrectly when \INSTALL_DIR\ is an absolute path (production installs via \install.sh\).

\\\
INSTALL_DIR=/opt/cliproxyapi-dashboard  (set by install.sh)
-> build context: /opt/cliproxyapi-dashboard/../perplexity-sidecar
-> resolves to:   /opt/perplexity-sidecar  (WRONG — directory doesn't exist)
\\\

**Fix**: Use a purely relative path \../perplexity-sidecar\, which always resolves correctly from the compose file's location (\infrastructure/\). This matches how \docker-compose.local.yml\ already handles it (\uild: ./perplexity-sidecar\).

### 2. Thread safety in get_client() (\perplexity-sidecar/app.py\)

**Bug**: The global \_client\ / \_client_token_hash\ variables in \get_client()\ are accessed without synchronization. Concurrent requests can race:
- Two threads see \_client is None\ simultaneously
- Both create new \Perplexity()\ objects
- One overwrites the other → resource leak + potential inconsistent state

**Fix**: Add \	hreading.Lock\ (\_client_lock\) and wrap the client creation/replacement block in \with _client_lock:\.

## Verification

- \python -m py_compile app.py\ passes with no errors
- Docker Compose path logic verified: relative path \../perplexity-sidecar\ correctly resolves from \infrastructure/\ to project root