### PR TITLE
fix(install): make systemd compose command cwd-portable (fixes #216)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,6 +2,37 @@
 
 ← [Back to README](../README.md)
 
+## `no configuration file provided: not found`
+
+If `docker compose` reports:
+
+```text
+no configuration file provided: not found
+```
+
+…you are running the command from a directory that does not contain `docker-compose.yml`. The compose file lives in `infrastructure/`, so any `docker compose ...` invocation must either run from there or be given an explicit path.
+
+```bash
+# Run from the infrastructure directory (recommended)
+cd /path/to/cliproxyapi-dashboard/infrastructure
+docker compose up -d --wait
+
+# Or run from anywhere with --project-directory
+docker compose --project-directory /path/to/cliproxyapi-dashboard/infrastructure up -d --wait
+```
+
+If you installed via `install.sh`, prefer the systemd unit — it already sets the
+working directory correctly:
+
+```bash
+sudo systemctl start cliproxyapi-stack
+sudo systemctl status cliproxyapi-stack
+```
+
+The systemd unit also uses `--project-directory` so it is safe to copy the
+`ExecStart` line out of `systemctl cat cliproxyapi-stack` and run it manually
+from any directory.
+
 ## Services Not Starting
 
 ### Local build vs image behavior (important)

--- a/install.sh
+++ b/install.sh
@@ -629,19 +629,26 @@ if [ $SKIP_SERVICE -eq 0 ]; then
     # services explicitly. NOTE: when services are listed explicitly on the command
     # line Docker Compose does NOT auto-start profiled services from COMPOSE_PROFILES,
     # so perplexity-sidecar must also be listed here when it is enabled.
+    #
+    # We pass --project-directory with an absolute path so the command is portable
+    # across working directories. Users who copy it from `systemctl cat` and run it
+    # from a different cwd will not hit "no configuration file provided: not found"
+    # (see https://github.com/itsmylife44/cliproxyapi-dashboard/issues/216).
+    COMPOSE_BASE_CMD="/usr/bin/docker compose --project-directory $INSTALL_DIR/infrastructure"
     if [ $EXTERNAL_PROXY -eq 1 ]; then
         COMPOSE_SERVICES="postgres cliproxyapi docker-proxy dashboard backup-scheduler"
         if [ $PERPLEXITY_ENABLED -eq 1 ]; then
             COMPOSE_SERVICES="$COMPOSE_SERVICES perplexity-sidecar"
         fi
-        COMPOSE_START_CMD="/usr/bin/docker compose up -d --wait $COMPOSE_SERVICES"
+        COMPOSE_START_CMD="$COMPOSE_BASE_CMD up -d --wait $COMPOSE_SERVICES"
         COMPOSE_DESC="(without Caddy - using external reverse proxy)"
     else
         # No explicit list — Compose starts everything; COMPOSE_PROFILES in .env
         # activates the perplexity profile when present.
-        COMPOSE_START_CMD="/usr/bin/docker compose up -d --wait"
+        COMPOSE_START_CMD="$COMPOSE_BASE_CMD up -d --wait"
         COMPOSE_DESC="(full stack)"
     fi
+    COMPOSE_STOP_CMD="$COMPOSE_BASE_CMD down"
     log_info "Systemd compose command: $COMPOSE_START_CMD $COMPOSE_DESC"
 
     cat > "$SERVICE_FILE" << EOF
@@ -656,7 +663,7 @@ Type=oneshot
 RemainAfterExit=true
 WorkingDirectory=$INSTALL_DIR/infrastructure
 ExecStart=$COMPOSE_START_CMD
-ExecStop=/usr/bin/docker compose down
+ExecStop=$COMPOSE_STOP_CMD
 TimeoutStartSec=300
 TimeoutStopSec=120
 
@@ -1076,7 +1083,8 @@ echo ""
 echo "  2. Check status:"
 echo "     sudo systemctl status cliproxyapi-stack"
 echo ""
-echo "  3. View logs:"
+echo "  3. View logs (must run from infrastructure/ — docker compose"
+echo "     needs to find docker-compose.yml in the current directory):"
 echo "     cd $INSTALL_DIR/infrastructure"
 echo "     docker compose logs -f"
 echo ""


### PR DESCRIPTION
## Summary

Closes [#216](https://github.com/itsmylife44/cliproxyapi-dashboard/issues/216).

The reporter ran the compose command they saw during install:

```
sudo docker compose up -d --wait postgres cliproxyapi docker-proxy dashboard backup-scheduler perplexity-sidecar
no configuration file provided: not found
```

Root cause: `install.sh` writes a systemd unit whose `ExecStart` is a bare `docker compose ...` invocation that only works because `WorkingDirectory=.../infrastructure` is set. The moment the user copies that line out of `systemctl cat` (or out of the install log) and runs it from a different directory — e.g. their home dir — Compose can't find `docker-compose.yml` and bails with the error above.

## Fix

- `install.sh`: prepend `--project-directory $INSTALL_DIR/infrastructure` (absolute path) to both the start and stop commands the systemd unit runs. The unit still sets `WorkingDirectory`, but the command is now self-contained and copy-pasteable from any cwd.
- `install.sh`: clarify the post-install "Next steps" output — the bare `docker compose logs -f` line must be run from `infrastructure/`.
- `docs/TROUBLESHOOTING.md`: add a top-level entry indexed on the exact error string ``no configuration file provided: not found`` so users hitting this Google straight to the fix.

No behavior change for users who go through `systemctl start cliproxyapi-stack` (the documented happy path). For users who go off-script, the same `ExecStart` now Just Works.

## Test plan

- [ ] Re-run `install.sh` on a fresh Ubuntu/Debian VM with `EXTERNAL_PROXY=0` and confirm `sudo systemctl start cliproxyapi-stack` brings the full stack up.
- [ ] Repeat with `EXTERNAL_PROXY=1` and `PERPLEXITY_ENABLED=1`; confirm Caddy is skipped, perplexity-sidecar starts.
- [ ] `systemctl cat cliproxyapi-stack` — copy the `ExecStart=` line, paste into a shell in `/tmp`, and confirm it brings the stack up (this is what #216 reproduces).
- [ ] `sudo systemctl stop cliproxyapi-stack` brings the stack down via the new `ExecStop`.