### PR TITLE
fix(usage): drain queued records in batches

### DIFF
--- a/dashboard/src/app/api/usage/collect/route.ts
+++ b/dashboard/src/app/api/usage/collect/route.ts
@@ -213,7 +213,7 @@ export async function POST(request: NextRequest) {
     let authFilesResponse: Response | null = null;
     try {
       [usageResponse, authFilesResponse] = await Promise.all([
-        fetch(`${CLIPROXYAPI_MANAGEMENT_URL}/usage-queue`, {
+        fetch(`${CLIPROXYAPI_MANAGEMENT_URL}/usage-queue?count=${BATCH_SIZE}`, {
           method: "GET",
           headers: { Authorization: `Bearer ${MANAGEMENT_API_KEY}` },
           signal: AbortSignal.timeout(30_000),


### PR DESCRIPTION
## Summary

- request usage queue records with `count=${BATCH_SIZE}` during collection
- reuse the existing collector database insert batch size
- prevents the collector from draining only one queued usage record per run

Fixes #218.

## Verification

- `npm run typecheck`
- `npm run lint`
