### PR TITLE
fix: log_warn to log_warning typo in install.sh (fixes #205)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1030,10 +1030,10 @@ EOF
         if grep -q "extra_hosts" "$OVERRIDE_FILE"; then
             log_info "extra_hosts already configured in override file"
         else
-            log_warn "docker-compose.override.yml exists but doesn't have extra_hosts."
-            log_warn "Please manually add the following under 'services: dashboard:':"
-            log_warn "    extra_hosts:"
-            log_warn "      - \"host.docker.internal:host-gateway\""
+            log_warning "docker-compose.override.yml exists but doesn't have extra_hosts."
+            log_warning "Please manually add the following under 'services: dashboard:':"
+            log_warning "    extra_hosts:"
+            log_warning "      - \"host.docker.internal:host-gateway\""
         fi
     else
         # Create new override file


### PR DESCRIPTION
## Summary

- Fixes #205

## Root Cause

In `install.sh`, the logging function is defined as `log_warning()` (line 27), but four calls on lines 1033-1036 use the nonexistent name `log_warn`. There is no definition of `log_warn` anywhere in the repository.

Because `install.sh` uses `set -euo pipefail` (line 9), this causes the script to **abort immediately** when it reaches the webhook deployment section, preventing:
- Creation of `docker-compose.override.yml` when needed
- All subsequent steps (backup cron, usage collector cron, final summary)

## Fix

Rename all 4 calls from `log_warn` to `log_warning` (the function already exists).

## Verification

- `bash -n install.sh` passes with no syntax errors
- All 27 other `log_warning` calls in the same file use the correct function name
- No other file in the repository calls `log_warn`
